### PR TITLE
Improve health check services

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -138,7 +138,7 @@
     "evenBetterToml.formatter.reorderKeys": true,
     "python.analysis.diagnosticMode": "workspace",
     "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
-    "python.languageServer": "Pylance",
+    "python.languageServer": "Jedi",
     "python.terminal.activateEnvironment": true,
     "python.testing.pytestArgs": [
         "tests",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Added Inverter and Plant estimated self-consumed power and daily energy sensors (thanks to @swainstm https://whrl.pl/RgV4Rd)
-- Added simulated grid outage during startup to Modbus test server for testing EVAC not on backup circuit
+- Added health check for Docker to MonitorService and also published it to MQTT for other potential monitoring services
 - Added `SIGENERGY2MQTT_LOG_FMT` configuration setting and CLI argument to allow override of the log message format
 - Added `SIGENERGY2MQTT_MODBUS_AUTO_DISCOVERY_NETWORKS` configuration setting and CLI argument to allow scanning of specific CIDR networks during auto-discovery
 - Added `SIGENERGY2MQTT_MODBUS_AUTO_DISCOVERY_EXCLUDE` to exclude devices from auto-discovery

--- a/sigenergy2mqtt/devices/base/device.py
+++ b/sigenergy2mqtt/devices/base/device.py
@@ -117,6 +117,8 @@ class Device(HaPublisherMixin, dict[str, str | list[str]], metaclass=abc.ABCMeta
 
     def _build_log_identity(self) -> str:
         """Build a stable log identity for device and service classes."""
+        if self.plant_index < 0:
+            return f"{self.__class__.__name__}"
         device_address = getattr(self, "device_address", "n/a")
         return f"{self.__class__.__name__}[plant={self.plant_index},dev={device_address}]"
 

--- a/sigenergy2mqtt/main/main.py
+++ b/sigenergy2mqtt/main/main.py
@@ -495,11 +495,15 @@ def setup_services(configs: list[ThreadConfig], protocol_version: Protocol | Non
 
     Side effects:
 
-    - Mutates ``configs`` in-place by inserting a ``Services`` thread at index 0
-      and/or appending a debug ``Monitor`` thread.
+    - Mutates ``configs`` in-place by inserting a ``Monitor`` thread at index 0
+      and/or appending a ``Services`` thread.
     - Instantiates integration services that may later make outbound API/network
       calls (PVOutput/InfluxDB/Metrics) once started.
     """
+    mon_thread_cfg = ThreadConfig.create(name="Monitor", host=None, port=None)
+    mon_thread_cfg.add_device(MonitorService([d for c in configs for d in c.devices]))
+    configs.insert(0, mon_thread_cfg)
+
     svc_thread_cfg = ThreadConfig.create(name="Services", host=None, port=None)
 
     if active_config.metrics_enabled:
@@ -514,13 +518,9 @@ def setup_services(configs: list[ThreadConfig], protocol_version: Protocol | Non
             svc_thread_cfg.add_device(service)
 
     if svc_thread_cfg.has_devices:
-        configs.insert(0, svc_thread_cfg)
+        configs.append(svc_thread_cfg)
     else:
         logging.info("No services configured - skipping service thread")
-
-    mon_thread_cfg = ThreadConfig.create(name="Monitor", host=None, port=None)
-    mon_thread_cfg.add_device(MonitorService([d for c in configs for d in c.devices]))
-    configs.append(mon_thread_cfg)
 
     return configs
 

--- a/sigenergy2mqtt/modbus/client.py
+++ b/sigenergy2mqtt/modbus/client.py
@@ -1,8 +1,13 @@
+import copy
 import logging
+import threading
 import time
+from dataclasses import dataclass
+from typing import Optional
 
 from pymodbus import FramerType
 from pymodbus.client import AsyncModbusTcpClient
+from pymodbus.client.mixin import ModbusClientMixin
 from pymodbus.exceptions import ModbusException
 from pymodbus.logging import Log
 from pymodbus.pdu import ExceptionResponse, ModbusPDU
@@ -13,7 +18,16 @@ from sigenergy2mqtt.metrics import Metrics
 from .read_ahead import ReadAhead
 
 
-from pymodbus.client.mixin import ModbusClientMixin
+@dataclass
+class ModbusClientHealth:
+    """Observed health state for a single Modbus client."""
+
+    client_id: str
+    last_connected_at: Optional[float] = None  # epoch seconds
+    last_closed_at: Optional[float] = None
+    last_read_at: Optional[float] = None
+    connect_count: int = 0
+    close_count: int = 0
 
 
 class ModbusClient(AsyncModbusTcpClient, ModbusClientMixin):
@@ -63,6 +77,9 @@ class ModbusClient(AsyncModbusTcpClient, ModbusClientMixin):
         self._trace: bool = False
         self._read_count: int = 0
         self._cache_hits: int = 0
+        # Health tracking
+        self._health: ModbusClientHealth = ModbusClientHealth(f"modbus://{self.comm_params.host}:{self.comm_params.port}")
+        self._health_lock = threading.RLock()
 
     async def _read_registers(
         self, address: int, count: int = 1, device_id: int = 1, input_type: InputType = InputType.HOLDING, no_response_expected: bool = False, use_pre_read: bool = False, trace: bool = False
@@ -109,6 +126,8 @@ class ModbusClient(AsyncModbusTcpClient, ModbusClientMixin):
             else:
                 raise Exception(f"Unknown input type '{input_type}'")
             elapsed = time.monotonic() - start
+            with self._health_lock:
+                self._health.last_read_at = start
             if rr is None:
                 rr = ExceptionResponse(function_code=0x3 if input_type == InputType.HOLDING else 0x04, exception_code=0x5, device_id=device_id)
             if rr.isError() or isinstance(rr, ExceptionResponse):
@@ -138,6 +157,20 @@ class ModbusClient(AsyncModbusTcpClient, ModbusClientMixin):
         """
         if device_id in self._read_ahead_pdu:
             self._read_ahead_pdu[device_id].update({key: None for key in range(address, address + count)})
+
+    async def connect(self) -> bool:
+        connected = await super().connect()
+        if connected:
+            with self._health_lock:
+                self._health.connect_count += 1
+                self._health.last_connected_at = time.monotonic()
+        return connected
+
+    def close(self) -> None:
+        super().close()
+        with self._health_lock:
+            self._health.close_count += 1
+            self._health.last_closed_at = time.monotonic()
 
     async def read_ahead_registers(self, address, count: int = 1, device_id: int = 1, input_type: InputType = InputType.INPUT, no_response_expected: bool = False, trace: bool = False) -> int:
         """Pre-fetch a register range and populate the read-ahead cache.
@@ -199,3 +232,12 @@ class ModbusClient(AsyncModbusTcpClient, ModbusClientMixin):
             A Modbus PDU response.
         """
         return await self._read_registers(address, count=count, device_id=device_id, input_type=InputType.INPUT, no_response_expected=no_response_expected, use_pre_read=True, trace=trace)
+
+    def snapshot(self) -> ModbusClientHealth:
+        """Return a shallow copy of client health.
+
+        Safe to iterate without holding any lock.  :class:`ModbusClientHealth`
+        value is itself a copy — mutating it has no effect.
+        """
+        with self._health_lock:
+            return copy.copy(self._health)

--- a/sigenergy2mqtt/modbus/client.py
+++ b/sigenergy2mqtt/modbus/client.py
@@ -167,10 +167,12 @@ class ModbusClient(AsyncModbusTcpClient, ModbusClientMixin):
         return connected
 
     def close(self) -> None:
+        was_connected = self.connected
         super().close()
-        with self._health_lock:
-            self._health.close_count += 1
-            self._health.last_closed_at = time.monotonic()
+        if was_connected:
+            with self._health_lock:
+                self._health.close_count += 1
+                self._health.last_closed_at = time.monotonic()
 
     async def read_ahead_registers(self, address, count: int = 1, device_id: int = 1, input_type: InputType = InputType.INPUT, no_response_expected: bool = False, trace: bool = False) -> int:
         """Pre-fetch a register range and populate the read-ahead cache.

--- a/sigenergy2mqtt/modbus/client.py
+++ b/sigenergy2mqtt/modbus/client.py
@@ -23,7 +23,7 @@ class ModbusClientHealth:
     """Observed health state for a single Modbus client."""
 
     client_id: str
-    last_connected_at: Optional[float] = None  # epoch seconds
+    last_connected_at: Optional[float] = None
     last_closed_at: Optional[float] = None
     last_read_at: Optional[float] = None
     connect_count: int = 0

--- a/sigenergy2mqtt/monitor/monitor_service.py
+++ b/sigenergy2mqtt/monitor/monitor_service.py
@@ -13,14 +13,14 @@ from sigenergy2mqtt.common import Protocol
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.devices import Device
 from sigenergy2mqtt.modbus import ModbusClientFactory
-from sigenergy2mqtt.mqtt import MqttHandler
+from sigenergy2mqtt.mqtt import MqttHandler, mqtt_health_registry
 from sigenergy2mqtt.sensors.base import ReadableSensorMixin
 
 from .monitored_sensor import MonitoredSensor
 
 
 class MonitorService(Device):
-    """Background service that warns when expected sensor topics go silent.
+    """Background service that monitors system health.
 
     Args:
         devices: Devices whose readable/publishable sensors should be monitored.
@@ -44,35 +44,17 @@ class MonitorService(Device):
         # Health publication should remain reasonably frequent and independent
         # of repeated-state payload cadence so Docker HEALTHCHECKs remain timely.
         self._health_publish_interval = 30
+        self._started = time.time()
 
-    async def _monitor(self, modbus_client: Any, mqtt_client: Any, *sensors: Any):
+    async def _monitor(self, mqtt_client: mqtt.Client):
         """Check for overdue topics and log warning/recovery events.
 
         Args:
-            modbus_client: Unused; part of the shared ``Device`` scheduler signature.
-            mqtt_client: Unused; part of the shared ``Device`` scheduler signature.
-            *sensors: Unused; optional positional values from the scheduler.
+            mqtt_client: MQTT client instance.
         """
 
-        logging.info(f"{self.log_identity} Sleeping for 30s before commencing...")
-        try:
-            task = asyncio.create_task(asyncio.sleep(30))
-            self.sleeper_task = task
-            await task
-        except asyncio.CancelledError:
-            logging.debug(f"{self.log_identity} sleep interrupted")
-            return
-        finally:
-            self.sleeper_task = None
-
         while self.online:
-            async with self._lock:
-                overdue: dict[str, MonitoredSensor] = {t: s for t, s in self._topics.items() if self._monitor_topic_updates and s.is_overdue}
-            if any(overdue):
-                for topic, sensor in overdue.items():
-                    sensor.notified = True
-                    logging.warning(f"{self.log_identity} '{sensor.name}' has not been seen for {sensor.overdue}s (scan_interval={sensor.scan_interval}s {topic=})")
-            await self._publish_health(mqtt_client, len(overdue))
+            await self._publish_health(mqtt_client)
             try:
                 task = asyncio.create_task(asyncio.sleep(self._health_publish_interval))
                 self.sleeper_task = task
@@ -83,18 +65,68 @@ class MonitorService(Device):
             finally:
                 self.sleeper_task = None
 
-    async def _publish_health(self, mqtt_client: mqtt.Client, overdue_count: int) -> None:
-        modbus_connected = all(client.connected for client in ModbusClientFactory._clients.values())
-        mqtt_connected = bool(mqtt_client and mqtt_client.is_connected())
-        status = "healthy" if overdue_count == 0 and mqtt_connected and modbus_connected else "degraded"
-        now = int(time.time())
+    def _check_modbus(self) -> bool:
+        """Checks that all Modbus Client instances are connected"""
+        now = time.monotonic()
+        modbus_healthy_connections = 0
+        clients = ModbusClientFactory._clients.values()
+        for client in clients:
+            health = client.snapshot()
+            cid = health.client_id
+            if not client.connected:
+                logging.warning(f"{self.log_identity}: {cid} disconnected ({health.close_count}x total)")
+            elif health.last_read_at and (now - health.last_read_at) > self._health_publish_interval:
+                logging.warning(f"{self.log_identity}: {cid} connected but no reads for {self._health_publish_interval}s")
+            else:
+                logging.debug(f"{self.log_identity}: {cid} healthy (connected {health.connect_count}x)")
+                modbus_healthy_connections += 1
+        return bool(modbus_healthy_connections == len(clients))
+
+    def _check_mqtt(self) -> bool:
+        """Checks that all MQTT client connections are healthy"""
+        now = time.monotonic()
+        mqtt_snapshot = mqtt_health_registry.snapshot()
+        mqtt_healthy_connections = 0
+        for cid, health in mqtt_snapshot.items():
+            if not health.connected:
+                logging.warning(f"{self.log_identity}: MQTT Client ID {cid} disconnected ({health.disconnect_count}x total)")
+            elif health.last_message_at and (now - health.last_message_at) > self._health_publish_interval:
+                logging.warning(f"{self.log_identity}: MQTT Client ID {cid} connected but no messages for {self._health_publish_interval}s")
+            else:
+                logging.debug(f"{self.log_identity}: MQTT Client ID {cid} healthy (connected {health.connect_count}x)")
+                mqtt_healthy_connections += 1
+        return bool(mqtt_healthy_connections == len(mqtt_snapshot))
+
+    async def _check_topic_health(self) -> int:
+        if time.time() < (self._started + self._health_publish_interval):
+            logging.debug(f"{self.log_identity} Topic health check not due yet (last check {time.time() - self._started}s ago)")
+            return 0
+        async with self._lock:
+            overdue: dict[str, MonitoredSensor] = {t: s for t, s in self._topics.items() if self._monitor_topic_updates and s.is_overdue}
+        if any(overdue):
+            for topic, sensor in overdue.items():
+                sensor.notified = True
+                logging.warning(f"{self.log_identity}: '{sensor.name}' has not been seen for {sensor.overdue}s (scan_interval={sensor.scan_interval}s {topic=})")
+        return len(overdue)
+
+    async def _publish_health(self, mqtt_client: mqtt.Client) -> None:
+        modbus_connected = self._check_modbus()
+        mqtt_connected = self._check_mqtt()
+        overdue_count = await self._check_topic_health()
+        if overdue_count == 0 and mqtt_connected and modbus_connected:
+            status = "healthy"
+            logging.debug(f"{self.log_identity}: Healthy")
+        else:
+            status = "degraded"
+            logging.warning(f"{self.log_identity}: DEGRADED (topic_{overdue_count=} {mqtt_connected=} {modbus_connected=})")
+
         payload = {
             "status": status,
             "mqtt_connected": mqtt_connected,
             "modbus_connected": modbus_connected,
             "overdue_topics": overdue_count,
             "monitored_topics": len(self._topics),
-            "timestamp": now,
+            "timestamp": int(time.time()),
         }
         try:
             self._health_file.write_text(json.dumps(payload), encoding="utf-8")
@@ -194,7 +226,7 @@ class MonitorService(Device):
         """Return the monitor coroutine(s) to schedule for this service.
 
         Args:
-            modbus_client: Modbus client instance.
+            modbus_client: Modbus client instance (unused).
             mqtt_client: MQTT client instance.
 
         Returns:
@@ -202,7 +234,7 @@ class MonitorService(Device):
             publishing is disabled for unchanged values.
         """
 
-        return [self._monitor(modbus_client, mqtt_client, [])]
+        return [self._monitor(mqtt_client)]
 
     def subscribe(self, mqtt_client: mqtt.Client, mqtt_handler: MqttHandler) -> None:
         """Subscribe to all publishable readable sensor state topics.

--- a/sigenergy2mqtt/monitor/monitor_service.py
+++ b/sigenergy2mqtt/monitor/monitor_service.py
@@ -105,7 +105,7 @@ class MonitorService(Device):
         """Checks for overdue topics (sensors that haven't been seen in their scan_interval)"""
         if time.monotonic() < (self._started + self._health_publish_interval):
             logging.debug(
-                f"{self.log_identity} Topic health check not due yet (only started {time.monotonic() - self._started}s ago) - next check in {self._health_publish_interval - (time.monotonic() - self._started)}s"
+                f"{self.log_identity} Topic health check not due yet (only started {time.monotonic() - self._started:0.2f}s ago) - next check in {self._health_publish_interval - (time.monotonic() - self._started):0.2f}s"
             )
             return 0
         async with self._lock:

--- a/sigenergy2mqtt/monitor/monitor_service.py
+++ b/sigenergy2mqtt/monitor/monitor_service.py
@@ -45,8 +45,7 @@ class MonitorService(Device):
         # Health publication should remain reasonably frequent and independent
         # of repeated-state payload cadence so Docker HEALTHCHECKs remain timely.
         self._health_publish_interval = 30
-        self._degraded_recheck_interval = 5
-        self._last_checked_at = time.monotonic()
+        self._started = time.monotonic()
 
     async def _monitor(self, mqtt_client: mqtt.Client):
         """Check for overdue topics and log warning/recovery events.
@@ -56,13 +55,9 @@ class MonitorService(Device):
         """
 
         while self.online:
-            if await self._publish_health(mqtt_client):
-                duration = self._health_publish_interval
-            else:
-                duration = self._degraded_recheck_interval
-            self._last_checked_at = time.monotonic()
+            await self._publish_health(mqtt_client)
             try:
-                task = asyncio.create_task(asyncio.sleep(duration))
+                task = asyncio.create_task(asyncio.sleep(self._health_publish_interval))
                 self.sleeper_task = task
                 await task
             except asyncio.CancelledError:
@@ -110,9 +105,12 @@ class MonitorService(Device):
         return bool(mqtt_healthy_connections == len(mqtt_snapshot))
 
     async def _check_topic_health(self) -> int:
-        if time.monotonic() < (self._last_checked_at + self._health_publish_interval):
+        """Checks for overdue topics (sensors that haven't been seen in their scan_interval)"""
+        if time.monotonic() < (self._started + self._health_publish_interval):
             if self._debugging:
-                logging.debug(f"{self.log_identity} Topic health check not due yet (last check {time.monotonic() - self._last_checked_at}s ago)")
+                logging.debug(
+                    f"{self.log_identity} Topic health check not due yet (only started {time.monotonic() - self._started}s ago) - next check in {self._health_publish_interval - (time.monotonic() - self._started)}s"
+                )
             return 0
         async with self._lock:
             overdue: dict[str, MonitoredSensor] = {t: s for t, s in self._topics.items() if self._monitor_topic_updates and s.is_overdue}

--- a/sigenergy2mqtt/monitor/monitor_service.py
+++ b/sigenergy2mqtt/monitor/monitor_service.py
@@ -95,7 +95,8 @@ class MonitorService(Device):
             elif health.last_message_at and (now - health.last_message_at) > self._health_publish_interval:
                 logging.warning(f"{self.log_identity} MQTT Client ID {cid} connected but no messages for {self._health_publish_interval}s")
             else:
-                logging.debug(f"{self.log_identity} MQTT Client ID {cid} healthy (connected {health.connect_count}x)")
+                if self._debugging:
+                    logging.debug(f"{self.log_identity} MQTT Client ID {cid} healthy (connected {health.connect_count}x)")
                 mqtt_healthy_connections += 1
         return bool(mqtt_healthy_connections == len(mqtt_snapshot))
 

--- a/sigenergy2mqtt/monitor/monitor_service.py
+++ b/sigenergy2mqtt/monitor/monitor_service.py
@@ -41,10 +41,11 @@ class MonitorService(Device):
         self._health_attributes_topic = "sigenergy2mqtt/health/attributes"
         self._health_file = Path("/tmp/sigenergy2mqtt-health.json")
         self._monitor_topic_updates = active_config.log_level == logging.DEBUG and active_config.repeated_state_publish_interval >= 0
+        self._debugging = True
         # Health publication should remain reasonably frequent and independent
         # of repeated-state payload cadence so Docker HEALTHCHECKs remain timely.
         self._health_publish_interval = 30
-        self._started = time.time()
+        self._started = time.monotonic()
 
     async def _monitor(self, mqtt_client: mqtt.Client):
         """Check for overdue topics and log warning/recovery events.
@@ -74,11 +75,12 @@ class MonitorService(Device):
             health = client.snapshot()
             cid = health.client_id
             if not client.connected:
-                logging.warning(f"{self.log_identity}: {cid} disconnected ({health.close_count}x total)")
+                logging.warning(f"{self.log_identity} Modbus connection {cid} disconnected ({health.close_count}x total)")
             elif health.last_read_at and (now - health.last_read_at) > self._health_publish_interval:
-                logging.warning(f"{self.log_identity}: {cid} connected but no reads for {self._health_publish_interval}s")
+                logging.warning(f"{self.log_identity} Modbus connection {cid} connected but no reads for {self._health_publish_interval}s")
             else:
-                logging.debug(f"{self.log_identity}: {cid} healthy (connected {health.connect_count}x)")
+                if self._debugging:
+                    logging.debug(f"{self.log_identity} Modbus connection {cid} healthy (connected {health.connect_count}x)")
                 modbus_healthy_connections += 1
         return bool(modbus_healthy_connections == len(clients))
 
@@ -89,24 +91,25 @@ class MonitorService(Device):
         mqtt_healthy_connections = 0
         for cid, health in mqtt_snapshot.items():
             if not health.connected:
-                logging.warning(f"{self.log_identity}: MQTT Client ID {cid} disconnected ({health.disconnect_count}x total)")
+                logging.warning(f"{self.log_identity} MQTT Client ID {cid} disconnected ({health.disconnect_count}x total)")
             elif health.last_message_at and (now - health.last_message_at) > self._health_publish_interval:
-                logging.warning(f"{self.log_identity}: MQTT Client ID {cid} connected but no messages for {self._health_publish_interval}s")
+                logging.warning(f"{self.log_identity} MQTT Client ID {cid} connected but no messages for {self._health_publish_interval}s")
             else:
-                logging.debug(f"{self.log_identity}: MQTT Client ID {cid} healthy (connected {health.connect_count}x)")
+                logging.debug(f"{self.log_identity} MQTT Client ID {cid} healthy (connected {health.connect_count}x)")
                 mqtt_healthy_connections += 1
         return bool(mqtt_healthy_connections == len(mqtt_snapshot))
 
     async def _check_topic_health(self) -> int:
-        if time.time() < (self._started + self._health_publish_interval):
-            logging.debug(f"{self.log_identity} Topic health check not due yet (last check {time.time() - self._started}s ago)")
+        if time.monotonic() < (self._started + self._health_publish_interval):
+            if self._debugging:
+                logging.debug(f"{self.log_identity} Topic health check not due yet (last check {time.monotonic() - self._started}s ago)")
             return 0
         async with self._lock:
             overdue: dict[str, MonitoredSensor] = {t: s for t, s in self._topics.items() if self._monitor_topic_updates and s.is_overdue}
         if any(overdue):
             for topic, sensor in overdue.items():
                 sensor.notified = True
-                logging.warning(f"{self.log_identity}: '{sensor.name}' has not been seen for {sensor.overdue}s (scan_interval={sensor.scan_interval}s {topic=})")
+                logging.warning(f"{self.log_identity} '{sensor.name}' has not been seen for {sensor.overdue}s (scan_interval={sensor.scan_interval}s {topic=})")
         return len(overdue)
 
     async def _publish_health(self, mqtt_client: mqtt.Client) -> None:
@@ -115,10 +118,11 @@ class MonitorService(Device):
         overdue_count = await self._check_topic_health()
         if overdue_count == 0 and mqtt_connected and modbus_connected:
             status = "healthy"
-            logging.debug(f"{self.log_identity}: Healthy")
+            if self._debugging:
+                logging.debug(f"{self.log_identity} Status is Healthy (topic_{overdue_count=} {mqtt_connected=} {modbus_connected=})")
         else:
             status = "degraded"
-            logging.warning(f"{self.log_identity}: DEGRADED (topic_{overdue_count=} {mqtt_connected=} {modbus_connected=})")
+            logging.warning(f"{self.log_identity} Status is DEGRADED (topic_{overdue_count=} {mqtt_connected=} {modbus_connected=})")
 
         payload = {
             "status": status,
@@ -130,11 +134,15 @@ class MonitorService(Device):
         }
         try:
             self._health_file.write_text(json.dumps(payload), encoding="utf-8")
+            if self._debugging:
+                logging.debug(f"{self.log_identity} Published health payload to {self._health_file}")
             if mqtt_client:
                 mqtt_client.publish(self._health_state_topic, status, qos=1, retain=True)
                 mqtt_client.publish(self._health_attributes_topic, json.dumps(payload), qos=1, retain=True)
+                if self._debugging:
+                    logging.debug(f"{self.log_identity} Published health payload to mqtt://{active_config.mqtt.broker}:{active_config.mqtt.port} {self._health_attributes_topic}")
         except Exception as ex:
-            logging.debug(f"{self.log_identity} unable to publish health payload: {ex}")
+            logging.warning(f"{self.log_identity} Failed to publish health payload: {ex}")
 
     async def on_ha_state_change(self, modbus_client: Any | None, mqtt_client: mqtt.Client, ha_state: str, source: str, mqtt_handler: MqttHandler) -> bool:
         """Handle Home Assistant state updates.

--- a/sigenergy2mqtt/monitor/monitor_service.py
+++ b/sigenergy2mqtt/monitor/monitor_service.py
@@ -41,7 +41,6 @@ class MonitorService(Device):
         self._health_attributes_topic = "sigenergy2mqtt/health/attributes"
         self._health_file = Path("/tmp/sigenergy2mqtt-health.json")
         self._monitor_topic_updates = active_config.log_level == logging.DEBUG and active_config.repeated_state_publish_interval >= 0
-        self._debugging = True
         # Health publication should remain reasonably frequent and independent
         # of repeated-state payload cadence so Docker HEALTHCHECKs remain timely.
         self._health_publish_interval = 30
@@ -81,8 +80,7 @@ class MonitorService(Device):
             elif health.last_read_at and (now - health.last_read_at) > self._health_publish_interval:
                 logging.warning(f"{self.log_identity} Modbus connection {cid} connected but no reads for {self._health_publish_interval}s")
             else:
-                if self._debugging:
-                    logging.debug(f"{self.log_identity} Modbus connection {cid} healthy (connected {health.connect_count}x)")
+                logging.debug(f"{self.log_identity} Modbus connection {cid} healthy (connected {health.connect_count}x)")
                 modbus_healthy_connections += 1
         return bool(modbus_healthy_connections == len(clients))
 
@@ -99,18 +97,16 @@ class MonitorService(Device):
             elif health.last_message_at and (now - health.last_message_at) > self._health_publish_interval:
                 logging.warning(f"{self.log_identity} MQTT Client ID {cid} connected but no messages for {self._health_publish_interval}s")
             else:
-                if self._debugging:
-                    logging.debug(f"{self.log_identity} MQTT Client ID {cid} healthy (connected {health.connect_count}x)")
+                logging.debug(f"{self.log_identity} MQTT Client ID {cid} healthy (connected {health.connect_count}x)")
                 mqtt_healthy_connections += 1
         return bool(mqtt_healthy_connections == len(mqtt_snapshot))
 
     async def _check_topic_health(self) -> int:
         """Checks for overdue topics (sensors that haven't been seen in their scan_interval)"""
         if time.monotonic() < (self._started + self._health_publish_interval):
-            if self._debugging:
-                logging.debug(
-                    f"{self.log_identity} Topic health check not due yet (only started {time.monotonic() - self._started}s ago) - next check in {self._health_publish_interval - (time.monotonic() - self._started)}s"
-                )
+            logging.debug(
+                f"{self.log_identity} Topic health check not due yet (only started {time.monotonic() - self._started}s ago) - next check in {self._health_publish_interval - (time.monotonic() - self._started)}s"
+            )
             return 0
         async with self._lock:
             overdue: dict[str, MonitoredSensor] = {t: s for t, s in self._topics.items() if self._monitor_topic_updates and s.is_overdue}
@@ -126,8 +122,7 @@ class MonitorService(Device):
         overdue_count = await self._check_topic_health()
         if overdue_count == 0 and mqtt_connected and modbus_connected:
             status = "healthy"
-            if self._debugging:
-                logging.debug(f"{self.log_identity} Status is Healthy (topic_{overdue_count=} {mqtt_connected=} {modbus_connected=})")
+            logging.debug(f"{self.log_identity} Status is Healthy (topic_{overdue_count=} {mqtt_connected=} {modbus_connected=})")
         else:
             status = "degraded"
             logging.warning(f"{self.log_identity} Status is DEGRADED (topic_{overdue_count=} {mqtt_connected=} {modbus_connected=})")
@@ -142,13 +137,11 @@ class MonitorService(Device):
         }
         try:
             self._health_file.write_text(json.dumps(payload), encoding="utf-8")
-            if self._debugging:
-                logging.debug(f"{self.log_identity} Published health payload to {self._health_file}")
+            logging.debug(f"{self.log_identity} Published health payload to {self._health_file}")
             if mqtt_client:
                 mqtt_client.publish(self._health_state_topic, status, qos=1, retain=True)
                 mqtt_client.publish(self._health_attributes_topic, json.dumps(payload), qos=1, retain=True)
-                if self._debugging:
-                    logging.debug(f"{self.log_identity} Published health payload to mqtt://{active_config.mqtt.broker}:{active_config.mqtt.port} {self._health_attributes_topic}")
+                logging.debug(f"{self.log_identity} Published health payload to mqtt://{active_config.mqtt.broker}:{active_config.mqtt.port} {self._health_attributes_topic}")
         except Exception as ex:
             logging.warning(f"{self.log_identity} Failed to publish health payload: {ex}")
         return bool(status == "healthy")

--- a/sigenergy2mqtt/monitor/monitor_service.py
+++ b/sigenergy2mqtt/monitor/monitor_service.py
@@ -45,7 +45,8 @@ class MonitorService(Device):
         # Health publication should remain reasonably frequent and independent
         # of repeated-state payload cadence so Docker HEALTHCHECKs remain timely.
         self._health_publish_interval = 30
-        self._started = time.monotonic()
+        self._degraded_recheck_interval = 5
+        self._last_checked_at = time.monotonic()
 
     async def _monitor(self, mqtt_client: mqtt.Client):
         """Check for overdue topics and log warning/recovery events.
@@ -55,9 +56,13 @@ class MonitorService(Device):
         """
 
         while self.online:
-            await self._publish_health(mqtt_client)
+            if await self._publish_health(mqtt_client):
+                duration = self._health_publish_interval
+            else:
+                duration = self._degraded_recheck_interval
+            self._last_checked_at = time.monotonic()
             try:
-                task = asyncio.create_task(asyncio.sleep(self._health_publish_interval))
+                task = asyncio.create_task(asyncio.sleep(duration))
                 self.sleeper_task = task
                 await task
             except asyncio.CancelledError:
@@ -68,9 +73,11 @@ class MonitorService(Device):
 
     def _check_modbus(self) -> bool:
         """Checks that all Modbus Client instances are connected"""
+        clients = ModbusClientFactory._clients.values()
+        if not clients:
+            return False
         now = time.monotonic()
         modbus_healthy_connections = 0
-        clients = ModbusClientFactory._clients.values()
         for client in clients:
             health = client.snapshot()
             cid = health.client_id
@@ -86,8 +93,10 @@ class MonitorService(Device):
 
     def _check_mqtt(self) -> bool:
         """Checks that all MQTT client connections are healthy"""
-        now = time.monotonic()
         mqtt_snapshot = mqtt_health_registry.snapshot()
+        if not mqtt_snapshot:
+            return False
+        now = time.monotonic()
         mqtt_healthy_connections = 0
         for cid, health in mqtt_snapshot.items():
             if not health.connected:
@@ -101,9 +110,9 @@ class MonitorService(Device):
         return bool(mqtt_healthy_connections == len(mqtt_snapshot))
 
     async def _check_topic_health(self) -> int:
-        if time.monotonic() < (self._started + self._health_publish_interval):
+        if time.monotonic() < (self._last_checked_at + self._health_publish_interval):
             if self._debugging:
-                logging.debug(f"{self.log_identity} Topic health check not due yet (last check {time.monotonic() - self._started}s ago)")
+                logging.debug(f"{self.log_identity} Topic health check not due yet (last check {time.monotonic() - self._last_checked_at}s ago)")
             return 0
         async with self._lock:
             overdue: dict[str, MonitoredSensor] = {t: s for t, s in self._topics.items() if self._monitor_topic_updates and s.is_overdue}
@@ -113,7 +122,7 @@ class MonitorService(Device):
                 logging.warning(f"{self.log_identity} '{sensor.name}' has not been seen for {sensor.overdue}s (scan_interval={sensor.scan_interval}s {topic=})")
         return len(overdue)
 
-    async def _publish_health(self, mqtt_client: mqtt.Client) -> None:
+    async def _publish_health(self, mqtt_client: mqtt.Client) -> bool:
         modbus_connected = self._check_modbus()
         mqtt_connected = self._check_mqtt()
         overdue_count = await self._check_topic_health()
@@ -144,6 +153,7 @@ class MonitorService(Device):
                     logging.debug(f"{self.log_identity} Published health payload to mqtt://{active_config.mqtt.broker}:{active_config.mqtt.port} {self._health_attributes_topic}")
         except Exception as ex:
             logging.warning(f"{self.log_identity} Failed to publish health payload: {ex}")
+        return bool(status == "healthy")
 
     async def on_ha_state_change(self, modbus_client: Any | None, mqtt_client: mqtt.Client, ha_state: str, source: str, mqtt_handler: MqttHandler) -> bool:
         """Handle Home Assistant state updates.

--- a/sigenergy2mqtt/mqtt/__init__.py
+++ b/sigenergy2mqtt/mqtt/__init__.py
@@ -7,10 +7,13 @@ from sigenergy2mqtt.modbus import ModbusClient
 
 from .client import MqttClient
 from .handler import MqttHandler
+from .registry import MqttHealthRegistry
 
-__all__ = ["MqttHandler", "mqtt_setup"]
+__all__ = ["MqttHandler", "mqtt_setup", "mqtt_health_registry"]
 
 _MAX_CONNECT_ATTEMPTS: int = 3
+
+mqtt_health_registry = MqttHealthRegistry()
 
 
 def _build_broker_url() -> str:
@@ -89,7 +92,7 @@ async def mqtt_setup(
 
     logging.debug(f"Creating MQTT Client ID {mqtt_client_id} for {broker_url} over {active_config.mqtt.transport}")
 
-    mqtt_handler = MqttHandler(mqtt_client_id, modbus_client, loop)
+    mqtt_handler = MqttHandler(mqtt_client_id, modbus_client, loop, mqtt_health_registry)
     mqtt_client = MqttClient(
         client_id=mqtt_client_id,
         userdata=mqtt_handler,

--- a/sigenergy2mqtt/mqtt/__init__.py
+++ b/sigenergy2mqtt/mqtt/__init__.py
@@ -100,6 +100,7 @@ async def mqtt_setup(
         tls=active_config.mqtt.tls,
         tls_insecure=active_config.mqtt.tls_insecure,
     )
+    mqtt_health_registry.register(mqtt_client_id)
 
     if active_config.mqtt.anonymous:
         logging.debug(f"MQTT Client ID {mqtt_client_id} connecting to {broker_url} anonymously")

--- a/sigenergy2mqtt/mqtt/client.py
+++ b/sigenergy2mqtt/mqtt/client.py
@@ -54,8 +54,6 @@ class MqttClient(mqtt.Client):
         )
         self.enable_logger(logger)
 
-        self._client_id = client_id
-
         if tls:
             ssl_context = ssl.create_default_context()
             if tls_insecure:
@@ -74,9 +72,6 @@ class MqttClient(mqtt.Client):
         self.on_publish = on_publish
         self.on_subscribe = on_subscribe
         self.on_unsubscribe = on_unsubscribe
-
-    def __repr__(self):
-        return f"<MQTTClientWrapper(client_id='{self._client_id}', broker='{self.host}', port={self.port}, keepalive={self.keepalive})>"
 
 
 # ---------------------------------------------------------------------------

--- a/sigenergy2mqtt/mqtt/client.py
+++ b/sigenergy2mqtt/mqtt/client.py
@@ -54,16 +54,18 @@ class MqttClient(mqtt.Client):
         )
         self.enable_logger(logger)
 
+        self._client_id = client_id
+
         if tls:
             ssl_context = ssl.create_default_context()
             if tls_insecure:
                 ssl_context.check_hostname = False
                 ssl_context.verify_mode = ssl.CERT_NONE
-                logging.warning(f"Using insecure TLS connection for client_id={client_id} - TLS certificate validation is DISABLED!")
+                logger.warning(f"Using insecure TLS connection for client_id={client_id} - TLS certificate validation is DISABLED!")
             else:
                 ssl_context.check_hostname = True
                 ssl_context.verify_mode = ssl.CERT_REQUIRED
-                logging.info(f"Using secure TLS connection for client_id={client_id}")
+                logger.info(f"Using secure TLS connection for client_id={client_id}")
             self.tls_set_context(ssl_context)
 
         self.on_disconnect = on_disconnect
@@ -72,6 +74,9 @@ class MqttClient(mqtt.Client):
         self.on_publish = on_publish
         self.on_subscribe = on_subscribe
         self.on_unsubscribe = on_unsubscribe
+
+    def __repr__(self):
+        return f"<MQTTClientWrapper(client_id='{self._client_id}', broker='{self.host}', port={self.port}, keepalive={self.keepalive})>"
 
 
 # ---------------------------------------------------------------------------
@@ -125,6 +130,7 @@ def on_connect(client: mqtt.Client, userdata: MqttHandler, flags, reason_code, p
     """
     if reason_code == 0:
         logger.debug(f"Connected to mqtt://{client.host}:{client.port} (client_id={userdata.client_id})")
+        userdata.registry.mark_connected(userdata.client_id)
         userdata.on_reconnect(client)
     else:
         logger.critical(f"Connection to mqtt://{client.host}:{client.port} REFUSED - {reason_code} (client_id={userdata.client_id})")
@@ -156,6 +162,7 @@ def on_disconnect(client: mqtt.Client, userdata: MqttHandler, disconnect_flags, 
     """
     userdata.connected = False
     logger.info(f"Disconnected from mqtt://{client.host}:{client.port} - {reason_code} (client_id={userdata.client_id})")
+    userdata.registry.mark_disconnected(userdata.client_id)
 
 
 def on_message(client: mqtt.Client, userdata: MqttHandler, message) -> None:
@@ -179,6 +186,7 @@ def on_message(client: mqtt.Client, userdata: MqttHandler, message) -> None:
         message.topic,
         message.payload.decode("utf-8", errors="replace"),
     )
+    userdata.registry.record_message(userdata.client_id)
     _ensure_subscriptions_are_fresh(client, userdata)
 
 
@@ -200,6 +208,7 @@ def on_publish(client: mqtt.Client, userdata: MqttHandler, mid: int, reason_code
     """
     logger.debug(f"Acknowledged publish MID={mid} (client_id={userdata.client_id})")
     userdata.on_response(mid, "publish", client)
+    userdata.registry.record_publish_ack(userdata.client_id)
     _ensure_subscriptions_are_fresh(client, userdata)
 
 
@@ -242,9 +251,8 @@ def on_subscribe(client: mqtt.Client, userdata: MqttHandler, mid: int, reason_co
     for r in succeeded:
         logger.debug(f"Acknowledged subscribe MID={mid} (reason_code={r} client_id={userdata.client_id})")
 
-    if succeeded:
-        # Signal once per mid regardless of how many topics succeeded.
-        userdata.on_response(mid, "subscribe", client)
+    # Signal once per mid regardless of how many topics succeeded.
+    userdata.on_response(mid, "subscribe", client)
 
 
 def on_unsubscribe(client: mqtt.Client, userdata: MqttHandler, mid: int, reason_codes, properties) -> None:
@@ -284,6 +292,5 @@ def on_unsubscribe(client: mqtt.Client, userdata: MqttHandler, mid: int, reason_
     for r in succeeded:
         logger.debug(f"Acknowledged unsubscribe MID={mid} (reason_code={r} client_id={userdata.client_id})")
 
-    if succeeded:
-        # Signal once per mid regardless of how many topics succeeded.
-        userdata.on_response(mid, "unsubscribe", client)
+    # Signal once per mid regardless of how many topics succeeded.
+    userdata.on_response(mid, "unsubscribe", client)

--- a/sigenergy2mqtt/mqtt/handler.py
+++ b/sigenergy2mqtt/mqtt/handler.py
@@ -32,13 +32,15 @@ import logging
 import threading
 import time
 from collections import namedtuple
-from typing import Any, Callable, Coroutine
+from typing import Any, Callable, Coroutine, Optional
 
 import paho.mqtt.client as mqtt
 from paho.mqtt.enums import MQTTErrorCode
 
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.modbus import ModbusClient
+
+from .registry import MqttHealthRegistry
 
 logger = logging.getLogger("paho.mqtt")
 
@@ -80,14 +82,21 @@ class MqttHandler:
         The running asyncio event loop.  Coroutines returned by topic
         handlers are scheduled on this loop via
         :func:`asyncio.run_coroutine_threadsafe`.
+    health_registry:
+        Optional :class:`MqttHealthRegistry` to register with, allowing
+        the monitor to report on publish success and failure. Should only
+        be omitted for testing.
     """
 
-    def __init__(self, client_id: str, modbus_client: ModbusClient | None, loop: asyncio.AbstractEventLoop):
+    def __init__(self, client_id: str, modbus_client: ModbusClient | None, loop: asyncio.AbstractEventLoop, health_registry: Optional[MqttHealthRegistry] = None):
         """Initialise internal state; no network I/O is performed here."""
         self._loop = loop
         self._modbus = modbus_client
         self.client_id = client_id
         self.connected = False
+
+        # Maybe none when testing
+        self._registry = MqttHealthRegistry() if health_registry is None else health_registry
 
         # Protects: self.connected, self._topics.
         self._state_lock = threading.Lock()
@@ -109,6 +118,10 @@ class MqttHandler:
         # Set when close() is called; signals background threads to stop
         # scheduling new coroutines.
         self._closing = threading.Event()
+
+    @property
+    def registry(self) -> MqttHealthRegistry:
+        return self._registry
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/sigenergy2mqtt/mqtt/registry.py
+++ b/sigenergy2mqtt/mqtt/registry.py
@@ -1,0 +1,117 @@
+"""Thread-safe registry of MQTT client health state.
+
+External monitoring classes should call :meth:`MqttHealthRegistry.snapshot`
+to obtain a point-in-time copy of all client states — safe to read from any
+thread with no locking required on the caller's side.
+"""
+
+import copy
+import threading
+import time
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+
+@dataclass
+class MqttClientHealth:
+    """Observed health state for a single MQTT client."""
+
+    client_id: str
+    connected: bool = False
+    last_connected_at: Optional[float] = None  # epoch seconds
+    last_disconnected_at: Optional[float] = None
+    last_message_at: Optional[float] = None
+    last_publish_ack_at: Optional[float] = None
+    connect_count: int = 0
+    disconnect_count: int = 0
+
+
+class MqttHealthRegistry:
+    """Tracks liveness and activity timestamps for registered MQTT clients.
+
+    Designed to be shared across the callback module and any external
+    monitoring class.  All mutations are serialised with an :class:`RLock`;
+    :meth:`snapshot` returns a shallow copy so callers never hold the lock.
+
+    Usage::
+
+        registry = MqttHealthRegistry()
+        client = MqttClient("my-client", handler, registry=registry)
+
+        # from a monitoring thread or class:
+        for cid, health in registry.snapshot().items():
+            if not health.connected:
+                alert(f"{cid} is down")
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._clients: Dict[str, MqttClientHealth] = {}
+
+    # ------------------------------------------------------------------
+    # Registration (called once per client at startup)
+    # ------------------------------------------------------------------
+
+    def register(self, client_id: str) -> None:
+        """Add *client_id* to the registry with a default-disconnected state."""
+        with self._lock:
+            if client_id not in self._clients:
+                self._clients[client_id] = MqttClientHealth(client_id=client_id)
+
+    # ------------------------------------------------------------------
+    # Mutation helpers (called from MQTT callbacks)
+    # ------------------------------------------------------------------
+
+    def mark_connected(self, client_id: str) -> None:
+        with self._lock:
+            entry = self._clients.get(client_id)
+            if entry is None:
+                return
+            entry.connected = True
+            entry.last_connected_at = time.monotonic()
+            entry.connect_count += 1
+
+    def mark_disconnected(self, client_id: str) -> None:
+        with self._lock:
+            entry = self._clients.get(client_id)
+            if entry is None:
+                return
+            entry.connected = False
+            entry.last_disconnected_at = time.monotonic()
+            entry.disconnect_count += 1
+
+    def record_message(self, client_id: str) -> None:
+        with self._lock:
+            entry = self._clients.get(client_id)
+            if entry:
+                entry.last_message_at = time.monotonic()
+
+    def record_publish_ack(self, client_id: str) -> None:
+        with self._lock:
+            entry = self._clients.get(client_id)
+            if entry:
+                entry.last_publish_ack_at = time.monotonic()
+
+    # ------------------------------------------------------------------
+    # Read-only interface for external consumers
+    # ------------------------------------------------------------------
+
+    def snapshot(self) -> Dict[str, MqttClientHealth]:
+        """Return a shallow copy of all client states.
+
+        Safe to iterate without holding any lock.  Each :class:`ClientHealth`
+        value is itself a copy — mutating it has no effect on the registry.
+        """
+        with self._lock:
+            return {cid: copy.copy(h) for cid, h in self._clients.items()}
+
+    def is_connected(self, client_id: str) -> Optional[bool]:
+        """Return the current connection state, or *None* if unknown."""
+        with self._lock:
+            entry = self._clients.get(client_id)
+            return entry.connected if entry else None
+
+    def __repr__(self) -> str:
+        with self._lock:
+            states = {cid: ("up" if h.connected else "down") for cid, h in self._clients.items()}
+        return f"MqttHealthRegistry({states})"

--- a/sigenergy2mqtt/mqtt/registry.py
+++ b/sigenergy2mqtt/mqtt/registry.py
@@ -18,7 +18,7 @@ class MqttClientHealth:
 
     client_id: str
     connected: bool = False
-    last_connected_at: Optional[float] = None  # epoch seconds
+    last_connected_at: Optional[float] = None
     last_disconnected_at: Optional[float] = None
     last_message_at: Optional[float] = None
     last_publish_ack_at: Optional[float] = None

--- a/tests/unit/main/test_main.py
+++ b/tests/unit/main/test_main.py
@@ -29,8 +29,6 @@ class FmtAsyncMock(AsyncMock):
         return str(self)
 
 
-
-
 class IllegalAddressResponse:
     exception_code = 0x02
 
@@ -83,6 +81,7 @@ def validation_payload(firmware_versions, modbus_hash, sensor_ids):
         },
         sort_keys=True,
     )
+
 
 # Use locally aliased function for backward compatibility
 configure_logging = main_mod.configure_logging
@@ -709,8 +708,8 @@ async def test_coverage_gap_closers(clean_config, monkeypatch):
         inv, plant = await main_mod.make_plant_and_inverter(0, mock_client, 1, mock_plant, seen)
         assert plant is mock_plant
 
-    from sigenergy2mqtt.sensors.base import ReadOnlySensor
     from sigenergy2mqtt.modbus import ModbusDataType
+    from sigenergy2mqtt.sensors.base import ReadOnlySensor
 
     sensor = ReadOnlySensor(
         name="Test RO",
@@ -732,9 +731,13 @@ async def test_coverage_gap_closers(clean_config, monkeypatch):
     )
     device = MagicMock()
     device.get_all_sensors.return_value = {"sensor": sensor}
+
     class RR:
-        def isError(self): return True
+        def isError(self):
+            return True
+
         exception_code = 0x02
+
     monkeypatch.setattr(main_mod, "read_registers", AsyncMock(return_value=RR()))
     await main_mod.validate_publishable_sensors(mock_client, device)
     assert sensor.publishable is False
@@ -881,9 +884,9 @@ async def test_setup_services_comprehensive(clean_config):
         patch("sigenergy2mqtt.main.main.get_influxdb_services", return_value=[MagicMock()]),
     ):
         result = main_mod.setup_services(configs, Protocol.V2_8)
-        # Should have Services thread at 0 and Monitor thread at end
-        assert result[0].name == "Services"
-        assert result[-1].name == "Monitor"
+        # Should have Monitor thread at 0 and Services thread at end
+        assert result[0].name == "Monitor"
+        assert result[-1].name == "Services"
         assert len(result) == 3
 
 

--- a/tests/unit/modbus/test_client.py
+++ b/tests/unit/modbus/test_client.py
@@ -1,12 +1,13 @@
 """Unit tests for ModbusClient class."""
 
+import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pymodbus.pdu import ExceptionResponse, ModbusPDU
 
 from sigenergy2mqtt.common import InputType
-from sigenergy2mqtt.modbus.client import ModbusClient
+from sigenergy2mqtt.modbus.client import ModbusClient, ModbusClientHealth
 from sigenergy2mqtt.modbus.read_ahead import ReadAhead
 
 
@@ -22,6 +23,8 @@ class TestModbusClient:
             client._trace = False
             client._read_count = 0
             client._cache_hits = 0
+            client._health: ModbusClientHealth = ModbusClientHealth("modbus://localhost:502")
+            client._health_lock = threading.RLock()
             return client
 
     @pytest.fixture

--- a/tests/unit/monitor/test_service.py
+++ b/tests/unit/monitor/test_service.py
@@ -162,6 +162,7 @@ async def test_monitor_marks_overdue_and_stops(monkeypatch):
     monkeypatch.setattr(asyncio, "sleep", mock_sleep)
 
     svc = MonitorService([])
+    svc._started = 0
     topic = "topic/overdue"
     # make last_seen well in the past so it's overdue
     ms = MonitoredSensor("Dev", "S", 1, last_seen=time.time() - 100)
@@ -172,7 +173,7 @@ async def test_monitor_marks_overdue_and_stops(monkeypatch):
     fut = loop.create_future()
     svc.online = fut
 
-    task = asyncio.create_task(svc._monitor(None, FakeMqttClient()))
+    task = asyncio.create_task(svc._monitor(FakeMqttClient()))
 
     # let the monitor run one iteration
     await original_sleep(0.2)
@@ -190,12 +191,20 @@ async def test_publish_health_includes_modbus_and_mqtt_connectivity(monkeypatch,
     svc._health_file = tmp_path / "health.json"
     mqtt_client = FakeMqttClient(connected=True)
 
+    class MockHealth:
+        client_id = "127.0.0.1"
+        close_count = 0
+        connect_count = 1
+        last_read_at = time.monotonic()
+
     class Modbus:
         connected = True
+        def snapshot(self):
+            return MockHealth()
 
     monkeypatch.setattr(ModbusClientFactory, "_clients", {("127.0.0.1", 502): Modbus()})
 
-    await svc._publish_health(mqtt_client, overdue_count=0)
+    await svc._publish_health(mqtt_client)
 
     assert svc._health_file.exists()
     content = svc._health_file.read_text(encoding="utf-8")
@@ -211,11 +220,27 @@ async def test_publish_health_considers_all_modbus_clients(monkeypatch, tmp_path
     svc._health_file = tmp_path / "health.json"
     mqtt_client = FakeMqttClient(connected=True)
 
+    class MockHealth1:
+        client_id = "127.0.0.1"
+        close_count = 0
+        connect_count = 1
+        last_read_at = time.monotonic()
+
+    class MockHealth2:
+        client_id = "192.168.0.2"
+        close_count = 1
+        connect_count = 0
+        last_read_at = time.monotonic()
+
     class ConnectedModbus:
         connected = True
+        def snapshot(self):
+            return MockHealth1()
 
     class DisconnectedModbus:
         connected = False
+        def snapshot(self):
+            return MockHealth2()
 
     monkeypatch.setattr(
         ModbusClientFactory,
@@ -226,7 +251,7 @@ async def test_publish_health_considers_all_modbus_clients(monkeypatch, tmp_path
         },
     )
 
-    await svc._publish_health(mqtt_client, overdue_count=0)
+    await svc._publish_health(mqtt_client)
 
     content = svc._health_file.read_text(encoding="utf-8")
     assert '"modbus_connected": false' in content

--- a/tests/unit/monitor/test_service.py
+++ b/tests/unit/monitor/test_service.py
@@ -162,7 +162,7 @@ async def test_monitor_marks_overdue_and_stops(monkeypatch):
     monkeypatch.setattr(asyncio, "sleep", mock_sleep)
 
     svc = MonitorService([])
-    svc._last_checked_at = 0
+    svc._started = 0
     topic = "topic/overdue"
     # make last_seen well in the past so it's overdue
     ms = MonitoredSensor("Dev", "S", 1, last_seen=time.time() - 100)

--- a/tests/unit/monitor/test_service.py
+++ b/tests/unit/monitor/test_service.py
@@ -205,6 +205,14 @@ async def test_publish_health_includes_modbus_and_mqtt_connectivity(monkeypatch,
 
     monkeypatch.setattr(ModbusClientFactory, "_clients", {("127.0.0.1", 502): Modbus()})
 
+    class MockMqttHealth:
+        connected = True
+        last_message_at = time.monotonic()
+        connect_count = 1
+        disconnect_count = 0
+
+    monkeypatch.setattr("sigenergy2mqtt.monitor.monitor_service.mqtt_health_registry.snapshot", lambda: {"fake": MockMqttHealth()})
+
     await svc._publish_health(mqtt_client)
 
     assert svc._health_file.exists()
@@ -253,6 +261,14 @@ async def test_publish_health_considers_all_modbus_clients(monkeypatch, tmp_path
             ("192.168.0.2", 502): DisconnectedModbus(),
         },
     )
+
+    class MockMqttHealth:
+        connected = True
+        last_message_at = time.monotonic()
+        connect_count = 1
+        disconnect_count = 0
+
+    monkeypatch.setattr("sigenergy2mqtt.monitor.monitor_service.mqtt_health_registry.snapshot", lambda: {"fake": MockMqttHealth()})
 
     await svc._publish_health(mqtt_client)
 

--- a/tests/unit/monitor/test_service.py
+++ b/tests/unit/monitor/test_service.py
@@ -162,7 +162,7 @@ async def test_monitor_marks_overdue_and_stops(monkeypatch):
     monkeypatch.setattr(asyncio, "sleep", mock_sleep)
 
     svc = MonitorService([])
-    svc._started = 0
+    svc._last_checked_at = 0
     topic = "topic/overdue"
     # make last_seen well in the past so it's overdue
     ms = MonitoredSensor("Dev", "S", 1, last_seen=time.time() - 100)
@@ -199,6 +199,7 @@ async def test_publish_health_includes_modbus_and_mqtt_connectivity(monkeypatch,
 
     class Modbus:
         connected = True
+
         def snapshot(self):
             return MockHealth()
 
@@ -234,11 +235,13 @@ async def test_publish_health_considers_all_modbus_clients(monkeypatch, tmp_path
 
     class ConnectedModbus:
         connected = True
+
         def snapshot(self):
             return MockHealth1()
 
     class DisconnectedModbus:
         connected = False
+
         def snapshot(self):
             return MockHealth2()
 


### PR DESCRIPTION
# Comprehensive System Health Monitoring

## Overview
This PR introduces a robust system health monitoring framework for both MQTT and Modbus connections. It integrates these new health registries into the `MonitorService`, which now centrally tracks the connection states and publishes the overall system health to MQTT. This enhances observability and enables integration with Docker health checks.

## Key Features
- **MQTT Health Registry (`sigenergy2mqtt/mqtt/registry.py`)**: Added a comprehensive registry to track MQTT client states, including connection status, connection/disconnection counts, and monotonic timestamps for last received messages and publish acknowledgments.
- **Modbus Connection Health (`sigenergy2mqtt/modbus/client.py`)**: Added health monitoring capabilities to track Modbus connection states and operational metrics.
- **Docker Health Check Support**: The `MonitorService` now aggregates MQTT and Modbus health statuses and publishes them to MQTT, making it suitable for container orchestration health checks.

## Refactoring & Improvements
- **MonitorService Enhancements**: 
  - Upgraded the health check logic to utilize `time.monotonic()` for resilient, clock-skew-immune time tracking.
  - Improved logging verbosity to provide better insights into connection issues and service state.
- **Thread Initialization Order**: Adjusted the initialization order of background threads in `main.py` (Monitor and Services) to ensure the monitoring context is fully established prior to starting functional services.

## Bug Fixes
- **MQTT Paho Client Variable Shadowing**: Fixed a bug where an internal variable of the `paho.mqtt` base class was inadvertently being shadowed in our implementation (`sigenergy2mqtt/mqtt/client.py`).

## Testing
- Updated unit tests for `main`, `modbus/client`, and `monitor_service` to accommodate the new health registries and initialization order changes.
