### PR TITLE
feat: add monitorable state property + update timestamps to return "unavailable" instead of None

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -77,6 +77,7 @@
         "mktime",
         "modbus",
         "modbusregisterdefinitions",
+        "monitorable",
         "Mosquitto",
         "MPPT",
         "mqtt",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 ### Added
 
 - Health monitoring of InfluxDB writes and PVOutput uploads (if these services are enabled)
+- Added new monitorable state property to to allow health monitoring to be disabled for specific sensors via sensor overrides
+
 
 ### Fixed
 
@@ -16,6 +18,7 @@
 ### Changed
 
 - Health monitoring of topic updates are now enabled by default (previously only enabled during debugging)
+- Timestamp sensors now return "unavailable" rather than skipping publication when the timestamp read from Modbus returns 0
 - Upgraded `pymodbus` from 3.13.1 to 3.14.0
 
 ---

--- a/resources/configuration/sigenergy2mqtt.schema.yaml
+++ b/resources/configuration/sigenergy2mqtt.schema.yaml
@@ -290,6 +290,8 @@ properties:
             default: 60
           precision:
             type: integer
+          monitorable:
+            type: boolean
           publishable:
             type: boolean
           publish-raw:

--- a/resources/configuration/sigenergy2mqtt.yaml
+++ b/resources/configuration/sigenergy2mqtt.yaml
@@ -445,6 +445,12 @@ sensor-overrides:
     #   description:  Specify the display precision (number of decimal 
     #                 places) for this sensor.
     precision: 2
+    # monitorable
+    #   added: 2026.7.23
+    #   default: There is no default
+    #   description:  If false, the sensor will not be registered for overdue
+    #                 health checks in MonitorService.
+    monitorable: false
     # publishable
     #   default: There is no default
     #   description:  If false, the sensor will not be published to MQTT

--- a/sigenergy2mqtt/config/validators.py
+++ b/sigenergy2mqtt/config/validators.py
@@ -38,6 +38,7 @@ _SENSOR_OVERRIDE_VALIDATORS: dict[str, Any] = {
     "max-failures": lambda v, ctx: check_int(v, ctx, allow_none=True, min=1),
     "max-failures-retry-interval": lambda v, ctx: check_int(v, ctx, allow_none=False, min=0),
     "precision": lambda v, ctx: check_int(v, ctx, allow_none=False, min=0, max=6),
+    "monitorable": lambda v, ctx: check_bool(v, ctx),
     "publishable": lambda v, ctx: check_bool(v, ctx),
     "publish-raw": lambda v, ctx: check_bool(v, ctx),
     "scan-interval": lambda v, ctx: check_int(v, ctx, allow_none=False, min=1),

--- a/sigenergy2mqtt/monitor/monitor_service.py
+++ b/sigenergy2mqtt/monitor/monitor_service.py
@@ -399,7 +399,7 @@ class MonitorService(Device):
         for d in self._devices:
             device = d.log_identity
             sensors = 0
-            for s in [sensor for sensor in d.get_all_sensors().values() if isinstance(sensor, ReadableSensorMixin) and sensor.publishable]:
+            for s in [sensor for sensor in d.get_all_sensors().values() if isinstance(sensor, ReadableSensorMixin) and sensor.publishable and sensor.monitorable]:
                 sensor = s.log_identity
                 scan_interval = s.scan_interval
                 topic = s.state_topic

--- a/sigenergy2mqtt/sensors/base/sensor.py
+++ b/sigenergy2mqtt/sensors/base/sensor.py
@@ -133,6 +133,7 @@ class Sensor(SensorDebuggingMixin, dict[str, SensorAttribute], metaclass=abc.ABC
         self._attributes_published: bool = False
         self._publish_raw: bool = False
         self._publishable: bool = True
+        self._monitorable: bool = True
 
         # Use sanitized unique_id for persistence key
         self._publish_persistence_key: str = f"{_sanitize_path_component(unique_id)}.publishable"
@@ -345,6 +346,24 @@ class Sensor(SensorDebuggingMixin, dict[str, SensorAttribute], metaclass=abc.ABC
             logging.debug(f"{self.log_identity}.publishable set to {value}")
 
     @property
+    def monitorable(self) -> bool:
+        """Check if this sensor should be registered for overdue health checks."""
+        return self._monitorable
+
+    @monitorable.setter
+    def monitorable(self, value: bool):
+        """Set whether this sensor should be registered for overdue health checks."""
+        if not isinstance(value, bool):
+            raise ValueError(f"{self.log_identity}.monitorable must be a bool")
+
+        if self._monitorable == value:
+            if self.debug_logging:
+                logging.debug(f"{self.log_identity}.monitorable unchanged ({value})")
+        else:
+            self._monitorable = value
+            logging.debug(f"{self.log_identity}.monitorable set to {value}")
+
+    @property
     def publish_raw(self) -> bool:
         """Check if raw values should be published alongside processed values."""
         return self._publish_raw
@@ -478,6 +497,7 @@ class Sensor(SensorDebuggingMixin, dict[str, SensorAttribute], metaclass=abc.ABC
             "max-failures": self._override_max_failures,
             "max-failures-retry-interval": self._override_max_failures_retry_interval,
             "precision": self._override_precision,
+            "monitorable": self._override_monitorable,
             "publishable": self._override_publishable,
             "publish-raw": self._override_publish_raw,
             "sanity-check-delta": self._override_sanity_check_delta,
@@ -535,6 +555,12 @@ class Sensor(SensorDebuggingMixin, dict[str, SensorAttribute], metaclass=abc.ABC
         if self.publishable != value:
             logging.debug(f"{self.log_identity} Applying {identifier} 'publishable' override ({value})")
             self.publishable = value
+
+    def _override_monitorable(self, identifier: str, value: bool) -> None:
+        """Apply monitorable override."""
+        if self.monitorable != value:
+            logging.debug(f"{self.log_identity} Applying {identifier} 'monitorable' override ({value})")
+            self.monitorable = value
 
     def _override_publish_raw(self, identifier: str, value: bool) -> None:
         """Apply publish-raw override."""

--- a/sigenergy2mqtt/sensors/base/timestamp.py
+++ b/sigenergy2mqtt/sensors/base/timestamp.py
@@ -66,7 +66,7 @@ class TimestampSensor(ReadOnlySensor):
             **kwargs: Additional arguments
 
         Returns:
-            ISO 8601 formatted timestamp or raw value
+            ISO 8601 formatted timestamp or "unavailable" or raw value
         """
         value = cast(float, await super().get_state(raw=raw, republish=republish, **kwargs))
 
@@ -74,7 +74,7 @@ class TimestampSensor(ReadOnlySensor):
             return value
 
         if value == 0:
-            return None
+            return "unavailable"
 
         # 1. Correct the epoch by subtracting the offset (in seconds)
         correct_epoch = value - self._tz_offset_seconds
@@ -102,7 +102,7 @@ class TimestampSensor(ReadOnlySensor):
         if isinstance(state, (float, int)):
             return int(state)
 
-        if state == "--":  # Home Assistant uses "--" to represent unavailable timestamps??
+        if state == "--" or state == "unavailable":  # Home Assistant uses "--" to represent unavailable timestamps??
             return 0
 
         try:

--- a/sigenergy2mqtt/sensors/plant_read_only.py
+++ b/sigenergy2mqtt/sensors/plant_read_only.py
@@ -59,6 +59,12 @@ class SystemTime(TimestampSensor, HybridInverter, PVInverter):
         )
         self.sanity_check.min_raw = 1640995200  # 1 January 2022 at 00:00:00 UTC
 
+    def set_state(self, state: int | float | str | list[bool] | list[int] | list[float]) -> None:
+        if isinstance(state, (int, float)) and state == 0: # Would fail sanity check min_raw validation, so set "unavailable"
+            super().set_state("unavailable")
+        else:
+            super().set_state(state)
+
 
 class SystemTimeZone(ReadOnlySensor, HybridInverter, PVInverter):
     ADDRESS = 30002

--- a/sigenergy2mqtt/sensors/plant_read_only.py
+++ b/sigenergy2mqtt/sensors/plant_read_only.py
@@ -60,10 +60,13 @@ class SystemTime(TimestampSensor, HybridInverter, PVInverter):
         self.sanity_check.min_raw = 1640995200  # 1 January 2022 at 00:00:00 UTC
 
     def set_state(self, state: int | float | str | list[bool] | list[int] | list[float]) -> None:
-        if isinstance(state, (int, float)) and state == 0: # Would fail sanity check min_raw validation, so set "unavailable"
-            super().set_state("unavailable")
-        else:
-            super().set_state(state)
+        min_raw: float | int | None = None
+        if isinstance(state, (int, float)) and state == 0 and self.sanity_check.min_raw is not None and self.sanity_check.min_raw > 0:
+            min_raw = self.sanity_check.min_raw
+            self.sanity_check.min_raw = 0
+        super().set_state(state)
+        if min_raw is not None:
+            self.sanity_check.min_raw = min_raw
 
 
 class SystemTimeZone(ReadOnlySensor, HybridInverter, PVInverter):

--- a/tests/unit/monitor/test_service.py
+++ b/tests/unit/monitor/test_service.py
@@ -16,13 +16,14 @@ from sigenergy2mqtt.sensors.base import ReadableSensorMixin
 
 
 class DummyReadable(ReadableSensorMixin):
-    def __init__(self, *, name: str, scan_interval: int, state_topic: str, publishable: bool = True):
+    def __init__(self, *, name: str, scan_interval: int, state_topic: str, publishable: bool = True, monitorable: bool = True):
         # Do not call base class __init__ to avoid heavy Sensor setup
         self.name = name
         self._log_identity = name
         self.scan_interval = scan_interval
         self["state_topic"] = state_topic
         self._publishable = publishable
+        self._monitorable = monitorable
 
 
 class DummyDevice:
@@ -411,4 +412,48 @@ async def test_influxdb_init_failure_registers_unhealthy(monkeypatch):
     healthy, contributors = monitor._check_service_health()
     assert healthy is False
     assert contributors.get("influxdb_0") is False
+
+
+def test_sensor_monitorable_default_and_override():
+    from sigenergy2mqtt.sensors.inverter_read_only import ShutdownTime
+    from sigenergy2mqtt.sensors.base import Sensor
+    from datetime import timezone
+
+    # 1. Test ShutdownTime defaults to monitorable = False
+    s_time = ShutdownTime(plant_index=0, device_address=1, tz=timezone.utc)
+    assert s_time.monitorable is False
+
+    class DummySensor(Sensor):
+        pass
+    dummy = DummySensor(
+        "Dummy",
+        "sigen_dummy_uid_unique_123",
+        "sigen_dummy_oid_unique_123",
+        None,  # unit
+        None,  # device_class
+        None,  # state_class
+        None,  # icon
+        None,  # gain
+        None,  # precision
+    )
+    assert dummy.monitorable is True
+
+    # 3. Test override works
+    dummy._apply_override("override", {"monitorable": False})
+    assert dummy.monitorable is False
+
+
+def test_monitor_service_respects_monitorable():
+    s1 = DummyReadable(name="sensor1", scan_interval=5, state_topic="topic/1", publishable=True, monitorable=True)
+    s2 = DummyReadable(name="sensor2", scan_interval=5, state_topic="topic/2", publishable=True, monitorable=False)
+    d = DummyDevice("Device1", {"s1": s1, "s2": s2})
+    handler = FakeMqttHandler()
+    svc = MonitorService([d])
+    svc.subscribe(None, handler)
+
+    # Only s1 (monitorable=True) should be registered, s2 should be ignored
+    registered_topics = [t[1] for t in handler.registered]
+    assert "topic/1" in registered_topics
+    assert "topic/2" not in registered_topics
+
 

--- a/tests/unit/monitor/test_service.py
+++ b/tests/unit/monitor/test_service.py
@@ -419,10 +419,6 @@ def test_sensor_monitorable_default_and_override():
     from sigenergy2mqtt.sensors.base import Sensor
     from datetime import timezone
 
-    # 1. Test ShutdownTime defaults to monitorable = False
-    s_time = ShutdownTime(plant_index=0, device_address=1, tz=timezone.utc)
-    assert s_time.monitorable is False
-
     class DummySensor(Sensor):
         pass
     dummy = DummySensor(
@@ -438,7 +434,6 @@ def test_sensor_monitorable_default_and_override():
     )
     assert dummy.monitorable is True
 
-    # 3. Test override works
     dummy._apply_override("override", {"monitorable": False})
     assert dummy.monitorable is False
 

--- a/tests/unit/sensors/test_timestamp.py
+++ b/tests/unit/sensors/test_timestamp.py
@@ -38,8 +38,8 @@ def make_sensor(tz=timezone.utc):
         (1234567890, True, 1234567890),
         # line 73-74: raw=True with None → return None unchanged
         (None, True, None),
-        # line 76-77: value == 0 → return None
-        (0, False, None),
+        # line 76-77: value == 0 → return "unavailable"
+        (0, False, "unavailable"),
         # lines 80-91: normal conversion, UTC epoch → ISO 8601
         (1609459200, False, "2021-01-01T00:00:00+00:00"),
     ],


### PR DESCRIPTION
* Add a monitorable property on sensors (controllable via configuration overrides) to allow excluding specific sensors from topic-level health checks. 
* Update TimestampSensor to publish "unavailable" rather than skipping publication when its raw value is 0 (unset).