### PR TITLE
Publish service health, add Docker HEALTHCHECK, and always enable Monitor service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,7 @@ WORKDIR /usr/src/app
 COPY dist/sigenergy2mqtt*.whl .
 RUN pip install --root-user-action=ignore --break-system-packages --no-cache-dir ./sigenergy2mqtt*.whl
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=45s --retries=3 \
+  CMD python -c "import json,time,pathlib; p=pathlib.Path('/tmp/sigenergy2mqtt-health.json'); d=json.loads(p.read_text()) if p.exists() else {}; ok=d.get('timestamp',0) >= int(time.time())-120 and d.get('mqtt_connected') is True and d.get('modbus_connected') is True; raise SystemExit(0 if ok else 1)"
+
 CMD [ "sigenergy2mqtt" ]

--- a/resources/sensors/TOPICS.md
+++ b/resources/sensors/TOPICS.md
@@ -10,6 +10,22 @@ or by specifying the `--hass-use-simplified-topics` command line option.
 
 Default Scan Intervals are shown in seconds, but may be overridden via configuration. Intervals for derived sensors are dependent on the source sensors.
 
+## Service Health Topics
+
+The monitor service publishes runtime health for both Docker and non-Docker observers:
+
+- `sigenergy2mqtt/health/state` (string: `healthy` or `degraded`)
+- `sigenergy2mqtt/health/attributes` (JSON object)
+
+The attributes payload currently includes:
+
+- `status`
+- `mqtt_connected`
+- `modbus_connected`
+- `overdue_topics`
+- `monitored_topics`
+- `timestamp`
+
 
 > [!IMPORTANT]
 > All `sigenergy2mqtt` sensor names begin with a prefix. The default is `sigen`, but this may be changed via configuration.

--- a/scripts/update_md.py
+++ b/scripts/update_md.py
@@ -324,6 +324,12 @@ async def sensor_index() -> None:
         f.write("\nYou can also enable the `sigenergy2mqtt/` topics when Home Assistant discovery is enabled by setting the `SIGENERGY2MQTT_HASS_USE_SIMPLIFIED_TOPICS` environment variable to true,\n")
         f.write("or by specifying the `--hass-use-simplified-topics` command line option.\n")
         f.write("\nDefault Scan Intervals are shown in seconds, but may be overridden via configuration. Intervals for derived sensors are dependent on the source sensors.\n")
+        f.write("\n## Service Health Topics\n")
+        f.write("\nThe monitor service publishes runtime health for both Docker and non-Docker observers:\n")
+        f.write("\n- `sigenergy2mqtt/health/state` (string: `healthy` or `degraded`)\n")
+        f.write("- `sigenergy2mqtt/health/attributes` (JSON object)\n")
+        f.write("\nThe attributes payload currently includes:\n")
+        f.write("\n- `status`\n- `mqtt_connected`\n- `modbus_connected`\n- `overdue_topics`\n- `monitored_topics`\n- `timestamp`\n")
         write_naming_convention(f)
         # Index
         published = 0

--- a/sigenergy2mqtt/main/main.py
+++ b/sigenergy2mqtt/main/main.py
@@ -556,10 +556,9 @@ def setup_services(configs: list[ThreadConfig], protocol_version: Protocol | Non
     else:
         logging.info("No services configured - skipping service thread")
 
-    if active_config.log_level == logging.DEBUG:
-        mon_thread_cfg = ThreadConfig.create(name="Monitor", host=None, port=None)
-        mon_thread_cfg.add_device(MonitorService([d for c in configs for d in c.devices]))
-        configs.append(mon_thread_cfg)
+    mon_thread_cfg = ThreadConfig.create(name="Monitor", host=None, port=None)
+    mon_thread_cfg.add_device(MonitorService([d for c in configs for d in c.devices]))
+    configs.append(mon_thread_cfg)
 
     return configs
 

--- a/sigenergy2mqtt/monitor/monitor_service.py
+++ b/sigenergy2mqtt/monitor/monitor_service.py
@@ -1,8 +1,10 @@
-"""Monitor service for tracking expected sensor MQTT updates."""
+"""Monitor service for tracking expected sensor MQTT updates and service health."""
 
 import asyncio
+import json
 import logging
 import time
+from pathlib import Path
 from typing import Any, Awaitable
 
 import paho.mqtt.client as mqtt
@@ -34,6 +36,13 @@ class MonitorService(Device):
         self._devices: list[Device] = devices
         self._lock = asyncio.Lock()
         self._topics: dict[str, MonitoredSensor] = {}
+        self._health_state_topic = f"sigenergy2mqtt/health/state"
+        self._health_attributes_topic = f"sigenergy2mqtt/health/attributes"
+        self._health_file = Path("/tmp/sigenergy2mqtt-health.json")
+        self._monitor_topic_updates = active_config.log_level == logging.DEBUG and active_config.repeated_state_publish_interval >= 0
+        # Health publication should remain reasonably frequent and independent
+        # of repeated-state payload cadence so Docker HEALTHCHECKs remain timely.
+        self._health_publish_interval = 30
 
     async def _monitor(self, modbus_client: Any, mqtt_client: Any, *sensors: Any):
         """Check for overdue topics and log warning/recovery events.
@@ -57,13 +66,14 @@ class MonitorService(Device):
 
         while self.online:
             async with self._lock:
-                overdue: dict[str, MonitoredSensor] = {t: s for t, s in self._topics.items() if s.is_overdue}
+                overdue: dict[str, MonitoredSensor] = {t: s for t, s in self._topics.items() if self._monitor_topic_updates and s.is_overdue}
             if any(overdue):
                 for topic, sensor in overdue.items():
                     sensor.notified = True
                     logging.warning(f"{self.log_identity} '{sensor.name}' has not been seen for {sensor.overdue}s (scan_interval={sensor.scan_interval}s {topic=})")
+            await self._publish_health(modbus_client, mqtt_client, len(overdue))
             try:
-                task = asyncio.create_task(asyncio.sleep(1))
+                task = asyncio.create_task(asyncio.sleep(self._health_publish_interval))
                 self.sleeper_task = task
                 await task
             except asyncio.CancelledError:
@@ -71,6 +81,27 @@ class MonitorService(Device):
                 break
             finally:
                 self.sleeper_task = None
+
+    async def _publish_health(self, modbus_client: Any, mqtt_client: mqtt.Client, overdue_count: int) -> None:
+        modbus_connected = bool(modbus_client and getattr(modbus_client, "connected", False))
+        mqtt_connected = bool(mqtt_client and mqtt_client.is_connected())
+        status = "healthy" if overdue_count == 0 and mqtt_connected and modbus_connected else "degraded"
+        now = int(time.time())
+        payload = {
+            "status": status,
+            "mqtt_connected": mqtt_connected,
+            "modbus_connected": modbus_connected,
+            "overdue_topics": overdue_count,
+            "monitored_topics": len(self._topics),
+            "timestamp": now,
+        }
+        try:
+            self._health_file.write_text(json.dumps(payload), encoding="utf-8")
+            if mqtt_client:
+                mqtt_client.publish(self._health_state_topic, status, qos=1, retain=True)
+                mqtt_client.publish(self._health_attributes_topic, json.dumps(payload), qos=1, retain=True)
+        except Exception as ex:
+            logging.debug(f"{self.log_identity} unable to publish health payload: {ex}")
 
     async def on_ha_state_change(self, modbus_client: Any | None, mqtt_client: mqtt.Client, ha_state: str, source: str, mqtt_handler: MqttHandler) -> bool:
         """Handle Home Assistant state updates.
@@ -170,10 +201,6 @@ class MonitorService(Device):
             publishing is disabled for unchanged values.
         """
 
-        if active_config.repeated_state_publish_interval < 0:
-            logging.info(f"{self.log_identity} Monitoring disabled (repeated_state_publish_interval={active_config.repeated_state_publish_interval})")
-            return []
-
         return [self._monitor(modbus_client, mqtt_client, [])]
 
     def subscribe(self, mqtt_client: mqtt.Client, mqtt_handler: MqttHandler) -> None:
@@ -184,8 +211,11 @@ class MonitorService(Device):
             mqtt_handler: Helper used to register topic callbacks.
         """
 
-        if active_config.repeated_state_publish_interval < 0:
-            logging.info(f"{self.log_identity} Monitoring subscriptions disabled (repeated_state_publish_interval={active_config.repeated_state_publish_interval})")
+        if not self._monitor_topic_updates:
+            logging.info(
+                f"{self.log_identity} Topic-overdue monitoring disabled (repeated_state_publish_interval={active_config.repeated_state_publish_interval}); "
+                "publishing connectivity health only"
+            )
             return
 
         for d in self._devices:

--- a/tests/unit/monitor/test_service.py
+++ b/tests/unit/monitor/test_service.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import time
 
 import pytest
@@ -37,7 +38,20 @@ class FakeMqttHandler:
         self.registered.append((mqtt_client, topic, handler))
 
 
+class FakeMqttClient:
+    def __init__(self, connected: bool = True):
+        self._connected = connected
+        self.published = []
+
+    def is_connected(self):
+        return self._connected
+
+    def publish(self, topic, payload, qos=0, retain=False):
+        self.published.append((topic, payload, qos, retain))
+
+
 def test_subscribe_registers_topics():
+    active_config.log_level = logging.DEBUG
     s = DummyReadable(name="sensor1", scan_interval=5, state_topic="topic/1", publishable=True)
     d = DummyDevice("Device1", {"s1": s})
     handler = FakeMqttHandler()
@@ -54,6 +68,7 @@ def test_subscribe_registers_topics():
 
 
 def test_subscribe_skips_registration_when_repeated_negative(monkeypatch):
+    monkeypatch.setattr(active_config, "log_level", logging.DEBUG)
     monkeypatch.setattr(active_config, "repeated_state_publish_interval", -1)
     s = DummyReadable(name="sensor1", scan_interval=5, state_topic="topic/1", publishable=True)
     d = DummyDevice("Device1", {"s1": s})
@@ -66,11 +81,13 @@ def test_subscribe_skips_registration_when_repeated_negative(monkeypatch):
     assert svc._topics == {}
 
 
-def test_schedule_returns_no_tasks_when_repeated_negative(monkeypatch):
+def test_schedule_returns_monitor_task_when_repeated_negative(monkeypatch):
     monkeypatch.setattr(active_config, "repeated_state_publish_interval", -1)
     svc = MonitorService([])
 
-    assert svc.schedule(None, None) == []
+    tasks = svc.schedule(None, None)
+    assert len(tasks) == 1
+    tasks[0].close()
 
 
 def test_monitored_sensor_last_seen_uses_creation_time_default():
@@ -126,6 +143,7 @@ async def test_on_topic_update_known_and_unknown():
 
 @pytest.mark.asyncio
 async def test_monitor_marks_overdue_and_stops(monkeypatch):
+    monkeypatch.setattr(active_config, "log_level", logging.DEBUG)
     # Track sleep calls to allow first 30s sleep, then mock subsequent 1s sleeps
     original_sleep = asyncio.sleep
     sleep_count = 0
@@ -153,7 +171,7 @@ async def test_monitor_marks_overdue_and_stops(monkeypatch):
     fut = loop.create_future()
     svc.online = fut
 
-    task = asyncio.create_task(svc._monitor(None, None))
+    task = asyncio.create_task(svc._monitor(None, FakeMqttClient()))
 
     # let the monitor run one iteration
     await original_sleep(0.2)
@@ -163,3 +181,22 @@ async def test_monitor_marks_overdue_and_stops(monkeypatch):
     await task
 
     assert ms.notified is True
+
+
+@pytest.mark.asyncio
+async def test_publish_health_includes_modbus_and_mqtt_connectivity(tmp_path):
+    svc = MonitorService([])
+    svc._health_file = tmp_path / "health.json"
+    mqtt_client = FakeMqttClient(connected=True)
+
+    class Modbus:
+        connected = True
+
+    await svc._publish_health(Modbus(), mqtt_client, overdue_count=0)
+
+    assert svc._health_file.exists()
+    content = svc._health_file.read_text(encoding="utf-8")
+    assert '"modbus_connected": true' in content
+    assert '"mqtt_connected": true' in content
+    assert any(t[0] == "sigenergy2mqtt/health/state" for t in mqtt_client.published)
+    assert any(t[0] == "sigenergy2mqtt/health/attributes" for t in mqtt_client.published)


### PR DESCRIPTION
### Motivation
- Provide a machine- and MQTT-readable service health payload so Docker `HEALTHCHECK` and external observers can determine runtime connectivity and topic liveness.
- Ensure the Monitor service is always present to publish connectivity/health even when repeated-state monitoring is disabled.
- Document the new health topics in the generated `TOPICS.md` so consumers know the state and attributes topics.

### Description
- Added a Docker `HEALTHCHECK` to the `Dockerfile` that evaluates `/tmp/sigenergy2mqtt-health.json` and exits with success only when health is recent and both MQTT and Modbus connections are present, and moved `CMD` to the end of the file.
- Extended `scripts/update_md.py` and the generated `resources/sensors/TOPICS.md` to include a `Service Health Topics` section describing `sigenergy2mqtt/health/state` and `sigenergy2mqtt/health/attributes` and the attributes payload.
- Made the Monitor thread always created in `sigenergy2mqtt/main/main.py` instead of only when debug logging is enabled.
- Enhanced `sigenergy2mqtt/monitor/monitor_service.py` to add health publishing: write a JSON health file to `/tmp/sigenergy2mqtt-health.json`, publish `sigenergy2mqtt/health/state` and `sigenergy2mqtt/health/attributes` via MQTT, and emit status every 30s; topic-overdue monitoring is now gated by a debug-level flag so the service can publish connectivity health without registering topic callbacks when repeated-state publishing is disabled.
- Updated `tests/unit/monitor/test_service.py` with a `FakeMqttClient`, adjusted subscription/scheduling expectations, and added a test to verify the health file and MQTT publications are created by `_publish_health`.

### Testing
- Ran the monitor unit tests with `pytest tests/unit/monitor/test_service.py`, and all tests completed successfully.
- The new health-publish behavior is covered by the added unit test `test_publish_health_includes_modbus_and_mqtt_connectivity` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7f451756c832ca4eac915deeead7f)