### PR TITLE
Fix removal of readonly flag that causes "At least one Modbus device must be configured" error when config relies on auto-discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - PV Total Generation Today and PV Total Generation Yesterday were incorrectly classified as State class TOTAL_INCREASING, which could cause a persistent sanity check error when they reset at midnight (#200)
 - PV Total Generation Today and PV Total Generation Yesterday were incorrectly marked as enabled by default in Home Assistant
 - Set negative delta range limits for unsigned integer types in sanity checks, because a delta can be less than zero
+- Fixed ConfigurationError raised for valid Modbus configurations with auto-discovery cache (fixes #203)
 
 ---
 

--- a/sigenergy2mqtt/config/config.py
+++ b/sigenergy2mqtt/config/config.py
@@ -22,6 +22,7 @@ For testing, use :func:`_swap_active_config` to temporarily replace the global::
 from __future__ import annotations
 
 import asyncio
+import builtins
 import ipaddress
 import logging
 import os
@@ -35,6 +36,7 @@ from io import StringIO
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generator
 
+from pydantic import ValidationError
 from ruamel.yaml import YAML
 
 from sigenergy2mqtt import i18n
@@ -45,6 +47,10 @@ from .auto_discovery import scan as auto_discovery_scan
 from .auto_discovery_settings import AutoDiscoverySettings
 from .settings import Settings
 from .sources import RuamelYamlSettingsSource, _auto_discovery_env_values
+
+# Keep ValidationError accessible as a builtin for any legacy test code that
+# references it without importing it explicitly.
+builtins.ValidationError = ValidationError  # type: ignore[attr-defined]
 
 AUTODISCOVERY_DEFAULT_TIMEOUT = 300.0
 
@@ -423,12 +429,26 @@ class Config:
 
     def _finalize_reload(self, auto_discovery_cache: Path | None) -> None:
         """Final load including the auto discovery results (if any), WITH post-init validation."""
-        self._settings = Settings(yaml_file_arg=self._source, discovery_yaml_arg=auto_discovery_cache)  # type: ignore[reportCallIssue]
+        # Load Settings; re-raise any pydantic ValidationError as ConfigurationError
+        try:
+            self._settings = Settings(yaml_file_arg=self._source, discovery_yaml_arg=auto_discovery_cache)  # type: ignore[reportCallIssue]
+        except ValidationError as exc:
+            raise ConfigurationError(str(exc)) from exc
+
+        # Ensure at least one Modbus device is configured (unless auto discovery provides it)
+        if not self._settings.modbus:
+            auto_settings = self._load_auto_discovery_settings()
+            if not auto_settings.modbus_auto_discovery:
+                raise ConfigurationError("At least one Modbus device must be configured")
+
         i18n.load(self._settings.language)
 
     def _validate_hosts_after_discovery(self) -> None:
-        """Ensure all Modbus devices have a host after auto-discovery finishes."""
-        for device in self._settings.modbus if self._settings is not None else []:
+        """Ensure at least one Modbus device is configured and all have a host."""
+        modbus_devices = self._settings.modbus if self._settings is not None else []
+        if not modbus_devices:
+            raise ConfigurationError("At least one Modbus device must be configured")
+        for device in modbus_devices:
             if not device.host:
                 raise ConfigurationError("modbus entry must have a host")
 

--- a/sigenergy2mqtt/config/config.py
+++ b/sigenergy2mqtt/config/config.py
@@ -22,7 +22,6 @@ For testing, use :func:`_swap_active_config` to temporarily replace the global::
 from __future__ import annotations
 
 import asyncio
-import builtins
 import ipaddress
 import logging
 import os
@@ -47,10 +46,6 @@ from .auto_discovery import scan as auto_discovery_scan
 from .auto_discovery_settings import AutoDiscoverySettings
 from .settings import Settings
 from .sources import RuamelYamlSettingsSource, _auto_discovery_env_values
-
-# Keep ValidationError accessible as a builtin for any legacy test code that
-# references it without importing it explicitly.
-builtins.ValidationError = ValidationError  # type: ignore[attr-defined]
 
 AUTODISCOVERY_DEFAULT_TIMEOUT = 300.0
 

--- a/sigenergy2mqtt/config/merge.py
+++ b/sigenergy2mqtt/config/merge.py
@@ -198,7 +198,10 @@ def apply_modbus_env_override(
     target_host = override.get("host")
 
     if not modbus_list:
-        return [ModbusConfig(**override)]
+        if target_host:
+            return [ModbusConfig(**override)]
+        else:
+            return modbus_list
 
     idx = 0
     if target_host:

--- a/sigenergy2mqtt/config/settings.py
+++ b/sigenergy2mqtt/config/settings.py
@@ -256,9 +256,6 @@ class Settings(BaseSettings):
         logging.getLogger().setLevel(self.log_level)
 
         # Cross-model validation
-        if not self.modbus:
-            raise ValueError("At least one Modbus device must be configured")
-
         if not self.ems_mode_check:
             for device in self.modbus:
                 if device.registers.no_remote_ems:

--- a/tests/unit/config/test_comprehensive_validation.py
+++ b/tests/unit/config/test_comprehensive_validation.py
@@ -3,12 +3,12 @@
 import pytest
 from pydantic import ValidationError
 
+from sigenergy2mqtt.config import ConfigurationError
 from sigenergy2mqtt.config.settings import (
     HomeAssistantConfig,
     ModbusConfig,
     MqttConfig,
     PvOutputConfig,
-    Settings,
 )
 
 
@@ -79,5 +79,7 @@ class TestConfigComprehensiveValidation:
         from unittest.mock import patch
 
         with patch.dict(os.environ, {}, clear=True):
-            with pytest.raises(ValidationError, match="At least one Modbus device must be configured"):
-                Settings(modbus=[])
+            with pytest.raises(ConfigurationError, match="At least one Modbus device must be configured"):
+                from sigenergy2mqtt.config.config import Config
+
+                Config()._finalize_reload(None)

--- a/tests/unit/config/test_environment_overrides.py
+++ b/tests/unit/config/test_environment_overrides.py
@@ -3,9 +3,8 @@ import os
 from unittest.mock import patch
 
 import pytest
-from pydantic import ValidationError
 
-from sigenergy2mqtt.config import Config, _swap_active_config, const
+from sigenergy2mqtt.config import Config, ConfigurationError, _swap_active_config, const
 
 
 class TestConfigEnvironmentOverrides:
@@ -63,7 +62,7 @@ class TestConfigSensorOverrides:
         with patch("sigenergy2mqtt.config.config.Config._run_auto_discovery", return_value=[]):
             with _swap_active_config(Config()) as cfg:
                 cfg.persistent_state_path = tmp_path
-                with pytest.raises(ValidationError, match="property is not known"):
+                with pytest.raises(ConfigurationError, match="property is not known"):
                     cfg.load(str(config_file))
 
     def test_invalid_sensor_override_structure(self, tmp_path):
@@ -72,7 +71,7 @@ class TestConfigSensorOverrides:
         with patch("sigenergy2mqtt.config.config.Config._run_auto_discovery", return_value=[]):
             with _swap_active_config(Config()) as cfg:
                 cfg.persistent_state_path = tmp_path
-                with pytest.raises(ValidationError):
+                with pytest.raises(ConfigurationError):
                     cfg.load(str(config_file))
 
 
@@ -143,9 +142,9 @@ class TestConfigFileLoading:
                 with _swap_active_config(Config()) as cfg:
                     cfg.persistent_state_path = tmp_path
                     with caplog.at_level(logging.WARNING):
-                        from pydantic import ValidationError
+                        from sigenergy2mqtt.config import ConfigurationError
 
-                        with pytest.raises(ValidationError):
+                        with pytest.raises(ConfigurationError):
                             cfg.load(str(config_file))
         finally:
             os.environ.update(original_env)


### PR DESCRIPTION
## Root Cause

The root cause of the error `Value error, At least one Modbus device must be configured` was an early empty list check inside `Settings.model_post_init()` (sigenergy2mqtt/config/settings.py).

During "Phase 1" of sigenergy2mqtt initialization, the application purposefully skips executing auto-discovery (`skip_auto_discovery=True`) to validate core options first. If a user relies on auto-discovery and does not define a manual Modbus host in YAML or environment variables, their configuration list is naturally empty at this stage.

When you passed `--modbus-readonly`, the CLI parser translated it to a runtime environment variable (`SIGENERGY2MQTT_MODBUS_READ_ONLY=true`), which tricked the override merging logic (`apply_modbus_env_override`) into instantiating a "dummy" Modbus configuration with `read_only=True` but no host. This dummy configuration ensured that `Settings.modbus` had a length of 1, effectively bypassing the `ValueError` check in Phase 1. When you removed the flag, the dummy configuration was no longer generated, resulting in an empty list and triggering the `ValueError`, which killed the process before auto-discovery cache loading ("Phase 2") could take place.

## The Fix

Defer the "At least one Modbus device must be configured" check until after auto-discovery has fully executed.

