### PR TITLE
Upgrade zlib and xz/xz-libs in Dockerfile with in-layer version checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,18 @@
 FROM python:3.14-alpine3.23
-# CVE-2026-27171 | CVSS 5.5 – Medium
-RUN apk upgrade --no-cache zlib
+# CVE-2026-27171 | Update zlib in-layer while keeping the pinned base image.
+RUN set -eux; \
+    apk update --no-cache; \
+    apk upgrade --no-cache zlib; \
+    zlib_version="$(apk info -e -v zlib | cut -d- -f2-)"; \
+    apk version -t "$zlib_version" "1.3.1-r2" | grep -qv '<'
+# SNYK-ALPINE323-XZ-10568945 | Update xz/xz-libs in-layer while keeping the pinned base image.
+RUN set -eux; \
+    apk update --no-cache; \
+    apk upgrade --no-cache xz xz-libs; \
+    xz_version="$(apk info -e -v xz | cut -d- -f2-)"; \
+    xz_libs_version="$(apk info -e -v xz-libs | cut -d- -f2-)"; \
+    apk version -t "$xz_version" "5.8.1-r0" | grep -qv '<'; \
+    apk version -t "$xz_libs_version" "5.8.1-r0" | grep -qv '<'
 
 ENV PYTHONUNBUFFERED=1
 


### PR DESCRIPTION
### Motivation
- Mitigate CVE-2026-27171 and the Snyk-reported xz issue by upgrading vulnerable libraries in-layer while retaining the pinned base image `python:3.14-alpine3.23`.

### Description
- Add `apk update` and `apk upgrade` steps to upgrade `zlib`, `xz`, and `xz-libs` in the Dockerfile and include inline verification of installed versions using `apk version -t` and `grep`.
- Keep the existing application install (`pip install ./sigenergy2mqtt*.whl`) and `CMD [ "sigenergy2mqtt" ]` unchanged while performing the library upgrades in separate `RUN` layers.
- Add explicit error handling in the `RUN` commands with `set -eux` and ensure a newline at end of file.

### Testing
- Built the image with `docker build .` and the build completed successfully.
- Launched a container from the built image and ran `sigenergy2mqtt --version` to confirm the entrypoint starts as expected.
- Executed `apk info -e -v` inside the container to verify that `zlib`, `xz`, and `xz-libs` are updated to the expected minimum versions, and those checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7f623a820832ca4f07234f76b56ce)