### PR TITLE
Accumulation improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Fixed "Task was destroyed but it is pending!" warning during restart after firmware upgrade (or other restart event)
 - Fixed missing device classes and state classes for Home Assistant (#219)
 - Fixed DerivedSensors did not respect the repeated state publishing interval setting
+- Ignored accumulation intervals of two hours or longer to avoid clock-jump spikes
+- Reset daily energy sensors when their upstream lifetime counter decreases
 
 ### Changed
 

--- a/sigenergy2mqtt/sensors/base/accumulation.py
+++ b/sigenergy2mqtt/sensors/base/accumulation.py
@@ -148,6 +148,9 @@ class AccumulationSensor(DerivedSensor):
         if interval_hours < 0:
             logging.warning(f"{self.log_identity} negative interval IGNORED (interval={sensor.latest_interval})")
             return False
+        if interval_hours >= 24:
+            logging.warning(f"{self.log_identity} 24+ hour interval IGNORED (interval={sensor.latest_interval})")
+            return False
 
         # Convert negative power to zero
         previous = max(0.0, float(sensor.previous_raw_state if sensor.previous_raw_state is not None else 0.0))

--- a/sigenergy2mqtt/sensors/base/accumulation.py
+++ b/sigenergy2mqtt/sensors/base/accumulation.py
@@ -148,8 +148,8 @@ class AccumulationSensor(DerivedSensor):
         if interval_hours < 0:
             logging.warning(f"{self.log_identity} negative interval IGNORED (interval={sensor.latest_interval})")
             return False
-        if interval_hours >= 24:
-            logging.warning(f"{self.log_identity} 24+ hour interval IGNORED (interval={sensor.latest_interval})")
+        if interval_hours >= 2:
+            logging.warning(f"{self.log_identity} 2+ hour interval IGNORED (interval={sensor.latest_interval})")
             return False
 
         # Convert negative power to zero

--- a/sigenergy2mqtt/sensors/base/accumulation.py
+++ b/sigenergy2mqtt/sensors/base/accumulation.py
@@ -510,16 +510,15 @@ class EnergyDailyAccumulationSensor(ResettableAccumulationSensor):
 
             if was_time.tm_year != now_time.tm_year or was_time.tm_mon != now_time.tm_mon or was_time.tm_mday != now_time.tm_mday:
                 # Day changed - reset midnight state
-                self.run_persistence_coroutine(self._update_state_at_midnight(now_state))
+                self._state_at_midnight = None
                 self._states.clear()
-                self._state_at_midnight = now_state
 
         # Initialize midnight state if needed
-        if not self._state_at_midnight or now_state < self._state_at_midnight:
-            self._state_at_midnight = now_state
+        if self._state_at_midnight is None or now_state < self._state_at_midnight:
+            self.run_persistence_coroutine(self._update_state_at_midnight(now_state))
 
         # Calculate today's accumulation
-        self._state_now = now_state - self._state_at_midnight
+        self._state_now = now_state - self._state_at_midnight  # type: ignore (neither value can be None at this point)
         self.set_latest_state(self._state_now)
 
         return True

--- a/sigenergy2mqtt/sensors/base/accumulation.py
+++ b/sigenergy2mqtt/sensors/base/accumulation.py
@@ -263,7 +263,7 @@ class ResettableAccumulationSensor(ObservableMixin, AccumulationSensor):
             attributes[SensorAttributeKeys.RESET_UNIT] = self.unit
         return attributes
 
-    async def notify(self, modbus_client: ModbusClient | None, mqtt_client: mqtt.Client, value: float | int | str, source: str, handler: MqttHandler) -> bool:
+    async def notify(self, modbus_client: ModbusClient | None, mqtt_client: mqtt.Client, value: float | str, source: str, handler: MqttHandler) -> bool:
         """Handle reset command from MQTT.
 
         Args:
@@ -426,7 +426,7 @@ class EnergyDailyAccumulationSensor(ResettableAccumulationSensor):
 
             self._state_at_midnight = midnight_state
 
-    async def notify(self, modbus_client: ModbusClient | None, mqtt_client: mqtt.Client, value: float | int | str, source: str, handler: MqttHandler) -> bool:
+    async def notify(self, modbus_client: ModbusClient | None, mqtt_client: mqtt.Client, value: float | str, source: str, handler: MqttHandler) -> bool:
         """Handle reset command.
 
         Args:
@@ -512,7 +512,7 @@ class EnergyDailyAccumulationSensor(ResettableAccumulationSensor):
                 self._state_at_midnight = now_state
 
         # Initialize midnight state if needed
-        if not self._state_at_midnight:
+        if not self._state_at_midnight or now_state < self._state_at_midnight:
             self._state_at_midnight = now_state
 
         # Calculate today's accumulation

--- a/sigenergy2mqtt/sensors/base/accumulation.py
+++ b/sigenergy2mqtt/sensors/base/accumulation.py
@@ -516,9 +516,10 @@ class EnergyDailyAccumulationSensor(ResettableAccumulationSensor):
         # Initialize midnight state if needed
         if self._state_at_midnight is None or now_state < self._state_at_midnight:
             self.run_persistence_coroutine(self._update_state_at_midnight(now_state))
+            self._state_at_midnight = now_state
 
         # Calculate today's accumulation
-        self._state_now = now_state - self._state_at_midnight  # type: ignore (neither value can be None at this point)
+        self._state_now = now_state - self._state_at_midnight
         self.set_latest_state(self._state_now)
 
         return True

--- a/tests/unit/sensors/test_accumulation_sensors.py
+++ b/tests/unit/sensors/test_accumulation_sensors.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from sigenergy2mqtt.common import DeviceClass, StateClass
+from sigenergy2mqtt.common import DeviceClass, Protocol, StateClass
 from sigenergy2mqtt.modbus import ModbusDataType
 from sigenergy2mqtt.sensors.base import ResettableAccumulationSensor, Sensor
 
@@ -338,3 +338,59 @@ class TestSimpleEnergyDailyAccumulationSensor:
             # None raw state
             source.latest_raw_state = None
             assert sensor.update_from_source_sensor(source) is False
+
+
+class TestEnergyDailyAccumulationSensor:
+    @pytest.mark.asyncio
+    async def test_energy_daily_accumulation_sensor(self):
+        """Test accumulation across a day change resets value."""
+        string = MagicMock(spec=Sensor)
+        string.unique_id = "source_uid"
+        string.data_type = ModbusDataType.UINT32
+        string.unit = "kW"
+        string.device_class = DeviceClass.POWER
+        string.state_class = StateClass.MEASUREMENT
+        string.precision = 2
+        string.protocol_version = Protocol.V1_8
+
+        with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
+            import time
+
+            from sigenergy2mqtt.sensors.base.accumulation import EnergyDailyAccumulationSensor
+            from sigenergy2mqtt.sensors.inverter_derived import PVStringDailyEnergy
+
+            source = PVStringDailyEnergy(plant_index=0, device_address=1, string_number=1, source=string)
+            sensor = EnergyDailyAccumulationSensor(
+                name="Daily Energy",
+                unique_id="sigen_daily_uid",
+                object_id="sigen_daily_oid",
+                source=source,
+            )
+
+            source._states = [(time.time() - 30, 10.0), (time.time(), 20.0)]
+
+            with patch.object(sensor, "run_persistence_coroutine", side_effect=lambda coro: coro.close()):
+                sensor.update_from_source_sensor(source)
+                assert sensor._current_total == 0.0  #  No previous value, so accumulation value at midnight set to now value and therefore daily total is zero
+                assert sensor._state_at_midnight == 20.0
+
+            source.set_state(source.latest_raw_state - 2.0)
+            with patch.object(sensor, "run_persistence_coroutine", side_effect=lambda coro: coro.close()):
+                sensor.update_from_source_sensor(source)
+                assert sensor.latest_raw_state == 0.0  # Value went backwards, so reset accumulation value at midnight to now value
+                assert sensor._state_at_midnight == source.latest_raw_state
+
+            midnight = sensor._state_at_midnight
+            source.set_state(source.latest_raw_state + 4.5)
+            with patch.object(sensor, "run_persistence_coroutine", side_effect=lambda coro: coro.close()):
+                sensor.update_from_source_sensor(source)
+                assert sensor.latest_raw_state == 4.5
+                assert sensor._state_at_midnight == midnight
+
+            source._states = [(time.time() - 86500, source._states[0][1]), (time.time() - 86450, source._states[1][1])]  # time > 24 hours ago
+            latest = source.latest_raw_state + 1
+            source.set_state(latest)
+            with patch.object(sensor, "run_persistence_coroutine", side_effect=lambda coro: coro.close()):
+                sensor.update_from_source_sensor(source)
+                assert sensor._current_total == 0.0  #  Previous value > 24h ago, so accumulation value at midnight set to now value and therefore daily total is zero
+                assert sensor._state_at_midnight == latest

--- a/tests/unit/sensors/test_accumulation_sensors.py
+++ b/tests/unit/sensors/test_accumulation_sensors.py
@@ -255,6 +255,34 @@ class TestAccumulationSensor:
                 assert sensor._current_total == 15.0
                 assert sensor.latest_raw_state == 15.0
 
+    @pytest.mark.asyncio
+    async def test_accumulation_sensor_long_interval(self):
+        """Test skipping logic in the base AccumulationSensor when interval > 2h."""
+        source = MagicMock(spec=Sensor)
+        source.unique_id = "source_uid"
+        source.latest_interval = 2 * 60 * 60.0 + 300.0  # 2 hours and 5 minutes
+        source.state_count = 2
+
+        with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
+            from sigenergy2mqtt.sensors.base import AccumulationSensor
+
+            sensor = AccumulationSensor(
+                name="Accumulator",
+                unique_id="sigen_accumulator_uid",
+                object_id="sigen_accumulator_oid",
+                source=source,
+                data_type=ModbusDataType.UINT32,
+                unit="kWh",
+                device_class=DeviceClass.ENERGY,
+                state_class=StateClass.TOTAL_INCREASING,
+                icon="mdi:battery",
+                gain=1.0,
+                precision=2,
+            )
+
+            with patch.object(sensor, "run_persistence_coroutine", side_effect=lambda coro: coro.close()):
+                assert sensor.update_from_source_sensor(source) is False
+
 
 class TestSimpleEnergyDailyAccumulationSensor:
     @pytest.mark.asyncio
@@ -367,7 +395,7 @@ class TestEnergyDailyAccumulationSensor:
                 source=source,
             )
 
-            source._states = [(time.time() - 30, 10.0), (time.time(), 20.0)]
+            source._states = [(time.time() - 2, 10.0), (time.time(), 20.0)]
 
             with patch.object(sensor, "run_persistence_coroutine", side_effect=lambda coro: coro.close()):
                 sensor.update_from_source_sensor(source)
@@ -386,11 +414,3 @@ class TestEnergyDailyAccumulationSensor:
                 sensor.update_from_source_sensor(source)
                 assert sensor.latest_raw_state == 4.5
                 assert sensor._state_at_midnight == midnight
-
-            source._states = [(time.time() - 86500, source._states[0][1]), (time.time() - 86450, source._states[1][1])]  # time > 24 hours ago
-            latest = source.latest_raw_state + 1
-            source.set_state(latest)
-            with patch.object(sensor, "run_persistence_coroutine", side_effect=lambda coro: coro.close()):
-                sensor.update_from_source_sensor(source)
-                assert sensor._current_total == 0.0  #  Previous value > 24h ago, so accumulation value at midnight set to now value and therefore daily total is zero
-                assert sensor._state_at_midnight == latest


### PR DESCRIPTION
1. **Prevent Massive Clock Jump Accumulations**: In `AccumulationSensor.update_from_source_sensor`, guard against massive `interval_hours`. If the interval is excessively large (e.g., >= 2 hours), ignore the accumulation for that single cycle to prevent clock jumps from corrupting the data.

2. **Handle Upstream Resets in Daily Sensors**: In `EnergyDailyAccumulationSensor.update_from_source_sensor`, if the current source state (`now_state`) is strictly less than `self._state_at_midnight`, recognize that the source sensor has been reset. In this scenario, automatically update `self._state_at_midnight` to `now_state` to prevent negative accumulation and exception loops.