### PR TITLE
fix: ensure DerivedSensors respect the configured repeated state publish interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed infinite tight loop in PVOutput status service when lock times out
 - Fixed "Task was destroyed but it is pending!" warning during restart after firmware upgrade (or other restart event)
 - Fixed missing device classes and state classes for Home Assistant (#219)
+- Fixed DerivedSensors did not respect the repeated state publishing interval setting
 
 ### Changed
 

--- a/sigenergy2mqtt/sensors/base/derived.py
+++ b/sigenergy2mqtt/sensors/base/derived.py
@@ -39,6 +39,7 @@ class DerivedSensor(TypedSensorMixin, Sensor):
         super().__init__(*args, **kwargs)
         self[DiscoveryKeys.ENABLED_BY_DEFAULT] = True
         self.bound_source_sensors: list[Sensor] = []
+        self._pending_update: bool = False
 
         # Initialise source_sensors from the constructor argument.  Subclasses
         # that use deferred / cross-device binding start with an empty list and
@@ -72,26 +73,19 @@ class DerivedSensor(TypedSensorMixin, Sensor):
             # Re-apply sensor overrides so that an explicit debug-logging=False override will be respected
             self.apply_sensor_overrides()
 
+    def set_latest_state(self, state: int | float | str | list[bool] | list[int] | list[float]) -> bool:
+        """Update latest state and track pending updates for publishing."""
+        updated = super().set_latest_state(state)
+        if updated:
+            self._pending_update = True
+        return updated
+
     async def _update_internal_state(self, **kwargs) -> bool | Exception | ExceptionResponse:
-        """Derived sensors don't update from Modbus."""
+        """Derived sensors check if they were updated by source sensors."""
+        if getattr(self, "_pending_update", False):
+            self._pending_update = False
+            return True
         return False
-
-    async def get_state(self, raw: bool = False, republish: bool = False, **kwargs) -> float | int | str | None:
-        """Get derived sensor state.
-
-        Args:
-            raw: If True, return raw unprocessed value
-            republish: If True, return last known state
-            **kwargs: Additional arguments (ignored)
-
-        Returns:
-            Current state value or None if no state available
-        """
-        if len(self._states) == 0:
-            return None
-
-        state = self._states[-1][1]
-        return state if isinstance(state, str) else self._apply_gain_and_precision(state, raw)
 
     def run_persistence_coroutine(self, coro: Coroutine[Any, Any, None]) -> None:
         """Run a coroutine in the background to persist state.


### PR DESCRIPTION
### Problem

`DerivedSensor` inherited its core state management from the base Sensor class, but it interacted poorly with the MQTT publishing flow:

When a source sensor received new data, it called `DerivedSensor.update_from_source_sensor(self)`. That eventually triggered `set_latest_state(state)` on the derived sensor, which correctly evaluated whether the state was a repeat and whether it should be suppressed based on the interval.

However, the result of that evaluation (a boolean indicating whether the state was actually "updated") was completely discarded.
The derived sensor overrode `get_state()` to always grab the latest value from its internal _states buffer, effectively bypassing the `_update_internal_state()` logic that normal Modbus sensors use to inform `get_state()` whether it should suppress publication for that cycle.

As a result, whenever the main loop checked the `DerivedSensor` during a publish cycle, it would simply grab the last known state and publish it, entirely side-stepping the interval suppression logic.

### Fix

**Tracked Pending Updates**: Overrode `set_latest_state()` in `DerivedSensor` to save a `self._pending_update` flag whenever `super().set_latest_state()` successfully processes an update (honoring the interval suppression).

**Exposed Updates to the Framework**: Modified `_update_internal_state()` in `DerivedSensor` to return and clear `_pending_update`, rather than blindly returning False.

**Restored Standard Behavior**: Completely removed the overridden `get_state()` from `DerivedSensor`, allowing it to fall back on the standard `Sensor.get_state()` logic. This logic properly consults `_update_internal_state()` and will only return the state (triggering a publish) if an update genuinely occurred.