### PR TITLE
fix: TimeoutError in save_sync (#207)

### DIFF
--- a/sigenergy2mqtt/persistence/state_store.py
+++ b/sigenergy2mqtt/persistence/state_store.py
@@ -614,6 +614,7 @@ class StateStore:
             try:
                 future.result(timeout=self._sync_timeout)
             except Exception as exc:
+                future.cancel()
                 logging.warning(f"StateStore.save_sync failed for {category}/{key}: {repr(exc)}")
         else:
             self._save_sync_impl(category, key, value)
@@ -639,6 +640,7 @@ class StateStore:
             try:
                 return future.result(timeout=self._sync_timeout)
             except Exception as exc:
+                future.cancel()
                 logging.warning(f"StateStore.load_sync failed for {category}/{key}: {repr(exc)}")
                 return None
         else:
@@ -654,6 +656,7 @@ class StateStore:
             try:
                 future.result(timeout=self._sync_timeout)
             except Exception as exc:
+                future.cancel()
                 logging.warning(f"StateStore.delete_sync failed for {category}/{key}: {repr(exc)}")
         else:
             self._delete_sync_impl(category, key)

--- a/sigenergy2mqtt/pvoutput/service_topics.py
+++ b/sigenergy2mqtt/pvoutput/service_topics.py
@@ -441,7 +441,7 @@ class ServiceTopics(dict[str, Topic]):
                     self[topic].timestamp = time.localtime()
                     if self._persistence_key and ((self._always_persist and state_was != state) or (self.calculation & (Calculation.DIFFERENCE | Calculation.PEAK)) or len(self._time_periods) > 0):
                         payload = json.dumps(self, default=Topic.json_encoder)
-                        state_store.save_sync(Category.PVOUTPUT, self._persistence_key, payload)
+                        await state_store.save(Category.PVOUTPUT, self._persistence_key, payload)
             elif active_config.pvoutput.update_debug_logging and state and Calculation.PEAK in self.calculation:
                 ts = self[topic].timestamp
                 if self[topic].restore_timestamp is not None and (ts is None or cast(time.struct_time, ts) < cast(time.struct_time, self[topic].restore_timestamp)):  # pyrefly: ignore

--- a/sigenergy2mqtt/sensors/base/accumulation.py
+++ b/sigenergy2mqtt/sensors/base/accumulation.py
@@ -120,7 +120,7 @@ class AccumulationSensor(DerivedSensor):
         """
         async with self._current_total_lock:
             try:
-                state_store.save_sync(Category.SENSOR, self._state_persistence_key, str(new_total))
+                await state_store.save(Category.SENSOR, self._state_persistence_key, str(new_total))
             except PermissionError as e:
                 logging.warning(f"{self.log_identity} Failed to persist state for {self._state_persistence_key}: {e}")
             except Exception as e:
@@ -422,7 +422,7 @@ class EnergyDailyAccumulationSensor(ResettableAccumulationSensor):
 
         async with self._state_at_midnight_lock:
             try:
-                state_store.save_sync(Category.SENSOR, self._midnight_persistence_key, str(midnight_state))
+                await state_store.save(Category.SENSOR, self._midnight_persistence_key, str(midnight_state))
             except Exception as e:
                 logging.warning(f"{self.log_identity} Failed to update midnight state for {self._midnight_persistence_key}: {e}")
 

--- a/tests/unit/pvoutput/test_service_topics.py
+++ b/tests/unit/pvoutput/test_service_topics.py
@@ -127,9 +127,12 @@ class TestPVOutputServiceTopics:
             st._service.lock.return_value.__aenter__ = AsyncMock()
             st._service.lock.return_value.__aexit__ = AsyncMock()
 
+            # Mock save as an AsyncMock
+            mock_ss.save = AsyncMock()
+
             await st.handle_update(None, MagicMock(), 100.0, "t/1", MagicMock())
             assert t.state == 100.0
-            mock_ss.save_sync.assert_called()
+            mock_ss.save.assert_called()
 
     def test_restore_state_from_file(self):
         st = make_service_topics(value_key=OutputField.PEAK_POWER)

--- a/tests/unit/sensors/test_base_registration_and_identity.py
+++ b/tests/unit/sensors/test_base_registration_and_identity.py
@@ -152,11 +152,11 @@ class TestResettableAccumulationSensorCoverage:
     @pytest.mark.asyncio
     async def test_persist_errors(self, mock_config, caplog):
         sensor = self._make_sensor()
-        with patch.object(state_store, "save_sync", side_effect=PermissionError):
+        with patch.object(state_store, "save", side_effect=PermissionError):
             await sensor._persist_current_total(100.0)
             assert "Failed to persist state" in caplog.text
 
-        with patch.object(state_store, "save_sync", side_effect=RuntimeError):
+        with patch.object(state_store, "save", side_effect=RuntimeError):
             await sensor._persist_current_total(100.0)
             assert "Unexpected error persisting state" in caplog.text
 
@@ -288,7 +288,7 @@ class TestEnergyDailyAccumulationSensorCoverageExtended:
     @pytest.mark.asyncio
     async def test_update_midnight_errors(self, mock_config, caplog):
         sensor = self._make_sensor()
-        with patch.object(state_store, "save_sync", side_effect=RuntimeError):
+        with patch.object(state_store, "save", side_effect=RuntimeError):
             await sensor._update_state_at_midnight(100.0)
             assert "Failed to update" in caplog.text
 

--- a/tests/unit/sensors/test_energy_daily_accumulation.py
+++ b/tests/unit/sensors/test_energy_daily_accumulation.py
@@ -1,6 +1,6 @@
 import time
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -111,9 +111,10 @@ class TestEnergyDailyAccumulationSensor:
                 source=source_sensor,
             )
 
+            mock_state_store.save = AsyncMock()
             await sensor._update_state_at_midnight(150.0)
             assert sensor._state_at_midnight == 150.0
-            mock_state_store.save_sync.assert_called_with(Category.SENSOR, "sigen_test_source_uid.atmidnight", "150.0")
+            mock_state_store.save.assert_called_with(Category.SENSOR, "sigen_test_source_uid.atmidnight", "150.0")
 
     @pytest.mark.asyncio
     async def test_notify(self, source_sensor):


### PR DESCRIPTION
# TimeoutError in `save_sync` — Root Cause Analysis

## The Mechanism

The [save_sync](file:///root/repositories/seud0nym/sigenergy2mqtt/sigenergy2mqtt/persistence/state_store.py#L601-L619) method bridges synchronous callers into the async event loop:

```python
def save_sync(self, category, key, value):
    loop = self._loop
    if loop is not None and loop.is_running() and threading.get_ident() != self._loop_thread_id:
        future = asyncio.run_coroutine_threadsafe(self.save(category, key, value), loop)
        future.result(timeout=self._sync_timeout)  # ← TimeoutError here (line 615)
```

The timeout defaults to **5.0 seconds** ([persistence.py:48](file:///root/repositories/seud0nym/sigenergy2mqtt/sigenergy2mqtt/config/models/persistence.py#L48-L54)), configurable 0.1–30s.

When the timeout fires, the coroutine is **not cancelled** — it remains scheduled on the event loop. The `save_sync` caller just gives up waiting for it.

## Root Cause — Async Callers Blocking the Event Loop

The `save_sync` guard at [line 612](file:///root/repositories/seud0nym/sigenergy2mqtt/sigenergy2mqtt/persistence/state_store.py#L612) routes calls one of two ways:

```python
if loop is not None and loop.is_running() and threading.get_ident() != self._loop_thread_id:
    # Non-event-loop thread: submit coroutine and wait with timeout
    future = asyncio.run_coroutine_threadsafe(self.save(category, key, value), loop)
    future.result(timeout=self._sync_timeout)
else:
    # Event loop thread (or no loop): call _save_sync_impl directly
    self._save_sync_impl(category, key, value)   # ← BLOCKS the event loop thread
```

The following callers are all **async functions running on the event loop thread**, so they take the `else` branch:

| Caller | File | Frequency |
|--------|------|-----------|
| `_persist_current_total` | [accumulation.py:123](file:///root/repositories/seud0nym/sigenergy2mqtt/sigenergy2mqtt/sensors/base/accumulation.py#L121-L127) | Every sensor reading |
| `_update_state_at_midnight` | [accumulation.py:425](file:///root/repositories/seud0nym/sigenergy2mqtt/sigenergy2mqtt/sensors/base/accumulation.py#L423-L427) | Daily rollover |
| `ServiceTopic.set` | [service_topics.py:444](file:///root/repositories/seud0nym/sigenergy2mqtt/sigenergy2mqtt/pvoutput/service_topics.py#L444) | Every PVOutput update |

Each of these calls `_save_sync_impl` directly, which does **synchronous disk I/O + MQTT publish on the event loop thread**. This freezes the event loop for the entire duration of that write.

### How This Causes the TimeoutError

During normal operation, any non-event-loop thread (paho's network thread, a timer callback, etc.) that calls `save_sync` submits a coroutine via `run_coroutine_threadsafe` and blocks on `future.result(timeout=5.0)`. If the event loop is frozen in a `_save_sync_impl` call from an async caller, that coroutine cannot be scheduled. After 5 seconds: **TimeoutError**.

```
Event loop thread:                 Non-event-loop thread:
  async _persist_current_total()
    → save_sync()
      → _save_sync_impl()          → save_sync()
        [disk write: ~Xs]              → run_coroutine_threadsafe(save())
        [MQTT publish]                     future.result(timeout=5.0)
        ...still blocking...                   ... waiting ...
        [finally done]                         ... 5s elapsed → TimeoutError
```

### Aggravating Factors

- **Single executor thread** (`max_workers=1`) — once the async callers are fixed to use `await save()`, all writes properly go through the executor. But they still queue behind each other, so slow I/O (below) compounds the backlog.
- **MQTT QoS 2 latency** — `_drain_retries` + QoS 2 handshake runs synchronously inside `_save_sync_impl`, contributing to per-write duration.
- **Disk I/O latency** — SD card wear-leveling or NFS latency can push individual writes to several seconds.
- **Orphaned coroutines** — when the timeout fires, the future is not cancelled, so the abandoned coroutine eventually runs anyway and queues another `_save_sync_impl` on the executor, worsening the backlog.

## Cascading Effect

When the timeout fires:
1. The warning is logged, but the **coroutine is not cancelled** — it remains in the event loop's task queue
2. If many `save_sync` calls timeout in sequence, orphaned coroutines accumulate on the loop
3. Each orphaned coroutine, when eventually executed, still queues work on the single executor thread
4. This creates a snowball effect where the executor queue grows unboundedly

---

## Mitigation Strategies

### A. Cancel the Future on Timeout (Quick Fix)

Currently the future is abandoned on timeout. Cancelling it prevents orphaned coroutines from piling up:

```diff
 try:
     future.result(timeout=self._sync_timeout)
 except Exception as exc:
     logging.warning(f"StateStore.save_sync failed for {category}/{key}: {repr(exc)}")
+    future.cancel()
```

> [!NOTE]
> Apply the same pattern to `load_sync` and `delete_sync`.

### B. Fall Back to Direct Execution on Timeout (Resilient)

When the async path times out, fall back to the synchronous implementation directly instead of just giving up:

```python
try:
    future.result(timeout=self._sync_timeout)
except TimeoutError:
    future.cancel()
    logging.warning(f"StateStore.save_sync timed out for {category}/{key}, falling back to direct write")
    self._save_sync_impl(category, key, value)
except Exception as exc:
    logging.warning(f"StateStore.save_sync failed for {category}/{key}: {repr(exc)}")
```

> [!WARNING]
> This introduces a thread-safety consideration: `_save_sync_impl` would run on the calling thread concurrently with the executor thread. Since disk writes to different files are independent and MQTT publish is thread-safe via paho, this is acceptable in practice.

### C. Increase Executor Workers (Trivial Change, Minor Audit)

Increase from 1 to 2–4 workers to prevent a single slow operation from blocking all persistence:

```python
self._executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="persistence")
```

The code change is one character. The only consideration is that `_drain_retries` mutates a shared `deque` without a lock — with multiple workers it needs synchronization (the existing `_MqttBackend._lock` could be reused). Disk writes target distinct `category/key` paths so rarely collide, and paho's `client.publish` is already thread-safe.

This helps with executor thread contention but doesn't address event loop saturation.

### D. Use Async Save Directly in Async Callers (Proper Fix)

The callers in [accumulation.py](file:///root/repositories/seud0nym/sigenergy2mqtt/sigenergy2mqtt/sensors/base/accumulation.py) and [service_topics.py](file:///root/repositories/seud0nym/sigenergy2mqtt/sigenergy2mqtt/pvoutput/service_topics.py) are already async functions. They should call `await state_store.save(...)` instead of `state_store.save_sync(...)`:

```diff
 async def _persist_current_total(self, new_total: float):
     async with self._current_total_lock:
         try:
-            state_store.save_sync(Category.SENSOR, self._state_persistence_key, str(new_total))
+            await state_store.save(Category.SENSOR, self._state_persistence_key, str(new_total))
```

This eliminates the `run_coroutine_threadsafe` + `future.result(timeout)` roundtrip entirely for the most frequent callers.

### E. Make `_sync_timeout` User-Configurable and Increase Default

The default 5s is already configurable (0.1–30s). For users experiencing this, document that they can increase it:

```yaml
persistence:
  sync-timeout: 10.0
```

This is a workaround, not a fix.

---

## Approach

Apply strategies **A + D** together:

1. **Cancel futures on timeout** (A) — prevents cascading failures, minimal code change
2. **Switch async callers to `await save()`** (D) — eliminates the problematic path for the most frequent callers, leaving `save_sync` only for the true sync contexts like `Config.reload()`

Strategy B will be considered in the future if the sync callers (Config.reload) experience issues.

Strategy C is considered unnecessary at this time.