### PR TITLE
Fix test failures that only appear when running under pytest-cov and parallel workers via pytest-xdist

### DIFF
--- a/sigenergy2mqtt/sensors/base/sensor.py
+++ b/sigenergy2mqtt/sensors/base/sensor.py
@@ -411,11 +411,6 @@ class Sensor(SensorDebuggingMixin, dict[str, SensorAttribute], metaclass=abc.ABC
             if self.debug_logging:
                 logging.debug(f"{self.log_identity} Device overrides not applied (publishable={self.publishable})")
         elif registers:
-            # Lazy imports to avoid circular dependencies
-            from .derived import DerivedSensor
-            from .mixins import ReadableSensorMixin, WritableSensorMixin
-            from .writable import WriteOnlySensor
-
             # Check for remote EMS override
             if registers.no_remote_ems and (getattr(self, "_remote_ems", None) is not None or getattr(self, "address", None) == 40029):
                 if self.debug_logging:
@@ -423,18 +418,23 @@ class Sensor(SensorDebuggingMixin, dict[str, SensorAttribute], metaclass=abc.ABC
                 self.publishable = False
                 return
 
-            # Check read/write permissions
-            if isinstance(self, WritableSensorMixin) and not isinstance(self, WriteOnlySensor):
+            # Check read/write permissions via MRO class names to be robust against reimports and test mocks
+            mro_names = {base.__name__ for base in self.__class__.__mro__}
+            is_writable = "WritableSensorMixin" in mro_names
+            is_readable = "ReadableSensorMixin" in mro_names or "DerivedSensor" in mro_names
+            is_write_only = "WriteOnlySensor" in mro_names
+
+            if is_writable and not is_write_only:
                 if not registers.read_write:
                     if self.debug_logging:
                         logging.debug(f"{self.log_identity} Applying device 'read-write' override ({registers.read_write})")
                     self.publishable = registers.read_write
-            elif isinstance(self, (ReadableSensorMixin, DerivedSensor)):
+            elif is_readable:
                 if not registers.read_only:
                     if self.debug_logging:
                         logging.debug(f"{self.log_identity} Applying device 'read-only' override ({registers.read_only})")
                     self.publishable = registers.read_only
-            elif isinstance(self, WriteOnlySensor):
+            elif is_write_only:
                 if not registers.write_only:
                     if self.debug_logging:
                         logging.debug(f"{self.log_identity} Applying device 'write-only' override ({registers.write_only})")

--- a/tests/unit/modbus/test_registers_config.py
+++ b/tests/unit/modbus/test_registers_config.py
@@ -191,3 +191,19 @@ class TestSensorPublishableState:
         for s in sensors:
             s.apply_device_overrides(reg_access)
             assert s.publishable is True
+
+    def test_mro_classname_expectations(self):
+        """Assert that class names match the hardcoded strings in apply_device_overrides.
+
+        This test ensures that the class names checked as string literals inside
+        sensor.apply_device_overrides() method match the actual class names
+        (WritableSensorMixin, ReadableSensorMixin, DerivedSensor, and WriteOnlySensor).
+
+        If any of these classes are renamed in the future, this test will fail
+        immediately at the import or assertion stage, preventing any silent
+        regressions or untracked override failures.
+        """
+        assert WritableSensorMixin.__name__ == "WritableSensorMixin"
+        assert ReadableSensorMixin.__name__ == "ReadableSensorMixin"
+        assert DerivedSensor.__name__ == "DerivedSensor"
+        assert WriteOnlySensor.__name__ == "WriteOnlySensor"


### PR DESCRIPTION
### Root Cause

The core issue causing test_read_only_override and test_read_write_override to fail under coverage/concurrency was a class identity mismatch. When apply_device_overrides lazily imported ReadableSensorMixin and WritableSensorMixin inside the function scope to avoid circular imports, different worker processes or coverage tracing imports resulted in separate class objects in memory than those used in the test's mock class definitions. This caused standard isinstance() checks to fail.

### Fix

* Refactored apply_device_overrides in `sensor.py` to check class names in self.__class__.__mro__ as strings (e.g. "ReadableSensorMixin" and "WritableSensorMixin") instead of performing isinstance calls on lazily imported classes.
* Removed the local lazy imports completely, eliminating import-time class identity issues entirely and simplifying the override logic.
