### PR TITLE
Fix "Task was destroyed but it is pending!" after internal restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 
 - Fixed infinite tight loop in PVOutput status service when lock times out
+- Fixed "Task was destroyed but it is pending!" warning during restart after firmware upgrade (or other restart event)
 
 ---
 

--- a/sigenergy2mqtt/main/device_thread.py
+++ b/sigenergy2mqtt/main/device_thread.py
@@ -161,7 +161,19 @@ def run_modbus_event_loop(
         if stop_event is not None:
             stop_event.set()
     finally:
-        loop.close()
+        # Drain any remaining fire-and-forget tasks (e.g. _persist_current_total)
+        # before closing the loop.  Without this, tasks that were scheduled via
+        # loop.create_task() but had not yet completed produce the asyncio
+        # "Task was destroyed but it is pending!" warning when the loop is closed
+        # during a restart (e.g. after a firmware upgrade).
+        try:
+            pending = asyncio.all_tasks(loop)
+            if pending:
+                loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+        except Exception:
+            logging.exception(f"{config.description} error draining pending tasks on shutdown")
+        finally:
+            loop.close()
 
 
 async def start(configs: list[ThreadConfig]) -> None:

--- a/sigenergy2mqtt/main/device_thread.py
+++ b/sigenergy2mqtt/main/device_thread.py
@@ -166,10 +166,23 @@ def run_modbus_event_loop(
         # loop.create_task() but had not yet completed produce the asyncio
         # "Task was destroyed but it is pending!" warning when the loop is closed
         # during a restart (e.g. after a firmware upgrade).
+        #
+        # A 5-second deadline (matching the state-store sync_timeout) prevents
+        # tasks blocked on the state-store lock or storage I/O from stalling the
+        # device thread indefinitely during a firmware restart.
         try:
             pending = asyncio.all_tasks(loop)
             if pending:
-                loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+                done, still_pending = loop.run_until_complete(asyncio.wait(pending, timeout=5.0))
+                if still_pending:
+                    logging.warning(
+                        f"{config.description} {len(still_pending)} background task(s) did not finish within the "
+                        f"shutdown deadline — cancelling to allow the loop to close"
+                    )
+                    for task in still_pending:
+                        task.cancel()
+                    # Brief await so cancelled tasks can run their CancelledError handlers
+                    loop.run_until_complete(asyncio.gather(*still_pending, return_exceptions=True))
         except Exception:
             logging.exception(f"{config.description} error draining pending tasks on shutdown")
         finally:


### PR DESCRIPTION
###  Summary

Root cause: `update_from_source_sensor` calls `run_persistence_coroutine(self._persist_current_total(new_total))`, which uses `loop.create_task()` — a fire-and-forget background task. During the firmware-upgrade restart, the per-thread event loop was closed (`loop.close()`) before that in-flight persistence task could complete, triggering Python's `"Task was destroyed but it is pending!"` warning (and losing the persistence write).

### Fix

Added a task-drain step in the finally block of run_modbus_event_loop, before loop.close(), in device_thread.py.

This gives all pending fire-and-forget tasks a final opportunity to complete before the loop is torn down. `return_exceptions=True` ensures one failing task doesn't abort the others, and the inner `finally` guarantees the loop is always closed regardless.