### PR TITLE
refactor: Protocol version references to use ProtocolVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Added plant active power and third-party PV power to dashboard
 - Refactored writeable sensor mixins to separate transport from entity behaviour
+- Refactored Protocol class name to ProtocolVersion because it shadowed typing.Protocol
 - Upgraded `pydantic-settings` from 2.14.2 to 2.15.0
 - Upgraded `pymodbus` from 3.14.0 to 3.15.0
 

--- a/scripts/update_md.py
+++ b/scripts/update_md.py
@@ -245,7 +245,7 @@ async def sensor_index() -> None:
                     elif isinstance(sensor, PVInverter):
                         f.write(" PV Inverter only")
                     f.write("</td></tr>\n")
-                f.write(f"<tr><td>Since&nbsp;ProtocolVersion&nbsp;Version</td><td>{protocol}</td></tr>\n")
+                f.write(f"<tr><td>Since&nbsp;Protocol&nbsp;Version</td><td>{protocol}</td></tr>\n")
                 if sensor.sanity_check.is_enabled:
                     f.write(f"<tr><td>Modbus&nbsp;Read&nbsp;Sanity&nbsp;Check</td><td>{sensor.sanity_check.description}</td></tr>\n")
                 f.write("</table>\n")

--- a/scripts/update_md.py
+++ b/scripts/update_md.py
@@ -20,7 +20,7 @@ os.environ["SIGENERGY2MQTT_MODBUS_HOST"] = "127.0.0.1"
 import requests
 from pymodbus.client import AsyncModbusTcpClient as ModbusClient
 
-from sigenergy2mqtt.common import ConsumptionMethod, HybridInverter, Protocol, PVInverter
+from sigenergy2mqtt.common import ConsumptionMethod, HybridInverter, ProtocolVersion, PVInverter
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.metrics.service import MetricsService
 from sigenergy2mqtt.sensors.base import AlarmCombinedSensor, ModbusSensorMixin, ReadableSensorMixin, ReservedSensor, Sensor, TypedSensorMixin, WriteableSensorMixin, WriteOnlySensor
@@ -151,7 +151,7 @@ async def sensor_index() -> None:
         if not index_only:
             f.write("| Metric | Interval | Unit | State Topic| Command Topic |\n")
             f.write("|--------|---------:|------|------------|---------------|\n")
-        metrics = MetricsService(Protocol.N_A)
+        metrics = MetricsService(ProtocolVersion.N_A)
         for metric in [s for s in sorted(metrics.all_sensors.values(), key=lambda x: x.name)]:
             count += 1
             if index_only:
@@ -177,7 +177,7 @@ async def sensor_index() -> None:
             if sensor_parent == device and sensor.publishable:
                 count += 1
                 string_number: int | None = getattr(sensor, "string_number", None)
-                protocol = "N/A" if sensor.protocol_version == Protocol.N_A else sensor.protocol_version.value
+                protocol = "N/A" if sensor.protocol_version == ProtocolVersion.N_A else sensor.protocol_version.value
                 if index_only:
                     f.write(f"<a href='#{sensor.unique_id}'>")
                     if string_number:
@@ -213,7 +213,7 @@ async def sensor_index() -> None:
                             source = sensor.get_attributes()["source"]
                             f.write(f"<dt>{method.name} Configuration Option:</dt><dd>{source}")
                             if method != ConsumptionMethod.CALCULATED:
-                                f.write(" (Protocol V2.8+ only)")
+                                f.write(" (ProtocolVersion V2.8+ only)")
                             f.write("</dd>")
                         f.write("</dl>")
                         protocol = "N/A"
@@ -245,7 +245,7 @@ async def sensor_index() -> None:
                     elif isinstance(sensor, PVInverter):
                         f.write(" PV Inverter only")
                     f.write("</td></tr>\n")
-                f.write(f"<tr><td>Since&nbsp;Protocol&nbsp;Version</td><td>{protocol}</td></tr>\n")
+                f.write(f"<tr><td>Since&nbsp;ProtocolVersion&nbsp;Version</td><td>{protocol}</td></tr>\n")
                 if sensor.sanity_check.is_enabled:
                     f.write(f"<tr><td>Modbus&nbsp;Read&nbsp;Sanity&nbsp;Check</td><td>{sensor.sanity_check.description}</td></tr>\n")
                 f.write("</table>\n")
@@ -264,7 +264,7 @@ async def sensor_index() -> None:
             sensor = mqtt_sensors[key]
             sensor_parent = None if not hasattr(sensor, "parent_device") else sensor.parent_device.__class__.__name__
             if sensor_parent == device:
-                protocol = "N/A" if sensor.protocol_version == Protocol.N_A else sensor.protocol_version.value
+                protocol = "N/A" if sensor.protocol_version == ProtocolVersion.N_A else sensor.protocol_version.value
                 count += 1
                 if index_only:
                     f.write(f"<a href='#{sensor.unique_id}_set'>{sensor['name']}</a><br>\n")
@@ -308,7 +308,7 @@ async def sensor_index() -> None:
                     elif isinstance(sensor, PVInverter):
                         f.write(" PV Inverter only")
                     f.write("</td></tr>\n")
-                f.write(f"<tr><td>Since&nbsp;Protocol&nbsp;Version</td><td>{protocol}</td></tr>\n")
+                f.write(f"<tr><td>Since&nbsp;ProtocolVersion&nbsp;Version</td><td>{protocol}</td></tr>\n")
                 f.write("</table>\n")
         return count
 

--- a/sigenergy2mqtt/common/__init__.py
+++ b/sigenergy2mqtt/common/__init__.py
@@ -7,7 +7,7 @@ from .firmware_version import FirmwareVersion
 from .health import ServiceHealthRegistry, service_health_registry
 from .input_type import InputType
 from .output_field import OutputField
-from .protocol import Protocol, ProtocolApplies
+from .protocol import ProtocolApplies, ProtocolVersion
 from .register_access import RegisterAccess
 from .scan_interval_default import ScanIntervalDefault
 from .state_class import StateClass
@@ -45,8 +45,8 @@ __all__ = [
     "InputType",
     "OutputField",
     "PVInverter",
-    "Protocol",
     "ProtocolApplies",
+    "ProtocolVersion",
     "RegisterAccess",
     "ScanIntervalDefault",
     "ServiceHealthRegistry",

--- a/sigenergy2mqtt/common/protocol.py
+++ b/sigenergy2mqtt/common/protocol.py
@@ -2,7 +2,7 @@ import time
 from enum import Enum
 
 
-class Protocol(float, Enum):
+class ProtocolVersion(float, Enum):
     N_A = 0.0
     V1_8 = 1.8
     V2_0 = 2.0
@@ -14,23 +14,23 @@ class Protocol(float, Enum):
     V2_9 = 2.9
 
 
-def ProtocolApplies(version: Protocol) -> str:
+def ProtocolApplies(version: ProtocolVersion) -> str:
     match version:
-        case Protocol.V1_8:
+        case ProtocolVersion.V1_8:
             return "2024-08-05"
-        case Protocol.V2_0:
+        case ProtocolVersion.V2_0:
             return "2024-10-14"
-        case Protocol.V2_4:
+        case ProtocolVersion.V2_4:
             return "2025-02-05"
-        case Protocol.V2_5:
+        case ProtocolVersion.V2_5:
             return "2025-02-19"
-        case Protocol.V2_6:
+        case ProtocolVersion.V2_6:
             return "2025-03-31"
-        case Protocol.V2_7:
+        case ProtocolVersion.V2_7:
             return "2025-05-23"
-        case Protocol.V2_8:
+        case ProtocolVersion.V2_8:
             return "2025-11-28"
-        case Protocol.V2_9:
+        case ProtocolVersion.V2_9:
             return "2026-05-13"
         case _:
             return time.strftime("%Y-%m-%d", time.localtime())

--- a/sigenergy2mqtt/devices/base/device.py
+++ b/sigenergy2mqtt/devices/base/device.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Literal, cast
 
 import paho.mqtt.client as mqtt
 
-from sigenergy2mqtt.common import DeviceType, HybridInverter, Protocol, PVInverter
+from sigenergy2mqtt.common import DeviceType, HybridInverter, ProtocolVersion, PVInverter
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.config.models import RegisterAccess
 from sigenergy2mqtt.i18n import _t
@@ -46,7 +46,7 @@ class Device(HaPublisherMixin, dict[str, str | list[str]], metaclass=abc.ABCMeta
     _add_sensor helpers.
     """
 
-    def __init__(self, name: str, plant_index: int, unique_id: str, manufacturer: str, model: str, protocol_version: Protocol, **kwargs):
+    def __init__(self, name: str, plant_index: int, unique_id: str, manufacturer: str, model: str, protocol_version: ProtocolVersion, **kwargs):
         """Initialise the device and register it in the DeviceRegistry.
 
         Args:
@@ -364,29 +364,29 @@ class Device(HaPublisherMixin, dict[str, str | list[str]], metaclass=abc.ABCMeta
             # Cross-device sensors defer source binding to finalise_binding().
             # Only apply a protocol check on the sensor itself here; source
             # validation and bidirectional wiring happen in bind_cross_device_sensors().
-            sensor_protocol = getattr(sensor, "protocol_version", Protocol.N_A)
-            if self.protocol_version > Protocol.N_A and sensor_protocol > self.protocol_version:
+            sensor_protocol = getattr(sensor, "protocol_version", ProtocolVersion.N_A)
+            if self.protocol_version > ProtocolVersion.N_A and sensor_protocol > self.protocol_version:
                 if sensor.debug_logging:
-                    logger.debug(f"{self.log_identity} skipped adding {sensor.__class__.__name__} - Protocol version {sensor_protocol} > {self.protocol_version}")
+                    logger.debug(f"{self.log_identity} skipped adding {sensor.__class__.__name__} - ProtocolVersion version {sensor_protocol} > {self.protocol_version}")
                 return False
             self._add_to_all_sensors(sensor)
             return True
         if isinstance(sensor, DerivedSensor):
-            sensor_protocol = getattr(sensor, "protocol_version", Protocol.N_A)
-            if self.protocol_version > Protocol.N_A and sensor_protocol > self.protocol_version:
+            sensor_protocol = getattr(sensor, "protocol_version", ProtocolVersion.N_A)
+            if self.protocol_version > ProtocolVersion.N_A and sensor_protocol > self.protocol_version:
                 if sensor.debug_logging:
-                    logger.debug(f"{self.log_identity} skipped adding {sensor.__class__.__name__} - Protocol version {sensor_protocol} > {self.protocol_version}")
+                    logger.debug(f"{self.log_identity} skipped adding {sensor.__class__.__name__} - ProtocolVersion version {sensor_protocol} > {self.protocol_version}")
                 return False
             source_sensors = getattr(sensor, "source_sensors", [])
             if not source_sensors:
                 logger.error(f"{self.log_identity} cannot add {sensor.__class__.__name__} - no declared source sensors")
                 return False
-            if self.protocol_version > Protocol.N_A and any(getattr(s, "protocol_version", Protocol.N_A) > self.protocol_version for s in source_sensors):
-                logger.debug(f"{self.log_identity} skipped adding {sensor.__class__.__name__} - one or more source sensors have Protocol version > {self.protocol_version}")
+            if self.protocol_version > ProtocolVersion.N_A and any(getattr(s, "protocol_version", ProtocolVersion.N_A) > self.protocol_version for s in source_sensors):
+                logger.debug(f"{self.log_identity} skipped adding {sensor.__class__.__name__} - one or more source sensors have ProtocolVersion version > {self.protocol_version}")
                 return False
             added = False
             for source in source_sensors:
-                if self.protocol_version > Protocol.N_A and source.protocol_version > self.protocol_version:
+                if self.protocol_version > ProtocolVersion.N_A and source.protocol_version > self.protocol_version:
                     logger.debug(
                         f"{self.log_identity} skipped binding source {source.__class__.__name__} to {sensor.__class__.__name__} - "
                         f"source protocol {source.protocol_version} > device protocol {self.protocol_version}"
@@ -581,7 +581,7 @@ class ModbusDevice(Device, metaclass=abc.ABCMeta):
         plant_index: int,
         device_address: int,
         model: str,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
         **kwargs,
     ):
         """Initialise a Modbus device and validate its address and unique_id.
@@ -643,7 +643,7 @@ class ModbusDevice(Device, metaclass=abc.ABCMeta):
             logger.debug(f"{self.log_identity} skipped adding {sensor.__class__.__name__} - not applicable to a {self._device_type.__class__.__name__}")
             return False
         elif sensor.protocol_version > self.protocol_version:
-            logger.debug(f"{self.log_identity} skipped adding {sensor.__class__.__name__} - Protocol version {sensor.protocol_version} > {self.protocol_version}")
+            logger.debug(f"{self.log_identity} skipped adding {sensor.__class__.__name__} - ProtocolVersion version {sensor.protocol_version} > {self.protocol_version}")
             return False
         else:
             return super()._add_sensor(sensor, group=group, search_children=search_children)

--- a/sigenergy2mqtt/devices/ev/ac_charger.py
+++ b/sigenergy2mqtt/devices/ev/ac_charger.py
@@ -2,7 +2,7 @@ from typing import cast
 
 import sigenergy2mqtt.sensors.ac_charger_read_only as ro
 import sigenergy2mqtt.sensors.ac_charger_read_write as rw
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.common.types import NonInverter
 from sigenergy2mqtt.devices import ModbusDevice
 from sigenergy2mqtt.modbus import ModbusClient
@@ -13,7 +13,7 @@ class ACCharger(ModbusDevice):
         self,
         plant_index: int,
         device_address: int,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
         sequence_number: int | None = None,
         total_count: int | None = None,
     ):
@@ -36,7 +36,7 @@ class ACCharger(ModbusDevice):
         cls,
         plant_index: int,
         device_address: int,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
         modbus_client: ModbusClient,
         sequence_number: int | None = None,
         total_count: int | None = None,

--- a/sigenergy2mqtt/devices/ev/dc_charger.py
+++ b/sigenergy2mqtt/devices/ev/dc_charger.py
@@ -1,6 +1,6 @@
 import sigenergy2mqtt.sensors.inverter_read_only as ro
 import sigenergy2mqtt.sensors.inverter_read_write as rw
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.common.types import NonInverter
 from sigenergy2mqtt.devices import ModbusDevice
 
@@ -10,7 +10,7 @@ class DCCharger(ModbusDevice):
         self,
         plant_index: int,
         device_address: int,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
         sequence_number: int | None = None,
         total_count: int | None = None,
     ):
@@ -33,7 +33,7 @@ class DCCharger(ModbusDevice):
         cls,
         plant_index: int,
         device_address: int,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
         sequence_number: int | None = None,
         total_count: int | None = None,
     ) -> "DCCharger":

--- a/sigenergy2mqtt/devices/inverter/ess.py
+++ b/sigenergy2mqtt/devices/inverter/ess.py
@@ -1,6 +1,6 @@
 import sigenergy2mqtt.sensors.inverter_derived as derived
 import sigenergy2mqtt.sensors.inverter_read_only as ro
-from sigenergy2mqtt.common import DeviceType, Protocol
+from sigenergy2mqtt.common import DeviceType, ProtocolVersion
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.devices import ModbusDevice
 
@@ -11,7 +11,7 @@ class ESS(ModbusDevice):
         plant_index: int,
         device_address: int,
         device_type: DeviceType,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
         model_id: str,
         serial_number: str,
     ):

--- a/sigenergy2mqtt/devices/inverter/inverter.py
+++ b/sigenergy2mqtt/devices/inverter/inverter.py
@@ -5,7 +5,7 @@ from typing import cast
 
 import sigenergy2mqtt.sensors.inverter_read_only as ro
 import sigenergy2mqtt.sensors.inverter_read_write as rw
-from sigenergy2mqtt.common import DeviceType, FirmwareVersion, HybridInverter, Protocol, PVInverter
+from sigenergy2mqtt.common import DeviceType, FirmwareVersion, HybridInverter, ProtocolVersion, PVInverter
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.devices import ModbusDevice
 from sigenergy2mqtt.modbus import ModbusClient
@@ -23,7 +23,7 @@ class Inverter(ModbusDevice):
         plant_index: int,
         device_address: int,
         device_type: DeviceType,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
         model_id: str,
         serial: str,
         firmware: str,
@@ -43,7 +43,7 @@ class Inverter(ModbusDevice):
         )
 
     @classmethod
-    async def create(cls, plant_index: int, device_address: int, device_type: DeviceType, protocol_version: Protocol, tz: timezone, modbus_client: ModbusClient) -> "Inverter":
+    async def create(cls, plant_index: int, device_address: int, device_type: DeviceType, protocol_version: ProtocolVersion, tz: timezone, modbus_client: ModbusClient) -> "Inverter":
         model = ro.InverterModel(plant_index, device_address)
         pv_string_count = ro.PVStringCount(plant_index, device_address)
         firmware_version = ro.InverterFirmwareVersion(plant_index, device_address)
@@ -81,7 +81,7 @@ class Inverter(ModbusDevice):
         plant_index: int,
         device_address: int,
         device_type: DeviceType,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
         model_id: str,
         serial: str,
         strings: int,
@@ -99,11 +99,11 @@ class Inverter(ModbusDevice):
                     string_number=n,
                     voltage_address=address,
                     current_address=address + 1,
-                    protocol_version=Protocol.V1_8,
+                    protocol_version=ProtocolVersion.V1_8,
                 )
             )
             address += 2  # voltage is in the first register, current in the second
-        if protocol_version >= Protocol.V2_4:
+        if protocol_version >= ProtocolVersion.V2_4:
             address = 31042  # PV String 5 Voltage register
             for n in range(5, min(16, strings) + 1):
                 self._add_child_device(
@@ -116,11 +116,11 @@ class Inverter(ModbusDevice):
                         string_number=n,
                         voltage_address=address,
                         current_address=address + 1,
-                        protocol_version=Protocol.V2_4,
+                        protocol_version=ProtocolVersion.V2_4,
                     )
                 )
                 address += 2  # voltage is in the first register, current in the second
-        if protocol_version >= Protocol.V2_8 and isinstance(device_type, PVInverter):
+        if protocol_version >= ProtocolVersion.V2_8 and isinstance(device_type, PVInverter):
             address = 31066  # PV String 17 Voltage register
             for n in range(17, min(36, strings) + 1):
                 self._add_child_device(
@@ -133,7 +133,7 @@ class Inverter(ModbusDevice):
                         string_number=n,
                         voltage_address=address,
                         current_address=address + 1,
-                        protocol_version=Protocol.V2_8,
+                        protocol_version=ProtocolVersion.V2_8,
                     )
                 )
                 address += 2  # voltage is in the first register, current in the second

--- a/sigenergy2mqtt/devices/inverter/pv_string.py
+++ b/sigenergy2mqtt/devices/inverter/pv_string.py
@@ -1,4 +1,4 @@
-from sigenergy2mqtt.common import DeviceType, Protocol
+from sigenergy2mqtt.common import DeviceType, ProtocolVersion
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.devices import ModbusDevice
 from sigenergy2mqtt.sensors.inverter_derived import PVStringDailyEnergy, PVStringLifetimeEnergy, PVStringPower
@@ -16,7 +16,7 @@ class PVString(ModbusDevice):
         string_number: int,
         voltage_address: int,
         current_address: int,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
     ):
         self.string_number = string_number
         super().__init__(

--- a/sigenergy2mqtt/devices/pid.py
+++ b/sigenergy2mqtt/devices/pid.py
@@ -5,7 +5,7 @@ from typing import cast
 
 import sigenergy2mqtt.sensors.pid_read_only as ro
 import sigenergy2mqtt.sensors.pid_read_write as rw
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.common.types import NonInverter
 from sigenergy2mqtt.devices import ModbusDevice
 from sigenergy2mqtt.modbus import ModbusClient
@@ -16,7 +16,7 @@ class PID(ModbusDevice):
         self,
         plant_index: int,
         device_address: int,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
         model_id: str,
         serial: str,
         firmware: str,
@@ -36,7 +36,7 @@ class PID(ModbusDevice):
         )
 
     @classmethod
-    async def create(cls, plant_index: int, device_address: int, protocol_version: Protocol, modbus_client: ModbusClient) -> PID:
+    async def create(cls, plant_index: int, device_address: int, protocol_version: ProtocolVersion, modbus_client: ModbusClient) -> PID:
         model = ro.PIDModelType(plant_index, device_address)
         firmware_version = ro.PIDMachineFirmwareVersion(plant_index, device_address)
         serial_number = ro.PIDSerialNumber(plant_index, device_address)

--- a/sigenergy2mqtt/devices/plant/ess_preheating.py
+++ b/sigenergy2mqtt/devices/plant/ess_preheating.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sigenergy2mqtt.sensors.plant_ess_preheating_read_write as rw
-from sigenergy2mqtt.common import DeviceType, Protocol
+from sigenergy2mqtt.common import DeviceType, ProtocolVersion
 from sigenergy2mqtt.devices import ModbusDevice
 
 
@@ -10,14 +10,14 @@ class ESSPreHeating(ModbusDevice):
         self,
         plant_index: int,
         device_type: DeviceType,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
     ):
         name = "Sigenergy Plant ESS Pre-Heating"
         plant_suffix = "" if plant_index == 0 else str(plant_index + 1)
         super().__init__(device_type, name, plant_index, 247, "ESS Pre-Heating", protocol_version, plant_suffix=plant_suffix)
 
     @classmethod
-    async def create(cls, plant_index: int, device_type: DeviceType, rated_charging_power: float, rated_discharging_power: float, protocol_version: Protocol) -> ESSPreHeating:
+    async def create(cls, plant_index: int, device_type: DeviceType, rated_charging_power: float, rated_discharging_power: float, protocol_version: ProtocolVersion) -> ESSPreHeating:
         ess_preheating = ESSPreHeating(plant_index, device_type, protocol_version)
         await ess_preheating._register_sensors(rated_charging_power, rated_discharging_power)
         return ess_preheating

--- a/sigenergy2mqtt/devices/plant/grid_code.py
+++ b/sigenergy2mqtt/devices/plant/grid_code.py
@@ -2,7 +2,7 @@ from typing import cast
 
 import sigenergy2mqtt.sensors.plant_read_only as ro
 import sigenergy2mqtt.sensors.plant_read_write as rw
-from sigenergy2mqtt.common import DeviceType, Protocol
+from sigenergy2mqtt.common import DeviceType, ProtocolVersion
 from sigenergy2mqtt.devices import ModbusDevice
 from sigenergy2mqtt.modbus import ModbusClient
 
@@ -12,14 +12,14 @@ class GridCode(ModbusDevice):
         self,
         plant_index: int,
         device_type: DeviceType,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
     ):
         name = "Sigenergy Plant Grid Code"
         plant_suffix = "" if plant_index == 0 else str(plant_index + 1)
         super().__init__(device_type, name, plant_index, 247, "Grid Code", protocol_version, plant_suffix=plant_suffix)
 
     @classmethod
-    async def create(cls, plant_index: int, device_type: DeviceType, protocol_version: Protocol, modbus_client: ModbusClient) -> "GridCode":
+    async def create(cls, plant_index: int, device_type: DeviceType, protocol_version: ProtocolVersion, modbus_client: ModbusClient) -> "GridCode":
         grid_code = GridCode(plant_index, device_type, protocol_version)
         await grid_code._register_sensors(modbus_client)
         return grid_code

--- a/sigenergy2mqtt/devices/plant/grid_sensor.py
+++ b/sigenergy2mqtt/devices/plant/grid_sensor.py
@@ -1,7 +1,7 @@
 import sigenergy2mqtt.sensors.plant_derived as derived
 import sigenergy2mqtt.sensors.plant_read_only as ro
 import sigenergy2mqtt.sensors.plant_read_write as rw
-from sigenergy2mqtt.common import DeviceType, Protocol
+from sigenergy2mqtt.common import DeviceType, ProtocolVersion
 from sigenergy2mqtt.devices import ModbusDevice
 from sigenergy2mqtt.modbus import ModbusClient
 
@@ -11,14 +11,14 @@ class GridSensor(ModbusDevice):
         self,
         plant_index: int,
         device_type: DeviceType,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
     ):
         name = "Sigenergy Plant Grid Sensor"
         plant_suffix = "" if plant_index == 0 else str(plant_index + 1)
         super().__init__(device_type, name, plant_index, 247, "Grid Sensor", protocol_version, plant_suffix=plant_suffix)
 
     @classmethod
-    async def create(cls, plant_index: int, device_type: DeviceType, protocol_version: Protocol, power_phases: int, consumption_group: str | None, modbus_client: ModbusClient) -> "GridSensor":
+    async def create(cls, plant_index: int, device_type: DeviceType, protocol_version: ProtocolVersion, power_phases: int, consumption_group: str | None, modbus_client: ModbusClient) -> "GridSensor":
         grid_sensor = GridSensor(plant_index, device_type, protocol_version)
         await grid_sensor._register_sensors(power_phases, consumption_group, modbus_client)
         return grid_sensor

--- a/sigenergy2mqtt/devices/plant/plant.py
+++ b/sigenergy2mqtt/devices/plant/plant.py
@@ -6,7 +6,7 @@ from typing import cast
 import sigenergy2mqtt.sensors.plant_derived as derived
 import sigenergy2mqtt.sensors.plant_read_only as ro
 import sigenergy2mqtt.sensors.plant_read_write as rw
-from sigenergy2mqtt.common import ConsumptionMethod, DeviceType, FirmwareVersion, HybridInverter, Protocol
+from sigenergy2mqtt.common import ConsumptionMethod, DeviceType, FirmwareVersion, HybridInverter, ProtocolVersion
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.devices import ModbusDevice
 from sigenergy2mqtt.devices.plant.ess_preheating import ESSPreHeating
@@ -27,7 +27,7 @@ class PowerPlant(ModbusDevice):
         self,
         plant_index: int,
         device_type: DeviceType,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
     ):
         name = "Sigenergy Plant"
         plant_suffix = "" if plant_index == 0 else str(plant_index + 1)
@@ -38,16 +38,16 @@ class PowerPlant(ModbusDevice):
             247,
             "Energy Management System",
             protocol_version,
-            sw=f"Modbus Protocol V{protocol_version.value}",
+            sw=f"Modbus ProtocolVersion V{protocol_version.value}",
             plant_suffix=plant_suffix,
         )
-        self._consumption_source = ConsumptionMethod.CALCULATED if self.protocol_version < Protocol.V2_8 else active_config.consumption
+        self._consumption_source = ConsumptionMethod.CALCULATED if self.protocol_version < ProtocolVersion.V2_8 else active_config.consumption
         self._consumption_group = "Consumption" if self._consumption_source == ConsumptionMethod.CALCULATED else None  # No need to group sensors for scanning if not calculating consumption
         self._grid_sensor = None
 
     @classmethod
     async def create(
-        cls, plant_index: int, device_type: DeviceType, firmware: FirmwareVersion, protocol_version: Protocol, tz: timezone, output_type: int, pre_heating: bool, modbus_client: ModbusClient
+        cls, plant_index: int, device_type: DeviceType, firmware: FirmwareVersion, protocol_version: ProtocolVersion, tz: timezone, output_type: int, pre_heating: bool, modbus_client: ModbusClient
     ) -> "PowerPlant":
         power_phases = OutputType.to_phases(output_type)
         plant = cls(plant_index, device_type, protocol_version)
@@ -81,13 +81,13 @@ class PowerPlant(ModbusDevice):
 
         self._add_child_device(await PlantStatistics.create(self.plant_index, self._device_type, self.protocol_version))
 
-        if self.protocol_version >= Protocol.V2_8:
+        if self.protocol_version >= ProtocolVersion.V2_8:
             if self._device_type.has_grid_code_interface:
                 self._add_child_device(await GridCode.create(self.plant_index, self._device_type, self.protocol_version, modbus_client))
             else:
                 logger.info(f"{self.log_identity} GridCode child device not registered because this device type ({self._device_type}) does not support grid code interface")
 
-        if self.protocol_version >= Protocol.V2_9:
+        if self.protocol_version >= ProtocolVersion.V2_9:
             if pre_heating:
                 self._add_child_device(await ESSPreHeating.create(self.plant_index, self._device_type, cast(float, rcp_value), cast(float, rdp_value), self.protocol_version))
             else:
@@ -234,7 +234,7 @@ class PowerPlant(ModbusDevice):
         self._add_sensor(ro.CurrentControlCommandValue(self.plant_index))
         self._add_sensor(ro.PlantAlarms(self.plant_index, ro.Alarm6(self.plant_index), ro.Alarm7(self.plant_index)))
 
-        plant_3rd_party_pv_power = ro.ThirdPartyPVPower(self.plant_index) if self.protocol_version >= Protocol.V2_7 else None
+        plant_3rd_party_pv_power = ro.ThirdPartyPVPower(self.plant_index) if self.protocol_version >= ProtocolVersion.V2_7 else None
         if plant_3rd_party_pv_power is None:
             total_pv_power = derived.TotalPVPower(self.plant_index, plant_pv_power)
         else:

--- a/sigenergy2mqtt/devices/plant/plant.py
+++ b/sigenergy2mqtt/devices/plant/plant.py
@@ -38,7 +38,7 @@ class PowerPlant(ModbusDevice):
             247,
             "Energy Management System",
             protocol_version,
-            sw=f"Modbus ProtocolVersion V{protocol_version.value}",
+            sw=f"Modbus Protocol V{protocol_version.value}",
             plant_suffix=plant_suffix,
         )
         self._consumption_source = ConsumptionMethod.CALCULATED if self.protocol_version < ProtocolVersion.V2_8 else active_config.consumption

--- a/sigenergy2mqtt/devices/plant/statistics.py
+++ b/sigenergy2mqtt/devices/plant/statistics.py
@@ -1,5 +1,5 @@
 import sigenergy2mqtt.sensors.plant_read_only as ro
-from sigenergy2mqtt.common import DeviceType, Protocol
+from sigenergy2mqtt.common import DeviceType, ProtocolVersion
 from sigenergy2mqtt.devices import ModbusDevice
 
 
@@ -8,14 +8,14 @@ class PlantStatistics(ModbusDevice):
         self,
         plant_index: int,
         device_type: DeviceType,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
     ):
         name = "Sigenergy Plant Statistics"
         plant_suffix = "" if plant_index == 0 else str(plant_index + 1)
         super().__init__(device_type, name, plant_index, 247, "EMS Statistics", protocol_version, plant_suffix=plant_suffix)
 
     @classmethod
-    async def create(cls, plant_index: int, device_type: DeviceType, protocol_version: Protocol) -> "PlantStatistics":
+    async def create(cls, plant_index: int, device_type: DeviceType, protocol_version: ProtocolVersion) -> "PlantStatistics":
         plant_statistics = PlantStatistics(plant_index, device_type, protocol_version)
         await plant_statistics._register_sensors()
         return plant_statistics

--- a/sigenergy2mqtt/devices/pss/distribution_cabinet.py
+++ b/sigenergy2mqtt/devices/pss/distribution_cabinet.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sigenergy2mqtt.sensors.pss_read_only as ro
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.common.types import NonInverter
 from sigenergy2mqtt.devices import ModbusDevice
 
@@ -11,7 +11,7 @@ class DistributionCabinet(ModbusDevice):
         self,
         plant_index: int,
         device_address: int,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
         model_id: str,
         serial: str,
     ):

--- a/sigenergy2mqtt/devices/pss/la.py
+++ b/sigenergy2mqtt/devices/pss/la.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sigenergy2mqtt.sensors.pss_read_only as ro
 import sigenergy2mqtt.sensors.pss_read_write as rw
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.common.types import NonInverter
 from sigenergy2mqtt.devices import ModbusDevice
 
@@ -12,7 +12,7 @@ class LA(ModbusDevice):
         self,
         plant_index: int,
         device_address: int,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
         model_id: str,
         serial: str,
     ):

--- a/sigenergy2mqtt/devices/pss/lb.py
+++ b/sigenergy2mqtt/devices/pss/lb.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sigenergy2mqtt.sensors.pss_read_only as ro
 import sigenergy2mqtt.sensors.pss_read_write as rw
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.common.types import NonInverter
 from sigenergy2mqtt.devices import ModbusDevice
 
@@ -12,7 +12,7 @@ class LB(ModbusDevice):
         self,
         plant_index: int,
         device_address: int,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
         model_id: str,
         serial: str,
     ):

--- a/sigenergy2mqtt/devices/pss/mv.py
+++ b/sigenergy2mqtt/devices/pss/mv.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sigenergy2mqtt.sensors.pss_read_only as ro
 import sigenergy2mqtt.sensors.pss_read_write as rw
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.common.types import NonInverter
 from sigenergy2mqtt.devices import ModbusDevice
 
@@ -12,7 +12,7 @@ class MV(ModbusDevice):
         self,
         plant_index: int,
         device_address: int,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
         model_id: str,
         serial: str,
     ):

--- a/sigenergy2mqtt/devices/pss/pss.py
+++ b/sigenergy2mqtt/devices/pss/pss.py
@@ -4,7 +4,7 @@ import asyncio
 from typing import cast
 
 import sigenergy2mqtt.sensors.pss_read_only as ro
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.common.types import NonInverter
 from sigenergy2mqtt.devices import ModbusDevice
 from sigenergy2mqtt.modbus import ModbusClient
@@ -21,7 +21,7 @@ class PSS(ModbusDevice):
         self,
         plant_index: int,
         device_address: int,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
         model_id: str,
         serial: str,
     ):
@@ -39,7 +39,7 @@ class PSS(ModbusDevice):
         )
 
     @classmethod
-    async def create(cls, plant_index: int, device_address: int, protocol_version: Protocol, modbus_client: ModbusClient) -> PSS:
+    async def create(cls, plant_index: int, device_address: int, protocol_version: ProtocolVersion, modbus_client: ModbusClient) -> PSS:
         model = ro.PSSModelType(plant_index, device_address)
         serial_number = ro.PSSSerialNumber(plant_index, device_address)
 
@@ -58,7 +58,7 @@ class PSS(ModbusDevice):
         self,
         plant_index: int,
         device_address: int,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
         model_id: str,
         serial: str,
     ) -> None:

--- a/sigenergy2mqtt/devices/pss/transformer.py
+++ b/sigenergy2mqtt/devices/pss/transformer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sigenergy2mqtt.sensors.pss_read_only as ro
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.common.types import NonInverter
 from sigenergy2mqtt.devices import ModbusDevice
 
@@ -11,7 +11,7 @@ class Transformer(ModbusDevice):
         self,
         plant_index: int,
         device_address: int,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
         model_id: str,
         serial: str,
     ):

--- a/sigenergy2mqtt/diagnostics/service.py
+++ b/sigenergy2mqtt/diagnostics/service.py
@@ -17,7 +17,7 @@ from typing import Any
 
 import paho.mqtt.client as mqtt
 
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.devices import Device
 
@@ -36,7 +36,7 @@ class DiagnosticsService(Device):
             f"{active_config.home_assistant.unique_id_prefix}_diagnostics",
             "sigenergy2mqtt",
             "Diagnostics",
-            Protocol.N_A,
+            ProtocolVersion.N_A,
         )
 
     def schedule(self, modbus_client: Any, mqtt_client: mqtt.Client) -> list[Awaitable[None]]:

--- a/sigenergy2mqtt/influxdb/base.py
+++ b/sigenergy2mqtt/influxdb/base.py
@@ -10,7 +10,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.exceptions import MaxRetryError
 from urllib3.util.retry import Retry
 
-from sigenergy2mqtt.common import Protocol, service_health_registry
+from sigenergy2mqtt.common import ProtocolVersion, service_health_registry
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.devices import Device
 from sigenergy2mqtt.metrics import Metrics
@@ -93,7 +93,7 @@ class InfluxBase(Device):
             manufacturer: Manufacturer string for device registration.
             model: Model string for device registration.
         """
-        super().__init__(name, plant_index, unique, manufacturer, model, Protocol.N_A)
+        super().__init__(name, plant_index, unique, manufacturer, model, ProtocolVersion.N_A)
 
         self.plant_index = plant_index
 

--- a/sigenergy2mqtt/main/main.py
+++ b/sigenergy2mqtt/main/main.py
@@ -16,7 +16,7 @@ from pymodbus import pymodbus_apply_logging_config
 from pymodbus.exceptions import ModbusException
 from pymodbus.pdu import ModbusPDU
 
-from sigenergy2mqtt.common import Constants, ConsumptionMethod, FirmwareVersion, HybridInverter, InputType, Protocol, ProtocolApplies, PVInverter, service_health_registry
+from sigenergy2mqtt.common import Constants, ConsumptionMethod, FirmwareVersion, HybridInverter, InputType, ProtocolApplies, ProtocolVersion, PVInverter, service_health_registry
 from sigenergy2mqtt.config import active_config, configure_root_logger, initialize_async, is_docker
 from sigenergy2mqtt.devices import PID, PSS, ACCharger, DCCharger, Device, Inverter, PowerPlant, bind_cross_device_sensors
 from sigenergy2mqtt.diagnostics import DiagnosticsService
@@ -191,11 +191,11 @@ async def read_registers(modbus_client: ModbusClient, register: int, count: int,
 
 
 # ---------------------------------------------------------------------------
-# Protocol probing
+# ProtocolVersion probing
 # ---------------------------------------------------------------------------
 
 
-async def probe_protocol(modbus_client: ModbusClient) -> Protocol:
+async def probe_protocol(modbus_client: ModbusClient) -> ProtocolVersion:
     """Interrogate the plant to determine the highest supported Modbus protocol version.
 
     Registers are probed in descending version order; the first successful read
@@ -204,11 +204,11 @@ async def probe_protocol(modbus_client: ModbusClient) -> Protocol:
     # Tuples of (register, count, protocol_version) — must be input registers
     # unique to each version, listed from newest to oldest.
     candidates = [
-        (PlantPVTotalGenerationToday.ADDRESS, 2, Protocol.V2_9),
-        (TotalLoadPower.ADDRESS, 2, Protocol.V2_8),
-        (ThirdPartyPVPower.ADDRESS, 2, Protocol.V2_7),
-        (TotalLoadDailyConsumption.ADDRESS, 2, Protocol.V2_6),
-        (PlantBatterySoH.ADDRESS, 1, Protocol.V2_5),
+        (PlantPVTotalGenerationToday.ADDRESS, 2, ProtocolVersion.V2_9),
+        (TotalLoadPower.ADDRESS, 2, ProtocolVersion.V2_8),
+        (ThirdPartyPVPower.ADDRESS, 2, ProtocolVersion.V2_7),
+        (TotalLoadDailyConsumption.ADDRESS, 2, ProtocolVersion.V2_6),
+        (PlantBatterySoH.ADDRESS, 1, ProtocolVersion.V2_5),
     ]
     for register, count, version in candidates:
         logger.debug(f"READING {get_modbus_url(modbus_client)} to probe V{version.value} register {register} ({count=} device_id={Constants.PLANT_DEVICE_ADDRESS})")
@@ -222,8 +222,8 @@ async def probe_protocol(modbus_client: ModbusClient) -> Protocol:
         except (ModbusException, TimeoutError, OSError, RuntimeError) as e:
             logger.debug(f"FAILURE {get_modbus_url(modbus_client)} {register=} {count=} device_id={Constants.PLANT_DEVICE_ADDRESS} -> {e}")
 
-    logger.debug(f"DEFAULT {get_modbus_url(modbus_client)} to Sigenergy Modbus Protocol V1.8")
-    return Protocol.V1_8
+    logger.debug(f"DEFAULT {get_modbus_url(modbus_client)} to Sigenergy Modbus ProtocolVersion V1.8")
+    return ProtocolVersion.V1_8
 
 
 async def probe_optional_interface(modbus_client: ModbusClient, register: int, interface_name: str) -> bool:
@@ -263,7 +263,7 @@ async def make_ac_charger(plant_index: int, modbus_client: ModbusClient, device_
     return charger
 
 
-async def make_dc_charger(plant_index: int, device_address: int, protocol_version: Protocol, inverter_unique_id: str, sequence_number: int | None = None, total_count: int | None = None) -> DCCharger:
+async def make_dc_charger(plant_index: int, device_address: int, protocol_version: ProtocolVersion, inverter_unique_id: str, sequence_number: int | None = None, total_count: int | None = None) -> DCCharger:
     """Create a DC charger device and associate it with its inverter.
 
     Side effects: performs async device initialisation and sets ``via_device``
@@ -350,13 +350,13 @@ async def make_plant_and_inverter(plant_index: int, modbus_client: ModbusClient,
     if plant is None:
         firmware = FirmwareVersion(cast(str, await get_state(InverterFirmwareVersion(plant_index, device_address), modbus_client, "plant/inverter")))
         protocol = await probe_protocol(modbus_client)
-        if protocol == Protocol.V2_8 and firmware.service_pack >= 114:
-            logger.debug(f"IGNORED {get_modbus_url(modbus_client)} detection of Protocol V{protocol.value} because Firmware {firmware} supports V2.9 features")
-            protocol = Protocol.V2_9
-        logger.info(f"Interrogated {get_modbus_url(modbus_client)} and found Sigenergy Modbus Protocol V{protocol.value} ({ProtocolApplies(protocol)})")
+        if protocol == ProtocolVersion.V2_8 and firmware.service_pack >= 114:
+            logger.debug(f"IGNORED {get_modbus_url(modbus_client)} detection of ProtocolVersion V{protocol.value} because Firmware {firmware} supports V2.9 features")
+            protocol = ProtocolVersion.V2_9
+        logger.info(f"Interrogated {get_modbus_url(modbus_client)} and found Sigenergy Modbus ProtocolVersion V{protocol.value} ({ProtocolApplies(protocol)})")
 
-        if protocol < Protocol.V2_8 and active_config.consumption != ConsumptionMethod.CALCULATED:
-            logger.warning(f"Resetting consumption configuration to {ConsumptionMethod.CALCULATED.name} because {active_config.consumption.name} is not supported on Modbus Protocol V{protocol.value}")
+        if protocol < ProtocolVersion.V2_8 and active_config.consumption != ConsumptionMethod.CALCULATED:
+            logger.warning(f"Resetting consumption configuration to {ConsumptionMethod.CALCULATED.name} because {active_config.consumption.name} is not supported on Modbus ProtocolVersion V{protocol.value}")
             active_config.consumption = ConsumptionMethod.CALCULATED
 
         ot = await get_state(OutputType(plant_index, device_address), modbus_client, "plant/inverter", raw=True)
@@ -411,9 +411,9 @@ async def make_pss(
 # ---------------------------------------------------------------------------
 
 
-async def setup_devices(seen_serial_numbers: set[str]) -> tuple[list[ThreadConfig], Protocol | None]:
+async def setup_devices(seen_serial_numbers: set[str]) -> tuple[list[ThreadConfig], ProtocolVersion | None]:
     """Iterate over all configured Modbus hosts, probe registers, and populate ThreadConfigs."""
-    protocol_version: Protocol | None = None
+    protocol_version: ProtocolVersion | None = None
     devices = active_config.modbus
     total_ac_chargers = sum(len(d.ac_chargers) if d.ac_chargers else 0 for d in devices)  # type: ignore[reportGeneralTypeIssues]
     total_dc_chargers = sum(len(d.dc_chargers) if d.dc_chargers else 0 for d in devices)  # type: ignore[reportGeneralTypeIssues]
@@ -560,7 +560,7 @@ async def setup_devices(seen_serial_numbers: set[str]) -> tuple[list[ThreadConfi
     return thread_config_registry.get_all(), protocol_version
 
 
-def setup_services(configs: list[ThreadConfig], protocol_version: Protocol | None) -> list[ThreadConfig]:
+def setup_services(configs: list[ThreadConfig], protocol_version: ProtocolVersion | None) -> list[ThreadConfig]:
     """Attach optional service/monitor threads to the discovered device configs.
 
     Side effects:
@@ -582,7 +582,7 @@ def setup_services(configs: list[ThreadConfig], protocol_version: Protocol | Non
 
     Metrics.commence()
     if active_config.metrics_enabled:
-        svc_thread_cfg.add_device(MetricsService(protocol_version if protocol_version is not None else Protocol.N_A))
+        svc_thread_cfg.add_device(MetricsService(protocol_version if protocol_version is not None else ProtocolVersion.N_A))
 
     if active_config.pvoutput.enabled and not active_config.clean:
         for service in get_pvoutput_services(configs):
@@ -666,7 +666,7 @@ async def _setup_ac_chargers(
     plant: PowerPlant,
     modbus_client: ModbusClient,
     config: ThreadConfig,
-    protocol_version: Protocol | None,
+    protocol_version: ProtocolVersion | None,
     sequence_start: int,
     total_count: int,
     inverter_firmware_versions: Mapping[int, str] | None = None,
@@ -681,8 +681,8 @@ async def _setup_ac_chargers(
             si_sensor.publishable = False
         return sequence_start
 
-    if protocol_version is not None and protocol_version < Protocol.V2_0:
-        logger.warning(f"AC Chargers are not supported on Sigenergy Modbus Protocol V{protocol_version.value} - skipping AC Charger device creation for modbus://{device.host}:{device.port}")
+    if protocol_version is not None and protocol_version < ProtocolVersion.V2_0:
+        logger.warning(f"AC Chargers are not supported on Sigenergy Modbus ProtocolVersion V{protocol_version.value} - skipping AC Charger device creation for modbus://{device.host}:{device.port}")
         return sequence_start
 
     sequence_number = sequence_start
@@ -764,7 +764,7 @@ async def _setup_pid(
     seen_serial_numbers: set[str],
     modbus_client: ModbusClient,
     config: ThreadConfig,
-    protocol_version: Protocol | None,
+    protocol_version: ProtocolVersion | None,
     sequence_start: int,
     total_count: int,
     inverter_firmware_versions: Mapping[int, str] | None = None,
@@ -772,8 +772,8 @@ async def _setup_pid(
     if not device.pid:
         return sequence_start
 
-    if protocol_version is not None and protocol_version < Protocol.V2_9:
-        logger.warning(f"PID devices are not supported on Sigenergy Modbus Protocol V{protocol_version.value} - skipping PID device creation for modbus://{device.host}:{device.port}")
+    if protocol_version is not None and protocol_version < ProtocolVersion.V2_9:
+        logger.warning(f"PID devices are not supported on Sigenergy Modbus ProtocolVersion V{protocol_version.value} - skipping PID device creation for modbus://{device.host}:{device.port}")
         return sequence_start
 
     sequence_number = sequence_start
@@ -815,7 +815,7 @@ async def _setup_pss(
     seen_serial_numbers: set[str],
     modbus_client: ModbusClient,
     config: ThreadConfig,
-    protocol_version: Protocol | None,
+    protocol_version: ProtocolVersion | None,
     sequence_start: int,
     total_count: int,
     inverter_firmware_versions: Mapping[int, str] | None = None,
@@ -823,8 +823,8 @@ async def _setup_pss(
     if not device.pss:
         return sequence_start
 
-    if protocol_version is not None and protocol_version < Protocol.V2_9:
-        logger.warning(f"PSS devices are not supported on Sigenergy Modbus Protocol V{protocol_version.value} - skipping PSS device creation for modbus://{device.host}:{device.port}")
+    if protocol_version is not None and protocol_version < ProtocolVersion.V2_9:
+        logger.warning(f"PSS devices are not supported on Sigenergy Modbus ProtocolVersion V{protocol_version.value} - skipping PSS device creation for modbus://{device.host}:{device.port}")
         return sequence_start
 
     sequence_number = sequence_start

--- a/sigenergy2mqtt/metrics/sensors.py
+++ b/sigenergy2mqtt/metrics/sensors.py
@@ -416,7 +416,7 @@ class ProtocolVersionSensor(MetricsSensor):
 
     def __init__(self, protocol_version: ProtocolVersion):
         super().__init__(
-            name="ProtocolVersion Version",
+            name="Protocol Version",
             unique_id=f"{active_config.home_assistant.unique_id_prefix}_modbus_protocol",
             object_id="sigenergy2mqtt_modbus_protocol",
             icon="mdi:book-information-variant",

--- a/sigenergy2mqtt/metrics/sensors.py
+++ b/sigenergy2mqtt/metrics/sensors.py
@@ -11,7 +11,7 @@ import logging
 import time
 from typing import Any, cast
 
-from sigenergy2mqtt.common import PERCENTAGE, DeviceClass, Protocol, ProtocolApplies
+from sigenergy2mqtt.common import PERCENTAGE, DeviceClass, ProtocolApplies, ProtocolVersion
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.sensors.base import DiscoveryKeys, ReadableSensorMixin, WriteOnlySensor
 
@@ -411,12 +411,12 @@ class Started(MetricsSensor):
         return True
 
 
-class ProtocolVersion(MetricsSensor):
+class ProtocolVersionSensor(MetricsSensor):
     """The Sigenergy modbus protocol version in use."""
 
-    def __init__(self, protocol_version: Protocol):
+    def __init__(self, protocol_version: ProtocolVersion):
         super().__init__(
-            name="Protocol Version",
+            name="ProtocolVersion Version",
             unique_id=f"{active_config.home_assistant.unique_id_prefix}_modbus_protocol",
             object_id="sigenergy2mqtt_modbus_protocol",
             icon="mdi:book-information-variant",
@@ -433,9 +433,9 @@ class ProtocolVersion(MetricsSensor):
 class ProtocolPublished(MetricsSensor):
     """The date from which the active Sigenergy modbus protocol applies."""
 
-    def __init__(self, protocol_version: Protocol):
+    def __init__(self, protocol_version: ProtocolVersion):
         super().__init__(
-            name="Protocol Published",
+            name="ProtocolVersion Published",
             unique_id=f"{active_config.home_assistant.unique_id_prefix}_modbus_protocol_published",
             object_id="sigenergy2mqtt_modbus_protocol_published",
             icon="mdi:book-clock",
@@ -982,7 +982,7 @@ class ResetMetrics(WriteOnlySensor):
             plant_index=0,  # Required for assertions, but not used
             device_address=1,  # Required for assertions, but not used
             address=99999,  # Required for assertions, but not used
-            protocol_version=Protocol.N_A,
+            protocol_version=ProtocolVersion.N_A,
             icon_off="mdi:reload",
             icon_on="mdi:reload",
             name_off="Reset Metrics",

--- a/sigenergy2mqtt/metrics/service.py
+++ b/sigenergy2mqtt/metrics/service.py
@@ -11,7 +11,7 @@ import logging
 
 import paho.mqtt.client as mqtt
 
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.devices import Device
 from sigenergy2mqtt.metrics import sensors
@@ -31,7 +31,7 @@ class MetricsService(Device):
     correctly via their shared availability topic.
     """
 
-    def __init__(self, protocol_version: Protocol):
+    def __init__(self, protocol_version: ProtocolVersion):
         unique_id = f"{active_config.home_assistant.unique_id_prefix}_metrics"
         super().__init__("Sigenergy Metrics", -1, unique_id, "sigenergy2mqtt", "Metrics", protocol_version)
 
@@ -82,7 +82,7 @@ class MetricsService(Device):
         self._add_sensor(sensors.StateStoreDeleteErrors())
 
         self._add_sensor(sensors.Started())
-        self._add_sensor(sensors.ProtocolVersion(protocol_version))
+        self._add_sensor(sensors.ProtocolVersionSensor(protocol_version))
         self._add_sensor(sensors.ProtocolPublished(protocol_version))
 
         self._add_sensor(sensors.ResetMetrics())

--- a/sigenergy2mqtt/monitor/service.py
+++ b/sigenergy2mqtt/monitor/service.py
@@ -11,7 +11,7 @@ from typing import Any
 import paho.mqtt.client as mqtt
 from paho.mqtt import MQTTException
 
-from sigenergy2mqtt.common import PERCENTAGE, Protocol, UnitOfTemperature, service_health_registry
+from sigenergy2mqtt.common import PERCENTAGE, ProtocolVersion, UnitOfTemperature, service_health_registry
 from sigenergy2mqtt.config import active_config, is_docker
 from sigenergy2mqtt.devices import Device
 from sigenergy2mqtt.diagnostics import diagnostics_registry
@@ -36,7 +36,7 @@ class MonitorService(Device):
             devices: Devices that expose sensors to subscribe to.
         """
 
-        super().__init__("Sigenergy Monitor", -1, f"{active_config.home_assistant.unique_id_prefix}_monitor", "sigenergy2mqtt", "Monitor", Protocol.N_A)
+        super().__init__("Sigenergy Monitor", -1, f"{active_config.home_assistant.unique_id_prefix}_monitor", "sigenergy2mqtt", "Monitor", ProtocolVersion.N_A)
         self._devices: list[Device] = devices
         self._lock = asyncio.Lock()
         self._topics: dict[str, MonitoredSensor] = {}

--- a/sigenergy2mqtt/pvoutput/service.py
+++ b/sigenergy2mqtt/pvoutput/service.py
@@ -12,7 +12,7 @@ import paho.mqtt.client as mqtt
 import requests
 from requests.structures import CaseInsensitiveDict
 
-from sigenergy2mqtt.common import Protocol, service_health_registry
+from sigenergy2mqtt.common import ProtocolVersion, service_health_registry
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.devices import Device
 from sigenergy2mqtt.metrics import Metrics
@@ -33,7 +33,7 @@ class Service(Device):
             unique_id: Stable unique identifier for this virtual device.
             model: Model string used for metadata/logging.
         """
-        super().__init__(name, -1, unique_id, "sigenergy2mqtt", model, Protocol.N_A)
+        super().__init__(name, -1, unique_id, "sigenergy2mqtt", model, ProtocolVersion.N_A)
         self._lock = asyncio.Lock()
         self._set_health_status(True)
 

--- a/sigenergy2mqtt/sensors/ac_charger_read_only.py
+++ b/sigenergy2mqtt/sensors/ac_charger_read_only.py
@@ -1,4 +1,4 @@
-from sigenergy2mqtt.common import DeviceClass, InputType, Protocol, StateClass, UnitOfElectricCurrent, UnitOfElectricPotential, UnitOfEnergy, UnitOfPower
+from sigenergy2mqtt.common import DeviceClass, InputType, ProtocolVersion, StateClass, UnitOfElectricCurrent, UnitOfElectricPotential, UnitOfEnergy, UnitOfPower
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.modbus import ModbusDataType
 from sigenergy2mqtt.sensors.base import DiscoveryKeys, ScanInterval
@@ -28,7 +28,7 @@ class ACChargerRunningState(ReadOnlySensor):
             icon="mdi:ev-station",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V2_0,
+            protocol_version=ProtocolVersion.V2_0,
         )
         options: list[str] = [  # https://www.mathworks.com/help/autoblks/ug/charge-an-electric-vehicle.html
             "Initialising",  # 0: System init - System is initialising # Not part of the IEC 61851-1 standard
@@ -79,7 +79,7 @@ class ACChargerTotalEnergyConsumed(ReadOnlySensor):
             icon="mdi:car-electric",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_0,
+            protocol_version=ProtocolVersion.V2_0,
         )
         self["enabled_by_default"] = True
 
@@ -104,7 +104,7 @@ class ACChargerChargingPower(ReadOnlySensor):
             icon="mdi:car-electric",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_0,
+            protocol_version=ProtocolVersion.V2_0,
         )
         self["enabled_by_default"] = True
 
@@ -129,7 +129,7 @@ class ACChargerRatedPower(ReadOnlySensor):
             icon="mdi:car-electric",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_0,
+            protocol_version=ProtocolVersion.V2_0,
         )
         self["entity_category"] = "diagnostic"
 
@@ -154,7 +154,7 @@ class ACChargerRatedCurrent(ReadOnlySensor):
             icon="mdi:car-electric",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_0,
+            protocol_version=ProtocolVersion.V2_0,
         )
         self["entity_category"] = "diagnostic"
 
@@ -179,7 +179,7 @@ class ACChargerRatedVoltage(ReadOnlySensor):
             icon="mdi:car-electric",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_0,
+            protocol_version=ProtocolVersion.V2_0,
         )
         self["entity_category"] = "diagnostic"
 
@@ -204,7 +204,7 @@ class ACChargerInputBreaker(ReadOnlySensor):
             icon="mdi:car-electric",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_0,
+            protocol_version=ProtocolVersion.V2_0,
         )
         self["entity_category"] = "diagnostic"
 
@@ -220,7 +220,7 @@ class ACChargerAlarm1(AlarmSensor):
             device_address=device_address,
             address=self.ADDRESS,
             alarm_type="EVAC",
-            protocol_version=Protocol.V2_0,
+            protocol_version=ProtocolVersion.V2_0,
         )
 
     def decode_alarm_bit(self, bit_position: int):
@@ -258,7 +258,7 @@ class ACChargerAlarm2(AlarmSensor):
             device_address=device_address,
             address=self.ADDRESS,
             alarm_type="EVAC",
-            protocol_version=Protocol.V2_0,
+            protocol_version=ProtocolVersion.V2_0,
         )
 
     def decode_alarm_bit(self, bit_position: int):
@@ -290,7 +290,7 @@ class ACChargerAlarm3(AlarmSensor):
             device_address=device_address,
             address=self.ADDRESS,
             alarm_type="EVAC",
-            protocol_version=Protocol.V2_0,
+            protocol_version=ProtocolVersion.V2_0,
         )
 
     def decode_alarm_bit(self, bit_position: int):

--- a/sigenergy2mqtt/sensors/ac_charger_read_write.py
+++ b/sigenergy2mqtt/sensors/ac_charger_read_write.py
@@ -1,4 +1,4 @@
-from sigenergy2mqtt.common import DeviceClass, InputType, Protocol, UnitOfElectricCurrent
+from sigenergy2mqtt.common import DeviceClass, InputType, ProtocolVersion, UnitOfElectricCurrent
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.modbus import ModbusDataType
 
@@ -17,7 +17,7 @@ class ACChargerStatus(WriteOnlySensor):
             plant_index=plant_index,
             device_address=device_address,
             address=self.ADDRESS,
-            protocol_version=Protocol.V2_0,
+            protocol_version=ProtocolVersion.V2_0,
             payload_off="stop",
             payload_on="start",
             name_off="Stop",
@@ -62,7 +62,7 @@ class ACChargerOutputCurrent(NumericSensor):
             icon="mdi:car-electric",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_0,
+            protocol_version=ProtocolVersion.V2_0,
             minimum=6.0,
             maximum=min(input_breaker, rated_current),
         )

--- a/sigenergy2mqtt/sensors/base/__init__.py
+++ b/sigenergy2mqtt/sensors/base/__init__.py
@@ -9,7 +9,7 @@ import sys  # noqa: F401
 import time  # noqa: F401
 from pathlib import Path  # noqa: F401
 
-from sigenergy2mqtt.common import DeviceType, Protocol  # noqa: F401
+from sigenergy2mqtt.common import DeviceType, ProtocolVersion  # noqa: F401
 from sigenergy2mqtt.config import active_config  # noqa: F401
 from sigenergy2mqtt.i18n import _t  # noqa: F401
 

--- a/sigenergy2mqtt/sensors/base/alarms.py
+++ b/sigenergy2mqtt/sensors/base/alarms.py
@@ -10,7 +10,7 @@ from typing import Any, Final, cast
 
 from pymodbus.pdu import ExceptionResponse
 
-from sigenergy2mqtt.common import DeviceClass, HybridInverter, InputType, Protocol, PVInverter
+from sigenergy2mqtt.common import DeviceClass, HybridInverter, InputType, ProtocolVersion, PVInverter
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.i18n import _t
 from sigenergy2mqtt.modbus import ModbusDataType
@@ -37,7 +37,7 @@ class AlarmSensor(ReadOnlySensor, metaclass=abc.ABCMeta):
         plant_index: int,
         device_address: int,
         address: int,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
         alarm_type: str,
         **kwargs,
     ):
@@ -217,7 +217,7 @@ class AlarmSensor(ReadOnlySensor, metaclass=abc.ABCMeta):
 class Alarm1Sensor(AlarmSensor):
     """PCS (Power Conversion System) alarms - Register 1."""
 
-    def __init__(self, name: str, object_id: str, plant_index: int, device_address: int, address: int, protocol_version: Protocol):
+    def __init__(self, name: str, object_id: str, plant_index: int, device_address: int, address: int, protocol_version: ProtocolVersion):
         super().__init__(name, object_id, plant_index, device_address, address, protocol_version, "PCS")
 
     def decode_alarm_bit(self, bit_position: int) -> str | None:
@@ -246,7 +246,7 @@ class Alarm1Sensor(AlarmSensor):
 class Alarm2Sensor(AlarmSensor):
     """PCS (Power Conversion System) alarms - Register 2."""
 
-    def __init__(self, name: str, object_id: str, plant_index: int, device_address: int, address: int, protocol_version: Protocol):
+    def __init__(self, name: str, object_id: str, plant_index: int, device_address: int, address: int, protocol_version: ProtocolVersion):
         super().__init__(name, object_id, plant_index, device_address, address, protocol_version, "PCS")
 
     def decode_alarm_bit(self, bit_position: int) -> str | None:
@@ -268,7 +268,7 @@ class Alarm2Sensor(AlarmSensor):
 class Alarm3Sensor(AlarmSensor):
     """ESS (Energy Storage System) alarms."""
 
-    def __init__(self, name: str, object_id: str, plant_index: int, device_address: int, address: int, protocol_version: Protocol):
+    def __init__(self, name: str, object_id: str, plant_index: int, device_address: int, address: int, protocol_version: ProtocolVersion):
         super().__init__(name, object_id, plant_index, device_address, address, protocol_version, "ESS")
         self[DiscoveryKeys.ENABLED_BY_DEFAULT] = True
 
@@ -296,7 +296,7 @@ class Alarm4Sensor(AlarmSensor):
         plant_index: int,
         device_address: int,
         address: int,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
     ):
         super().__init__(name, object_id, plant_index, device_address, address, protocol_version, "GW")
         self[DiscoveryKeys.ENABLED_BY_DEFAULT] = True
@@ -319,7 +319,7 @@ class Alarm4Sensor(AlarmSensor):
 class Alarm5Sensor(AlarmSensor):
     """EV DC Charger alarms."""
 
-    def __init__(self, name: str, object_id: str, plant_index: int, device_address: int, address: int, protocol_version: Protocol):
+    def __init__(self, name: str, object_id: str, plant_index: int, device_address: int, address: int, protocol_version: ProtocolVersion):
         super().__init__(name, object_id, plant_index, device_address, address, protocol_version, "EVDC")
         self[DiscoveryKeys.ENABLED_BY_DEFAULT] = True
 
@@ -385,7 +385,7 @@ class AlarmCombinedSensor(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:flash-triangle",
             gain=None,
             precision=None,
-            protocol_version=Protocol.N_A,
+            protocol_version=ProtocolVersion.N_A,
             input_type=InputType.INPUT,
             plant_index=plant_index,
             device_address=next(iter(device_addresses)),
@@ -398,7 +398,7 @@ class AlarmCombinedSensor(ReadOnlySensor, HybridInverter, PVInverter):
         self[DiscoveryKeys.ENABLED_BY_DEFAULT] = True
 
     @property
-    def protocol_version(self) -> Protocol:
+    def protocol_version(self) -> ProtocolVersion:
         """Get the highest protocol version from all alarms."""
         protocol = super().protocol_version
         for alarm in self.alarms:
@@ -406,8 +406,8 @@ class AlarmCombinedSensor(ReadOnlySensor, HybridInverter, PVInverter):
         return protocol
 
     @protocol_version.setter
-    def protocol_version(self, protocol_version: Protocol | float):
-        """Protocol version is read-only for combined sensors."""
+    def protocol_version(self, protocol_version: ProtocolVersion | float):
+        """ProtocolVersion version is read-only for combined sensors."""
         raise NotImplementedError("protocol_version is read-only for AlarmCombinedSensor")
 
     async def _update_internal_state(self, **kwargs) -> bool | Exception | ExceptionResponse:
@@ -508,7 +508,7 @@ class RunningStateSensor(ReadOnlySensor):
         plant_index: int,
         device_address: int,
         address: int,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
         **kwargs,
     ):
         super().__init__(

--- a/sigenergy2mqtt/sensors/base/derived.py
+++ b/sigenergy2mqtt/sensors/base/derived.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from pymodbus.pdu import ExceptionResponse
 
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 
 from .constants import DiscoveryKeys
 from .sensor import Sensor, TypedSensorMixin
@@ -36,7 +36,7 @@ class DerivedSensor(TypedSensorMixin, Sensor):
             **kwargs: Forwarded to the Sensor base class.
         """
         if "protocol_version" not in kwargs:
-            kwargs["protocol_version"] = Protocol.N_A
+            kwargs["protocol_version"] = ProtocolVersion.N_A
 
         super().__init__(*args, **kwargs)
         self[DiscoveryKeys.ENABLED_BY_DEFAULT] = True
@@ -215,7 +215,7 @@ class CrossDeviceDerivedSensor(DerivedSensor):
         added = False
         for pending in pending_sources:
             # Skip sources that violate the owner device's protocol version
-            if owner_device.protocol_version > Protocol.N_A and pending.protocol_version > owner_device.protocol_version:
+            if owner_device.protocol_version > ProtocolVersion.N_A and pending.protocol_version > owner_device.protocol_version:
                 logger.debug(f"{self.log_identity} skipped cross-device binding of {pending.__class__.__name__} - source protocol {pending.protocol_version} > device protocol {owner_device.protocol_version}")
                 continue
 

--- a/sigenergy2mqtt/sensors/base/readable.py
+++ b/sigenergy2mqtt/sensors/base/readable.py
@@ -10,7 +10,7 @@ from typing import Any, cast
 from pymodbus.exceptions import ModbusException
 from pymodbus.pdu import ExceptionResponse
 
-from sigenergy2mqtt.common import DeviceClass, InputType, Protocol, StateClass
+from sigenergy2mqtt.common import DeviceClass, InputType, ProtocolVersion, StateClass
 from sigenergy2mqtt.config.models import RegisterAccess
 from sigenergy2mqtt.i18n import _t
 from sigenergy2mqtt.modbus import ModbusClient, ModbusDataType
@@ -46,7 +46,7 @@ class ReadOnlySensor(TypedSensorMixin, ReadableSensorMixin, ModbusSensorMixin, S
         icon: str | None,
         gain: float | None,
         precision: int | None,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
         unique_id_override: str | None = None,
         **kwargs,
     ):
@@ -228,7 +228,7 @@ class UnpublishResetSensorMixin(Sensor):
 
 
 class ReservedSensor(ReadOnlySensor):
-    """Sensor for Modbus registers marked as Reserved in the Protocol document.
+    """Sensor for Modbus registers marked as Reserved in the ProtocolVersion document.
 
     Reserved sensors are never published but can be used for internal logic.
     """
@@ -250,7 +250,7 @@ class ReservedSensor(ReadOnlySensor):
         icon: str | None,
         gain: float | None,
         precision: int | None,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
         unique_id_override: str | None = None,
         availability_control_sensor: AvailabilityMixin | None = None,
         **kwargs,

--- a/sigenergy2mqtt/sensors/base/sensor.py
+++ b/sigenergy2mqtt/sensors/base/sensor.py
@@ -16,7 +16,7 @@ import paho.mqtt.client as mqtt
 from pymodbus.exceptions import ModbusException
 from pymodbus.pdu import ExceptionResponse
 
-from sigenergy2mqtt.common import DeviceClass, Protocol, StateClass
+from sigenergy2mqtt.common import DeviceClass, ProtocolVersion, StateClass
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.config.models import RegisterAccess
 from sigenergy2mqtt.i18n import _t
@@ -91,7 +91,7 @@ class Sensor(SensorDebuggingMixin, dict[str, SensorAttribute], metaclass=abc.ABC
         icon: str | None,
         gain: float | None,
         precision: int | None,
-        protocol_version: Protocol = Protocol.V2_4,
+        protocol_version: ProtocolVersion = ProtocolVersion.V2_4,
         **kwargs,
     ):
         # Validate unique_id
@@ -105,7 +105,7 @@ class Sensor(SensorDebuggingMixin, dict[str, SensorAttribute], metaclass=abc.ABC
             raise AssertionError(f"{self.__class__.__name__} icon {icon} does not start with 'mdi:'")
 
         # Validate protocol version
-        if not isinstance(protocol_version, Protocol):
+        if not isinstance(protocol_version, ProtocolVersion):
             raise TypeError(f"{self.__class__.__name__} protocol_version '{protocol_version}' is invalid")
 
         super().__init__(**kwargs)
@@ -315,24 +315,24 @@ class Sensor(SensorDebuggingMixin, dict[str, SensorAttribute], metaclass=abc.ABC
         return self._log_identity
 
     @property
-    def protocol_version(self) -> Protocol:
+    def protocol_version(self) -> ProtocolVersion:
         """Get the protocol version this sensor was introduced in."""
-        return self._protocol_version if self._protocol_version else Protocol.N_A
+        return self._protocol_version if self._protocol_version else ProtocolVersion.N_A
 
     @protocol_version.setter
-    def protocol_version(self, protocol_version: Protocol | float):
+    def protocol_version(self, protocol_version: ProtocolVersion | float):
         """Set the protocol version this sensor was introduced in."""
-        if isinstance(protocol_version, Protocol):
+        if isinstance(protocol_version, ProtocolVersion):
             self._protocol_version = protocol_version
         elif isinstance(protocol_version, float):
-            if protocol_version not in [p.value for p in Protocol]:
+            if protocol_version not in [p.value for p in ProtocolVersion]:
                 raise AssertionError(f"{self.log_identity}: Invalid protocol_version '{protocol_version}'")
-            protocol = {p.value: p for p in Protocol}.get(protocol_version)
+            protocol = {p.value: p for p in ProtocolVersion}.get(protocol_version)
             if protocol is None:
                 raise AssertionError(f"{self.log_identity}: Invalid protocol_version '{protocol_version}'")
             self._protocol_version = protocol
         else:
-            raise TypeError(f"{self.log_identity}: protocol_version must be Protocol or float, got {type(protocol_version)}")
+            raise TypeError(f"{self.log_identity}: protocol_version must be ProtocolVersion or float, got {type(protocol_version)}")
 
     @property
     def publishable(self) -> bool:
@@ -698,7 +698,7 @@ class Sensor(SensorDebuggingMixin, dict[str, SensorAttribute], metaclass=abc.ABC
 
         attributes[SensorAttributeKeys.SENSOR_CLASS] = self.__class__.__name__
 
-        if self.protocol_version and self.protocol_version != Protocol.N_A:
+        if self.protocol_version and self.protocol_version != ProtocolVersion.N_A:
             attributes[SensorAttributeKeys.SINCE_PROTOCOL] = f"V{self.protocol_version.value}"
 
         if self._gain:

--- a/sigenergy2mqtt/sensors/base/timestamp.py
+++ b/sigenergy2mqtt/sensors/base/timestamp.py
@@ -6,7 +6,7 @@ import logging
 from datetime import datetime, timezone
 from typing import cast
 
-from sigenergy2mqtt.common import DeviceClass, InputType, Protocol
+from sigenergy2mqtt.common import DeviceClass, InputType, ProtocolVersion
 from sigenergy2mqtt.modbus import ModbusDataType
 
 from .constants import DiscoveryKeys
@@ -31,7 +31,7 @@ class TimestampSensor(ReadOnlySensor):
         device_address: int,
         address: int,
         scan_interval: int,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
         tz: timezone,
         **kwargs,
     ):

--- a/sigenergy2mqtt/sensors/base/writeable.py
+++ b/sigenergy2mqtt/sensors/base/writeable.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, cast
 import paho.mqtt.client as mqtt
 from pymodbus.pdu import ExceptionResponse
 
-from sigenergy2mqtt.common import Constants, Protocol
+from sigenergy2mqtt.common import Constants, ProtocolVersion
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.i18n import _t
 from sigenergy2mqtt.modbus import ModbusClient, ModbusDataType
@@ -40,7 +40,7 @@ class WriteOnlySensor(ModbusWriteableSensorMixin, Sensor):
         plant_index: int,
         device_address: int,
         address: int,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
         payload_off: str = "off",
         payload_on: str = "on",
         name_off: str = "Power Off",
@@ -200,7 +200,7 @@ class ReadWriteSensor(ModbusWriteableSensorMixin, ReadOnlySensor):
         icon: str | None,
         gain: float | None,
         precision: int | None,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
         **kwargs,
     ):
         # Validate availability control sensor
@@ -375,7 +375,7 @@ class NumericSensor(ReadWriteSensor):
         icon: str | None,
         gain: float | None,
         precision: int | None,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
         minimum: float | tuple[float, float] | None = None,
         maximum: float | tuple[float, float] | None = None,
         **kwargs,
@@ -691,7 +691,7 @@ class SelectSensor(ReadWriteSensor):
         address: int,
         scan_interval: int,
         options: list[str],
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
         **kwargs,
     ):
         # Validate options
@@ -812,7 +812,7 @@ class SwitchSensor(ReadWriteSensor):
         device_address: int,
         address: int,
         scan_interval: int,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
         **kwargs,
     ):
         super().__init__(

--- a/sigenergy2mqtt/sensors/inverter_derived.py
+++ b/sigenergy2mqtt/sensors/inverter_derived.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 
 import paho.mqtt.client as mqtt
 
-from sigenergy2mqtt.common import DeviceClass, HybridInverter, Protocol, PVInverter, StateClass, UnitOfPower
+from sigenergy2mqtt.common import DeviceClass, HybridInverter, ProtocolVersion, PVInverter, StateClass, UnitOfPower
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.modbus import ModbusClient, ModbusDataType
 from sigenergy2mqtt.sensors.base import SanityCheckException
@@ -228,7 +228,7 @@ class InverterSelfConsumedPower(DerivedSensor, HybridInverter, PVInverter):
             icon="mdi:battery-unknown",
             gain=None,
             precision=0,  # Intentional rounding to nearest watt
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             source_sensors=(active_power, battery_power, *pv_string_power),
         )
 

--- a/sigenergy2mqtt/sensors/inverter_read_only.py
+++ b/sigenergy2mqtt/sensors/inverter_read_only.py
@@ -9,7 +9,7 @@ from sigenergy2mqtt.common import (
     DeviceClass,
     HybridInverter,
     InputType,
-    Protocol,
+    ProtocolVersion,
     PVInverter,
     StateClass,
     UnitOfApparentPower,
@@ -64,7 +64,7 @@ class InverterModel(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:text-short",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["entity_category"] = "diagnostic"
 
@@ -89,7 +89,7 @@ class InverterSerialNumber(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:text-short",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["entity_category"] = "diagnostic"
 
@@ -114,7 +114,7 @@ class InverterFirmwareVersion(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:text-short",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["entity_category"] = "diagnostic"
 
@@ -157,7 +157,7 @@ class RatedActivePower(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["entity_category"] = "diagnostic"
 
@@ -182,7 +182,7 @@ class MaxRatedApparentPower(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["entity_category"] = "diagnostic"
 
@@ -207,7 +207,7 @@ class InverterMaxActivePower(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["entity_category"] = "diagnostic"
 
@@ -232,7 +232,7 @@ class MaxAbsorptionPower(ReadOnlySensor, HybridInverter):
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["entity_category"] = "diagnostic"
 
@@ -257,7 +257,7 @@ class RatedBatteryCapacity(ReadOnlySensor, HybridInverter):
             icon="mdi:battery-high",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self.sanity_check.delta = False
         self["entity_category"] = "diagnostic"
@@ -283,7 +283,7 @@ class RatedChargingPower(ReadOnlySensor, HybridInverter):
             icon="mdi:battery-positive",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["entity_category"] = "diagnostic"
 
@@ -308,7 +308,7 @@ class RatedDischargingPower(ReadOnlySensor, HybridInverter):
             icon="mdi:battery-negative",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["entity_category"] = "diagnostic"
 
@@ -333,7 +333,7 @@ class ReservedDailyExportEnergy(ReservedSensor, HybridInverter):  # 30554-30565 
             icon="mdi:transmission-tower-export",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
 
@@ -357,7 +357,7 @@ class ReservedAccumulatedExportEnergy(ReservedSensor, HybridInverter):  # 30554-
             icon="mdi:transmission-tower-export",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
 
@@ -381,7 +381,7 @@ class ReservedDailyImportEnergy(ReservedSensor, HybridInverter):  # 30554-30565 
             icon="mdi:transmission-tower-import",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
 
@@ -405,7 +405,7 @@ class ReservedAccumulatedImportEnergy(ReservedSensor, HybridInverter):  # 30554-
             icon="mdi:transmission-tower-import",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
 
@@ -429,7 +429,7 @@ class DailyChargeEnergy(ReadOnlySensor, HybridInverter):
             icon="mdi:battery-arrow-up",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["enabled_by_default"] = True
         self.sanity_check.min_raw = None
@@ -455,7 +455,7 @@ class AccumulatedChargeEnergy(ReadOnlySensor, HybridInverter):
             icon="mdi:battery-arrow-up",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["enabled_by_default"] = True
 
@@ -480,7 +480,7 @@ class DailyDischargeEnergy(ReadOnlySensor, HybridInverter):
             icon="mdi:battery-arrow-down",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["enabled_by_default"] = True
         self.sanity_check.min_raw = None
@@ -506,7 +506,7 @@ class AccumulatedDischargeEnergy(ReadOnlySensor, HybridInverter):
             icon="mdi:battery-arrow-down",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["enabled_by_default"] = True
 
@@ -521,7 +521,7 @@ class InverterRunningState(RunningStateSensor, HybridInverter, PVInverter):
             plant_index=plant_index,
             device_address=device_address,
             address=self.ADDRESS,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
 
@@ -545,7 +545,7 @@ class MaxActivePowerAdjustment(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:adjust",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["entity_category"] = "diagnostic"
 
@@ -570,7 +570,7 @@ class MinActivePowerAdjustment(ReadOnlySensor, HybridInverter):
             icon="mdi:adjust",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["entity_category"] = "diagnostic"
 
@@ -595,7 +595,7 @@ class MaxReactivePowerAdjustment(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:adjust",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["entity_category"] = "diagnostic"
 
@@ -620,7 +620,7 @@ class MinReactivePowerAdjustment(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:adjust",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["entity_category"] = "diagnostic"
 
@@ -645,7 +645,7 @@ class ActivePower(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
 
@@ -669,7 +669,7 @@ class ReactivePower(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
 
@@ -693,7 +693,7 @@ class MaxBatteryChargePower(ReadOnlySensor, HybridInverter):
             icon="mdi:battery-arrow-up",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
 
@@ -717,7 +717,7 @@ class MaxBatteryDischargePower(ReadOnlySensor, HybridInverter):
             icon="mdi:battery-arrow-down",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
 
@@ -741,7 +741,7 @@ class AvailableBatteryChargeEnergy(ReadOnlySensor, HybridInverter):
             icon="mdi:battery-plus-variant",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self.sanity_check.delta = False
         self["enabled_by_default"] = True
@@ -767,7 +767,7 @@ class AvailableBatteryDischargeEnergy(ReadOnlySensor, HybridInverter):
             icon="mdi:battery-minus-variant",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self.sanity_check.delta = False
         self["enabled_by_default"] = True
@@ -787,13 +787,13 @@ class ChargeDischargePower(ReadOnlySensor, HybridInverter):
             count=2,
             data_type=ModbusDataType.INT32,
             scan_interval=ScanInterval.realtime(plant_index),
-            unit=UnitOfPower.WATT,  # Protocol defines kW, but prefer the greater precision of watts
+            unit=UnitOfPower.WATT,  # ProtocolVersion defines kW, but prefer the greater precision of watts
             device_class=DeviceClass.POWER,
             state_class=StateClass.MEASUREMENT,
             icon="mdi:battery-charging-outline",
-            gain=None,  # Protocol defines kW, but prefer the greater precision of watts
+            gain=None,  # ProtocolVersion defines kW, but prefer the greater precision of watts
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["enabled_by_default"] = True
 
@@ -818,7 +818,7 @@ class InverterBatterySoC(ReadOnlySensor, HybridInverter):
             icon="mdi:home-battery-outline",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["enabled_by_default"] = True
 
@@ -843,7 +843,7 @@ class InverterBatterySoH(ReadOnlySensor, HybridInverter):
             icon="mdi:battery-heart-variant",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["enabled_by_default"] = True
 
@@ -868,7 +868,7 @@ class AverageCellTemperature(ReadOnlySensor, HybridInverter):
             icon="mdi:thermometer",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["enabled_by_default"] = True
         self.sanity_check.min_raw = -400  # -40.0 °C
@@ -895,7 +895,7 @@ class AverageCellVoltage(ReadOnlySensor, HybridInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["enabled_by_default"] = True
 
@@ -910,7 +910,7 @@ class InverterAlarm1(Alarm1Sensor, HybridInverter, PVInverter):
             plant_index=plant_index,
             device_address=device_address,
             address=self.ADDRESS,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
 
@@ -924,7 +924,7 @@ class InverterAlarm2(Alarm2Sensor, HybridInverter, PVInverter):
             plant_index=plant_index,
             device_address=device_address,
             address=self.ADDRESS,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
 
@@ -948,7 +948,7 @@ class InverterAlarm3(Alarm3Sensor, HybridInverter):
             plant_index=plant_index,
             device_address=device_address,
             address=self.ADDRESS,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
 
@@ -962,7 +962,7 @@ class InverterAlarm4(Alarm4Sensor, HybridInverter, PVInverter):
             plant_index=plant_index,
             device_address=device_address,
             address=self.ADDRESS,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
 
@@ -976,7 +976,7 @@ class InverterAlarm5(Alarm5Sensor, HybridInverter):
             plant_index=plant_index,
             device_address=device_address,
             address=self.ADDRESS,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
 
@@ -1000,7 +1000,7 @@ class Reserved30610(ReservedSensor, HybridInverter, PVInverter):
             icon="mdi:comment-question",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V2_5,
+            protocol_version=ProtocolVersion.V2_5,
         )
 
 
@@ -1024,7 +1024,7 @@ class InverterActivePowerFixedValueAdjustmentFeedback(ReadOnlySensor, HybridInve
             icon="mdi:comment-quote",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_6,
+            protocol_version=ProtocolVersion.V2_6,
         )
 
 
@@ -1048,7 +1048,7 @@ class InverterReactivePowerFixedValueAdjustmentFeedback(ReadOnlySensor, HybridIn
             icon="mdi:comment-quote",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_6,
+            protocol_version=ProtocolVersion.V2_6,
         )
 
 
@@ -1072,7 +1072,7 @@ class InverterActivePowerPercentageAdjustmentFeedback(ReadOnlySensor, HybridInve
             icon="mdi:percent",
             gain=100,
             precision=None,
-            protocol_version=Protocol.V2_6,
+            protocol_version=ProtocolVersion.V2_6,
         )
 
 
@@ -1096,7 +1096,7 @@ class InverterReactivePowerPercentageAdjustmentFeedback(ReadOnlySensor, HybridIn
             icon="mdi:percent",
             gain=100,
             precision=None,
-            protocol_version=Protocol.V2_6,
+            protocol_version=ProtocolVersion.V2_6,
         )
 
 
@@ -1120,7 +1120,7 @@ class InverterPowerFactorAdjustmentFeedback(ReadOnlySensor, HybridInverter, PVIn
             icon="mdi:adjust",
             gain=1000,
             precision=None,
-            protocol_version=Protocol.V2_6,
+            protocol_version=ProtocolVersion.V2_6,
         )
 
 
@@ -1144,7 +1144,7 @@ class InverterMaxBatteryTemperature(ReadOnlySensor, HybridInverter):
             icon="mdi:thermometer-high",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["enabled_by_default"] = True
         self.sanity_check.min_raw = -400  # -40.0 °C
@@ -1171,7 +1171,7 @@ class InverterMinBatteryTemperature(ReadOnlySensor, HybridInverter):
             icon="mdi:thermometer-low",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["enabled_by_default"] = True
         self.sanity_check.min_raw = -400  # -40.0 °C
@@ -1198,7 +1198,7 @@ class InverterMaxCellVoltage(ReadOnlySensor, HybridInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["enabled_by_default"] = True
 
@@ -1223,7 +1223,7 @@ class InverterMinCellVoltage(ReadOnlySensor, HybridInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["enabled_by_default"] = True
 
@@ -1248,7 +1248,7 @@ class RatedGridVoltage(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:flash",
             gain=10,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["entity_category"] = "diagnostic"
 
@@ -1273,7 +1273,7 @@ class RatedGridFrequency(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:sine-wave",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["entity_category"] = "diagnostic"
 
@@ -1298,7 +1298,7 @@ class GridFrequency(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:sine-wave",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
 
@@ -1322,7 +1322,7 @@ class InverterTemperature(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:thermometer",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["enabled_by_default"] = True
         self.sanity_check.min_raw = -400  # -40.0 °C
@@ -1349,7 +1349,7 @@ class OutputType(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:home-lightning-bolt",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["entity_category"] = "diagnostic"
         self[DiscoveryKeys.OPTIONS] = [
@@ -1384,7 +1384,7 @@ class OutputType(ReadOnlySensor, HybridInverter, PVInverter):
 
 
 class LineVoltage(ReadOnlySensor, HybridInverter, PVInverter):
-    # Invalid when Output Type is L/N, L1/L2/N, or L1/L2/N (sic as per Protocol V2.8 should be L1/L2/L3/N)
+    # Invalid when Output Type is L/N, L1/L2/N, or L1/L2/N (sic as per ProtocolVersion V2.8 should be L1/L2/L3/N)
     def __init__(self, plant_index: int, device_address: int, phase: str):
         match phase:
             case "A-B":
@@ -1411,7 +1411,7 @@ class LineVoltage(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:flash",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             phase=phase,
         )
         self.phase = phase
@@ -1450,7 +1450,7 @@ class PhaseVoltage(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:flash",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             phase4name=phase4name,  # Used for i18n processing
         )
         self.phase = phase
@@ -1489,7 +1489,7 @@ class PhaseCurrent(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:current-ac",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             phase4name=phase4name,  # Used for i18n processing
         )
         self.phase = phase
@@ -1516,7 +1516,7 @@ class PowerFactor(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:angle-acute",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self.sanity_check.min_raw = 0  # 0.0
         self.sanity_check.max_raw = 1000  # 1.0
@@ -1583,7 +1583,7 @@ class PACKBCUCount(ReadOnlySensor, HybridInverter):
             icon="mdi:eye",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["entity_category"] = "diagnostic"
         self.sanity_check.min_raw = 0
@@ -1610,7 +1610,7 @@ class PVStringCount(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:solar-panel",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["entity_category"] = "diagnostic"
         self.sanity_check.min_raw = 2
@@ -1637,7 +1637,7 @@ class MPPTCount(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:solar-panel",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["entity_category"] = "diagnostic"
 
@@ -1645,7 +1645,7 @@ class MPPTCount(ReadOnlySensor, HybridInverter, PVInverter):
 class PVCurrentSensor(ReadOnlySensor, HybridInverter, PVInverter):
     raw2amps: float = 100  # divisor to convert raw value to amps
 
-    def __init__(self, plant_index: int, device_address: int, address: int, string_number: int, protocol_version: Protocol):
+    def __init__(self, plant_index: int, device_address: int, address: int, string_number: int, protocol_version: ProtocolVersion):
         assert 1 <= string_number <= 36, "string_number must be between 1 and 36"
         super().__init__(
             name="Current",
@@ -1674,7 +1674,7 @@ class PVCurrentSensor(ReadOnlySensor, HybridInverter, PVInverter):
 class PVVoltageSensor(ReadOnlySensor, HybridInverter, PVInverter):
     raw2volts: float = 10  # divisor to convert raw value to volts
 
-    def __init__(self, plant_index: int, device_address: int, address: int, string_number: int, protocol_version: Protocol):
+    def __init__(self, plant_index: int, device_address: int, address: int, string_number: int, protocol_version: ProtocolVersion):
         assert 1 <= string_number <= 36, "string_number must be between 1 and 36"
         super().__init__(
             name="Voltage",
@@ -1714,13 +1714,13 @@ class InverterPVPower(ReadOnlySensor, HybridInverter, PVInverter):
             count=2,
             data_type=ModbusDataType.INT32,
             scan_interval=ScanInterval.high(plant_index),
-            unit=UnitOfPower.WATT,  # Protocol defines kW, but prefer the greater precision of watts
+            unit=UnitOfPower.WATT,  # ProtocolVersion defines kW, but prefer the greater precision of watts
             device_class=DeviceClass.POWER,
             state_class=StateClass.MEASUREMENT,
             icon="mdi:solar-power",
-            gain=None,  # Protocol defines kW, but prefer the greater precision of watts
+            gain=None,  # ProtocolVersion defines kW, but prefer the greater precision of watts
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["enabled_by_default"] = True
         self.sanity_check.min_raw = 0
@@ -1746,7 +1746,7 @@ class InsulationResistance(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:omega",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
 
@@ -1762,7 +1762,7 @@ class StartupTime(TimestampSensor, HybridInverter, PVInverter):
             device_address=device_address,
             address=self.ADDRESS,
             scan_interval=ScanInterval.low(plant_index),
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             tz=tz,
         )
 
@@ -1779,7 +1779,7 @@ class ShutdownTime(TimestampSensor, HybridInverter, PVInverter):
             device_address=device_address,
             address=self.ADDRESS,
             scan_interval=ScanInterval.low(plant_index),
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             tz=tz,
         )
         self.monitorable = False  # ShutdownTime can regularly return 0 from Modbus which causes the value to not be published but this does not indicate lack of health
@@ -1805,7 +1805,7 @@ class DCChargerVehicleBatteryVoltage(ReadOnlySensor, HybridInverter):
             icon="mdi:car-electric",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
 
@@ -1829,7 +1829,7 @@ class DCChargerVehicleChargingCurrent(ReadOnlySensor, HybridInverter):
             icon="mdi:car-electric",
             gain=10,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
 
@@ -1853,7 +1853,7 @@ class DCChargerOutputPower(ReadOnlySensor, HybridInverter):
             icon="mdi:car-electric",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
 
@@ -1877,7 +1877,7 @@ class DCChargerVehicleSoC(ReadOnlySensor, HybridInverter):
             icon="mdi:car-electric",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
 
@@ -1901,7 +1901,7 @@ class DCChargerCurrentChargingCapacity(ReadOnlySensor, HybridInverter):
             icon="mdi:car-electric",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
     def get_attributes(self) -> dict[str, float | int | str]:
@@ -1930,7 +1930,7 @@ class DCChargerCurrentChargingDuration(ReadOnlySensor, HybridInverter):
             icon="mdi:car-clock",
             gain=1,
             precision=None,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
     def get_attributes(self) -> dict[str, float | int | str]:
@@ -1945,7 +1945,7 @@ class InverterPVDailyGeneration(UnpublishResetSensorMixin, ReadOnlySensor, Hybri
     def __init__(self, plant_index: int, device_address: int):
         super().__init__(
             name="Daily Production",
-            object_id=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_inverter_{device_address}_daily_pv_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus Protocol v2.7, but need to keep the same object_id for backward compatibility
+            object_id=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_inverter_{device_address}_daily_pv_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus ProtocolVersion v2.7, but need to keep the same object_id for backward compatibility
             input_type=InputType.INPUT,
             plant_index=plant_index,
             device_address=device_address,
@@ -1959,8 +1959,8 @@ class InverterPVDailyGeneration(UnpublishResetSensorMixin, ReadOnlySensor, Hybri
             icon="mdi:solar-power-variant",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_6,
-            unique_id_override=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_inverter_{device_address}_daily_pv_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus Protocol v2.7
+            protocol_version=ProtocolVersion.V2_6,
+            unique_id_override=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_inverter_{device_address}_daily_pv_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus ProtocolVersion v2.7
         )
         self["enabled_by_default"] = True
         self.sanity_check.min_raw = None
@@ -1972,7 +1972,7 @@ class InverterPVLifetimeGeneration(UnpublishResetSensorMixin, ReadOnlySensor, Hy
     def __init__(self, plant_index: int, device_address: int):
         super().__init__(
             name="Lifetime Production",
-            object_id=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_inverter_{device_address}_lifetime_pv_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus Protocol v2.7, but need to keep the same object_id for backward compatibility
+            object_id=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_inverter_{device_address}_lifetime_pv_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus ProtocolVersion v2.7, but need to keep the same object_id for backward compatibility
             input_type=InputType.INPUT,
             plant_index=plant_index,
             device_address=device_address,
@@ -1986,13 +1986,13 @@ class InverterPVLifetimeGeneration(UnpublishResetSensorMixin, ReadOnlySensor, Hy
             icon="mdi:solar-power-variant",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_6,
-            unique_id_override=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_inverter_{device_address}_lifetime_pv_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus Protocol v2.7
+            protocol_version=ProtocolVersion.V2_6,
+            unique_id_override=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_inverter_{device_address}_lifetime_pv_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus ProtocolVersion v2.7
         )
         self["enabled_by_default"] = True
 
 
-class DCChargerRunningState(ReadOnlySensor, HybridInverter):  # Not applicable to PVInverter as per Protocol V2.9
+class DCChargerRunningState(ReadOnlySensor, HybridInverter):  # Not applicable to PVInverter as per ProtocolVersion V2.9
     ADDRESS = 31513
 
     def __init__(self, plant_index: int, device_address: int):
@@ -2012,7 +2012,7 @@ class DCChargerRunningState(ReadOnlySensor, HybridInverter):  # Not applicable t
             icon="mdi:ev-station",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V2_8,
+            protocol_version=ProtocolVersion.V2_8,
         )
         self["enabled_by_default"] = True
         self[DiscoveryKeys.OPTIONS] = [
@@ -2065,7 +2065,7 @@ class DCChargerDischargingCurrent(ReadOnlySensor, HybridInverter):
             icon="mdi:car-electric",
             gain=10,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2089,7 +2089,7 @@ class DCChargerCurrentDischargingCapacity(ReadOnlySensor, HybridInverter):
             icon="mdi:car-electric",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
     def get_attributes(self) -> dict[str, float | int | str]:
@@ -2118,7 +2118,7 @@ class DCChargerCurrentDischargingDuration(ReadOnlySensor, HybridInverter):
             icon="mdi:car-clock",
             gain=1,
             precision=None,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
     def get_attributes(self) -> dict[str, float | int | str]:
@@ -2147,7 +2147,7 @@ class DCChargerTotalChargingCapacity(ReadOnlySensor, HybridInverter):
             icon="mdi:car-electric",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2171,7 +2171,7 @@ class DCChargerTotalDischargingCapacity(ReadOnlySensor, HybridInverter):
             icon="mdi:car-electric",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2195,7 +2195,7 @@ class DCChargerRatedChargingPower(ReadOnlySensor, HybridInverter):
             icon="mdi:ev-plug-ccs2",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
         self["entity_category"] = "diagnostic"
 
@@ -2220,6 +2220,6 @@ class DCChargerRatedDischargingPower(ReadOnlySensor, HybridInverter):
             icon="mdi:ev-plug-ccs2",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
         self["entity_category"] = "diagnostic"

--- a/sigenergy2mqtt/sensors/inverter_read_write.py
+++ b/sigenergy2mqtt/sensors/inverter_read_write.py
@@ -1,4 +1,4 @@
-from sigenergy2mqtt.common import PERCENTAGE, DeviceClass, HybridInverter, InputType, Protocol, PVInverter, UnitOfPower, UnitOfReactivePower
+from sigenergy2mqtt.common import PERCENTAGE, DeviceClass, HybridInverter, InputType, ProtocolVersion, PVInverter, UnitOfPower, UnitOfReactivePower
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.modbus import ModbusDataType
 from sigenergy2mqtt.sensors.base import NumericSensor, ReservedSensor, ScanInterval, WriteOnlySensor
@@ -16,7 +16,7 @@ class InverterStatus(WriteOnlySensor, HybridInverter, PVInverter):
             plant_index=plant_index,
             device_address=device_address,
             address=self.ADDRESS,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
     def get_attributes(self) -> dict[str, float | int | str]:
@@ -45,7 +45,7 @@ class ReservedGridCode(ReservedSensor, HybridInverter):  # 40501 Marked as Reser
             icon="mdi:earth",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
 
@@ -59,7 +59,7 @@ class DCChargerStatus(WriteOnlySensor, HybridInverter):
             plant_index=plant_index,
             device_address=device_address,
             address=self.ADDRESS,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             payload_off="stop",
             payload_on="start",
             name_off="Stop",
@@ -96,7 +96,7 @@ class Reserved41001(ReservedSensor):
             icon="mdi:comment-question",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -120,7 +120,7 @@ class DCChargerMaxChargingPowerLimit(NumericSensor, HybridInverter):
             icon="mdi:ev-station",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
             minimum=0.0,
         )
 
@@ -150,7 +150,7 @@ class DCChargerMaxDischargingPowerLimit(NumericSensor, HybridInverter):
             icon="mdi:ev-station",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
             minimum=0.0,
         )
 
@@ -180,7 +180,7 @@ class ReservedInverterRemoteEMSDispatch(ReservedSensor, PVInverter):  # 41500 Ma
             icon="mdi:toggle-switch",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V2_5,
+            protocol_version=ProtocolVersion.V2_5,
         )
 
 
@@ -204,7 +204,7 @@ class InverterActivePowerFixedValueAdjustment(NumericSensor, PVInverter):
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_5,
+            protocol_version=ProtocolVersion.V2_5,
         )
 
 
@@ -228,7 +228,7 @@ class InverterReactivePowerFixedValueAdjustment(NumericSensor, PVInverter):
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_5,
+            protocol_version=ProtocolVersion.V2_5,
         )
 
 
@@ -252,7 +252,7 @@ class InverterActivePowerPercentageAdjustment(NumericSensor, PVInverter):
             icon="mdi:percent",
             gain=100,
             precision=None,
-            protocol_version=Protocol.V2_5,
+            protocol_version=ProtocolVersion.V2_5,
             minimum=-100.00,
             maximum=100.00,
         )
@@ -278,7 +278,7 @@ class InverterReactivePowerQSAdjustment(NumericSensor, PVInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=None,
-            protocol_version=Protocol.V2_5,
+            protocol_version=ProtocolVersion.V2_5,
             minimum=-60.0,
             maximum=60.0,
         )
@@ -304,7 +304,7 @@ class InverterPowerFactorAdjustment(NumericSensor, PVInverter):
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_5,
+            protocol_version=ProtocolVersion.V2_5,
             minimum=-1.0,
             maximum=1.0,
         )

--- a/sigenergy2mqtt/sensors/pid_read_only.py
+++ b/sigenergy2mqtt/sensors/pid_read_only.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sigenergy2mqtt.common import DeviceClass, InputType, Protocol, UnitOfElectricCurrent, UnitOfElectricPotential, UnitOfFrequency, UnitOfTemperature
+from sigenergy2mqtt.common import DeviceClass, InputType, ProtocolVersion, UnitOfElectricCurrent, UnitOfElectricPotential, UnitOfFrequency, UnitOfTemperature
 from sigenergy2mqtt.common.types import NonInverter
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.modbus import ModbusDataType
@@ -27,7 +27,7 @@ class PIDModelType(ReadOnlySensor, NonInverter):
             icon="mdi:information-outline",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
         self["entity_category"] = "diagnostic"
 
@@ -52,7 +52,7 @@ class PIDSerialNumber(ReadOnlySensor, NonInverter):
             icon="mdi:identifier",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
         self["entity_category"] = "diagnostic"
 
@@ -77,7 +77,7 @@ class PIDMachineFirmwareVersion(ReadOnlySensor, NonInverter):
             icon="mdi:information-outline",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
         self["entity_category"] = "diagnostic"
 
@@ -102,7 +102,7 @@ class PIDCommunicationStatus(ReadOnlySensor, NonInverter):
             icon="mdi:wifi",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
         options: list[str] = [
             "Loading",  # 0
@@ -134,7 +134,7 @@ class PIDRunningStatus(ReadOnlySensor, NonInverter):
             icon="mdi:run",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
         options: list[str] = [
             "Idle",  # 0
@@ -167,7 +167,7 @@ class PIDABLineVoltage(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -191,7 +191,7 @@ class PIDBCLineVoltage(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -215,7 +215,7 @@ class PIDCALineVoltage(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -239,7 +239,7 @@ class PIDPhaseAVoltage(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -263,7 +263,7 @@ class PIDPhaseBVoltage(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -287,7 +287,7 @@ class PIDPhaseCVoltage(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -311,7 +311,7 @@ class PIDGridFrequency(NumericSensor, NonInverter):
             icon="mdi:sine-wave",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -335,7 +335,7 @@ class PIDOutputVoltage(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -359,7 +359,7 @@ class PIDBusVoltage(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -383,7 +383,7 @@ class PIDInverterVoltage(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -407,7 +407,7 @@ class PIDInverterCurrent(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -431,7 +431,7 @@ class PIDOutputCurrent(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -455,7 +455,7 @@ class PIDInternalTemperature1(NumericSensor, NonInverter):
             icon="mdi:thermometer",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -479,7 +479,7 @@ class PIDInternalTemperature2(NumericSensor, NonInverter):
             icon="mdi:thermometer",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -503,7 +503,7 @@ class PIDInternalTemperature3(NumericSensor, NonInverter):
             icon="mdi:thermometer",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -527,7 +527,7 @@ class PIDInternalTemperature4(NumericSensor, NonInverter):
             icon="mdi:thermometer",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -551,7 +551,7 @@ class PIDInternalTemperature5(NumericSensor, NonInverter):
             icon="mdi:thermometer",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -566,7 +566,7 @@ class PIDAlarm1(AlarmSensor):
             device_address=device_address,
             address=self.ADDRESS,
             alarm_type="PID",
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
     def decode_alarm_bit(self, bit_position: int):
@@ -618,7 +618,7 @@ class PIDAlarm2(AlarmSensor):
             device_address=device_address,
             address=self.ADDRESS,
             alarm_type="PID",
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
     def decode_alarm_bit(self, bit_position: int):

--- a/sigenergy2mqtt/sensors/pid_read_write.py
+++ b/sigenergy2mqtt/sensors/pid_read_write.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.common.types import NonInverter
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.sensors.base import WriteOnlySensor
@@ -16,7 +16,7 @@ class PIDStartStop(WriteOnlySensor, NonInverter):
             plant_index=plant_index,
             device_address=device_address,
             address=self.ADDRESS,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
             payload_off="stop",
             payload_on="start",
             name_off="Stop",

--- a/sigenergy2mqtt/sensors/plant_derived.py
+++ b/sigenergy2mqtt/sensors/plant_derived.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 import paho.mqtt.client as mqtt
 
-from sigenergy2mqtt.common import ConsumptionMethod, DeviceClass, HybridInverter, Protocol, PVInverter, StateClass, UnitOfEnergy, UnitOfPower
+from sigenergy2mqtt.common import ConsumptionMethod, DeviceClass, HybridInverter, ProtocolVersion, PVInverter, StateClass, UnitOfEnergy, UnitOfPower
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.modbus import ModbusClient, ModbusDataType
 
@@ -142,7 +142,7 @@ class BatteryStatus(DerivedSensor, HybridInverter):
             "Cutoff",  # 5
             "Idle",  # 6
         ]
-        self.protocol_version = Protocol.V2_9
+        self.protocol_version = ProtocolVersion.V2_9
         self._backup_soc: float | None = None
         self._charge_soc: float | None = None
         self._current_soc: float | None = None
@@ -304,7 +304,7 @@ class GridActivity(DerivedSensor, HybridInverter):
             "Unknown",  # 2
             "Idle",  # 3
         ]
-        self.protocol_version = Protocol.V2_9
+        self.protocol_version = ProtocolVersion.V2_9
 
     def get_attributes(self) -> dict[str, float | int | str]:
         attributes = super().get_attributes()
@@ -449,13 +449,13 @@ class PlantConsumedPower(CrossDeviceDerivedSensor, HybridInverter, PVInverter):
         match self.method:
             case ConsumptionMethod.CALCULATED:
                 self._sources.update({"battery": PlantConsumedPower.Value(negate=True), "grid": PlantConsumedPower.Value(), "pv": PlantConsumedPower.Value()})
-                self.protocol_version = Protocol.N_A
+                self.protocol_version = ProtocolVersion.N_A
             case ConsumptionMethod.GENERAL:
                 self._sources.update({ConsumptionMethod.GENERAL.value: PlantConsumedPower.Value()})
-                self.protocol_version = Protocol.V2_8
+                self.protocol_version = ProtocolVersion.V2_8
             case ConsumptionMethod.TOTAL:
                 self._sources.update({ConsumptionMethod.TOTAL.value: PlantConsumedPower.Value()})
-                self.protocol_version = Protocol.V2_8
+                self.protocol_version = ProtocolVersion.V2_8
 
     def finalise_binding(self, plant_index: int, *sources: Sensor) -> bool:
         """Discover all publishable ACChargerChargingPower and DCChargerOutputPower sensors
@@ -597,7 +597,7 @@ class TotalLifetimePVEnergy(UnpublishResetSensorMixin, DerivedSensor, HybridInve
         super().__init__(
             name="Lifetime Total PV Production",
             unique_id=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_lifetime_pv_energy",
-            object_id=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_lifetime_pv_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus Protocol v2.7, but need to keep the same object_id for backward compatibility
+            object_id=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_lifetime_pv_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus ProtocolVersion v2.7, but need to keep the same object_id for backward compatibility
             data_type=ModbusDataType.UINT32,
             unit=UnitOfEnergy.KILO_WATT_HOUR,
             device_class=DeviceClass.ENERGY,
@@ -608,7 +608,7 @@ class TotalLifetimePVEnergy(UnpublishResetSensorMixin, DerivedSensor, HybridInve
             source_sensors=(plant_pv_total_generation, third_party_lifetime_pv_energy),
         )
         self["enabled_by_default"] = True
-        self.protocol_version = Protocol.V2_7
+        self.protocol_version = ProtocolVersion.V2_7
         self.plant_lifetime_pv_energy: float | None = None
         self.plant_3rd_party_lifetime_pv_energy: float | None = None
 
@@ -734,7 +734,7 @@ class PlantSelfConsumedPower(CrossDeviceDerivedSensor, HybridInverter):
             icon="mdi:battery-unknown",
             gain=None,
             precision=0,  # Intentional rounding to nearest watt
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         # _values is populated in finalise_binding() once inverter sensors are known
         self._values: dict[str, int | None] = {}

--- a/sigenergy2mqtt/sensors/plant_ess_preheating_read_write.py
+++ b/sigenergy2mqtt/sensors/plant_ess_preheating_read_write.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, cast
 
 import paho.mqtt.client as mqtt
 
-from sigenergy2mqtt.common import Constants, Protocol
+from sigenergy2mqtt.common import Constants, ProtocolVersion
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.modbus import ModbusClient, ModbusDataType
 
@@ -32,7 +32,7 @@ class ESSPreHeatingEnable(SwitchSensor, HybridInverter):
             device_address=Constants.PLANT_DEVICE_ADDRESS,
             address=self.ADDRESS,
             scan_interval=ScanInterval.high(plant_index),
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
     def get_attributes(self) -> dict[str, float | int | str]:
@@ -57,7 +57,7 @@ class ESSPreHeatingMode(SelectSensor, AvailabilityMixin, HybridInverter):
                 "Automatic",  # 0
                 "Manual",  # 1
             ],
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
         self.publish_raw = True  # Always publish raw value for Advance availability control
 
@@ -79,7 +79,7 @@ class ESSPreHeatingAdvanceEnable(SwitchSensor, HybridInverter):
             device_address=Constants.PLANT_DEVICE_ADDRESS,
             address=self.ADDRESS,
             scan_interval=ScanInterval.high(plant_index),
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
         self._use_raw_for_availability = True  # Use raw value of Preheating Mode for availability control
 
@@ -125,7 +125,7 @@ class ESSPreHeatingTOUTime(NumericSensor, HybridInverter, ABC):
             icon=icon,
             gain=1,
             precision=0,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
             slot=slot,
         )
         self[DiscoveryKeys.PLATFORM] = "time"
@@ -221,7 +221,7 @@ class ESSPreHeatingTOUTargetPower(NumericSensor, HybridInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
             min=-rated_discharging_power,
             max=rated_charging_power,
             slot=slot,
@@ -253,7 +253,7 @@ class ESSPreHeatingReservedSOC(NumericSensor, HybridInverter):
             icon="mdi:percent-box-outline",
             gain=100,
             precision=None,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
     def get_attributes(self) -> dict[str, float | int | str]:

--- a/sigenergy2mqtt/sensors/plant_read_only.py
+++ b/sigenergy2mqtt/sensors/plant_read_only.py
@@ -7,7 +7,7 @@ from sigenergy2mqtt.common import (
     DeviceClass,
     HybridInverter,
     InputType,
-    Protocol,
+    ProtocolVersion,
     PVInverter,
     StateClass,
     UnitOfApparentPower,
@@ -53,7 +53,7 @@ class SystemTime(TimestampSensor, HybridInverter, PVInverter):
             device_address=Constants.PLANT_DEVICE_ADDRESS,
             address=self.ADDRESS,
             scan_interval=ScanInterval.medium(plant_index),
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             tz=tz,
         )
         self.sanity_check.min_raw = 1640995200  # 1 January 2022 at 00:00:00 UTC
@@ -88,7 +88,7 @@ class SystemTimeZone(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:map-clock",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["entity_category"] = "diagnostic"
         self.sanity_check.min_raw = -1440  # -24 hours
@@ -139,7 +139,7 @@ class EMSWorkMode(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:pencil",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self[DiscoveryKeys.OPTIONS] = [
             "Max Self Consumption",  # 0
@@ -190,7 +190,7 @@ class GridSensorStatus(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:meter-electric-outline",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["enabled_by_default"] = True
         self[DiscoveryKeys.OPTIONS] = [
@@ -229,13 +229,13 @@ class GridSensorActivePower(ReadOnlySensor, HybridInverter, PVInverter):
             count=2,
             data_type=ModbusDataType.INT32,
             scan_interval=ScanInterval.realtime(plant_index),
-            unit=UnitOfPower.WATT,  # Protocol defines kW, but prefer the greater precision of watts
+            unit=UnitOfPower.WATT,  # ProtocolVersion defines kW, but prefer the greater precision of watts
             device_class=DeviceClass.POWER,
             state_class=StateClass.MEASUREMENT,
             icon="mdi:transmission-tower",
-            gain=None,  # Protocol defines kW, but prefer the greater precision of watts
+            gain=None,  # ProtocolVersion defines kW, but prefer the greater precision of watts
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["enabled_by_default"] = True
         self.sanity_check.max_raw = 100000  # 100kW
@@ -267,7 +267,7 @@ class GridSensorReactivePower(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:transmission-tower",
             gain=None,  # Consistent with GridSensorActivePower
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
     def get_attributes(self) -> dict[str, float | int | str]:
@@ -296,7 +296,7 @@ class GridStatus(ReadOnlySensor, HybridInverter):
             icon="mdi:meter-electric-outline",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["enabled_by_default"] = True
         self[DiscoveryKeys.OPTIONS] = [
@@ -337,7 +337,7 @@ class MaxActivePower(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["entity_category"] = "diagnostic"
 
@@ -367,7 +367,7 @@ class MaxApparentPower(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["entity_category"] = "diagnostic"
 
@@ -397,7 +397,7 @@ class PlantBatterySoC(ReadOnlySensor, HybridInverter):
             icon="mdi:home-battery-outline",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["enabled_by_default"] = True
 
@@ -431,7 +431,7 @@ class PlantPhaseActivePower(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             phase_label=phase_label,
         )
 
@@ -465,7 +465,7 @@ class PlantPhaseReactivePower(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             phase_label=phase_label,
         )
 
@@ -478,7 +478,7 @@ class GeneralAlarm1(Alarm1Sensor, HybridInverter, PVInverter):
             plant_index,
             Constants.PLANT_DEVICE_ADDRESS,
             30027,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
     def get_attributes(self) -> dict[str, float | int | str]:
@@ -495,7 +495,7 @@ class GeneralAlarm2(Alarm2Sensor, HybridInverter, PVInverter):
             plant_index,
             Constants.PLANT_DEVICE_ADDRESS,
             30028,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
     def get_attributes(self) -> dict[str, float | int | str]:
@@ -527,7 +527,7 @@ class GeneralAlarm3(Alarm3Sensor, HybridInverter):
             plant_index,
             Constants.PLANT_DEVICE_ADDRESS,
             30029,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
     def get_attributes(self) -> dict[str, float | int | str]:
@@ -544,7 +544,7 @@ class GeneralAlarm4(Alarm4Sensor, HybridInverter, PVInverter):
             plant_index,
             Constants.PLANT_DEVICE_ADDRESS,
             30030,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
     def get_attributes(self) -> dict[str, float | int | str]:
@@ -573,7 +573,7 @@ class PlantActivePower(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
 
@@ -597,7 +597,7 @@ class PlantReactivePower(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
 
@@ -615,13 +615,13 @@ class PlantPVPower(ReadOnlySensor, PVPowerSensor, HybridInverter, PVInverter):
             count=2,
             data_type=ModbusDataType.INT32,
             scan_interval=ScanInterval.realtime(plant_index),
-            unit=UnitOfPower.WATT,  # Protocol defines kW, but prefer the greater precision of watts
+            unit=UnitOfPower.WATT,  # ProtocolVersion defines kW, but prefer the greater precision of watts
             device_class=DeviceClass.POWER,
             state_class=StateClass.MEASUREMENT,
             icon="mdi:solar-power",
-            gain=None,  # Protocol defines kW, but prefer the greater precision of watts
+            gain=None,  # ProtocolVersion defines kW, but prefer the greater precision of watts
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["enabled_by_default"] = True
         self.sanity_check.min_raw = 0
@@ -641,13 +641,13 @@ class BatteryPower(ReadOnlySensor, HybridInverter):
             count=2,
             data_type=ModbusDataType.INT32,
             scan_interval=ScanInterval.realtime(plant_index),
-            unit=UnitOfPower.WATT,  # Protocol defines kW, but prefer the greater precision of watts
+            unit=UnitOfPower.WATT,  # ProtocolVersion defines kW, but prefer the greater precision of watts
             device_class=DeviceClass.POWER,
             state_class=StateClass.MEASUREMENT,
             icon="mdi:home-battery-outline",
-            gain=None,  # Protocol defines kW, but prefer the greater precision of watts
+            gain=None,  # ProtocolVersion defines kW, but prefer the greater precision of watts
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self["enabled_by_default"] = True
 
@@ -677,7 +677,7 @@ class AvailableMaxActivePower(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self.sanity_check.delta = False
         self["entity_category"] = "diagnostic"
@@ -708,7 +708,7 @@ class AvailableMinActivePower(ReadOnlySensor, HybridInverter):
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self.sanity_check.delta = False
         self["entity_category"] = "diagnostic"
@@ -739,7 +739,7 @@ class AvailableMaxReactivePower(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self.sanity_check.delta = False
         self["entity_category"] = "diagnostic"
@@ -770,7 +770,7 @@ class AvailableMinReactivePower(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self.sanity_check.delta = False
         self["entity_category"] = "diagnostic"
@@ -801,7 +801,7 @@ class AvailableMaxChargingPower(ReadOnlySensor, HybridInverter):
             icon="mdi:battery-plus-outline",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self.sanity_check.delta = False
 
@@ -831,7 +831,7 @@ class AvailableMaxDischargingPower(ReadOnlySensor, HybridInverter):
             icon="mdi:battery-minus-outline",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self.sanity_check.delta = False
 
@@ -849,7 +849,7 @@ class PlantRunningState(RunningStateSensor, HybridInverter, PVInverter):
             plant_index,
             Constants.PLANT_DEVICE_ADDRESS,
             30051,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
 
@@ -880,7 +880,7 @@ class GridPhaseActivePower(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             phase=phase,
         )
 
@@ -917,7 +917,7 @@ class GridPhaseReactivePower(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             phase=phase,
         )
 
@@ -947,7 +947,7 @@ class AvailableMaxChargingCapacity(ReadOnlySensor, HybridInverter):
             icon="mdi:battery-plus",
             gain=100,
             precision=1,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self.sanity_check.delta = False
 
@@ -977,7 +977,7 @@ class AvailableMaxDischargingCapacity(ReadOnlySensor, HybridInverter):
             icon="mdi:battery-minus",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self.sanity_check.delta = False
 
@@ -1007,7 +1007,7 @@ class PlantRatedChargingPower(ReadOnlySensor, HybridInverter):
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self.sanity_check.delta = False
         self["entity_category"] = "diagnostic"
@@ -1033,7 +1033,7 @@ class PlantRatedDischargingPower(ReadOnlySensor, HybridInverter):
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self.sanity_check.delta = False
         self["entity_category"] = "diagnostic"
@@ -1047,7 +1047,7 @@ class GeneralAlarm5(Alarm5Sensor, HybridInverter):
             plant_index,
             Constants.PLANT_DEVICE_ADDRESS,
             30072,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
     def get_attributes(self) -> dict[str, float | int | str]:
@@ -1076,7 +1076,7 @@ class Reserved30073(ReservedSensor, HybridInverter, PVInverter):
             icon="mdi:comment-question",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V2_5,
+            protocol_version=ProtocolVersion.V2_5,
         )
 
 
@@ -1100,7 +1100,7 @@ class PlantRatedEnergyCapacity(ReadOnlySensor, HybridInverter):
             icon="mdi:battery-charging",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_5,
+            protocol_version=ProtocolVersion.V2_5,
         )
         self.sanity_check.delta = False
         self["entity_category"] = "diagnostic"
@@ -1126,7 +1126,7 @@ class ChargeCutOffSoC(ReadOnlySensor, HybridInverter):
             icon="mdi:battery-charging-high",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_5,
+            protocol_version=ProtocolVersion.V2_5,
         )
 
 
@@ -1150,7 +1150,7 @@ class DischargeCutOffSoC(ReadOnlySensor, HybridInverter):
             icon="mdi:battery-charging-low",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_5,
+            protocol_version=ProtocolVersion.V2_5,
         )
 
 
@@ -1174,7 +1174,7 @@ class PlantBatterySoH(ReadOnlySensor, HybridInverter):
             icon="mdi:battery-heart-variant",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_5,
+            protocol_version=ProtocolVersion.V2_5,
         )
         self["enabled_by_default"] = True
 
@@ -1204,7 +1204,7 @@ class PlantPVTotalGeneration(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:solar-power-variant",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_6,
+            protocol_version=ProtocolVersion.V2_6,
         )
 
 
@@ -1214,7 +1214,7 @@ class TotalLoadDailyConsumption(UnpublishResetSensorMixin, ReadOnlySensor, Hybri
     def __init__(self, plant_index: int):
         super().__init__(
             name="Daily Consumption",
-            object_id=f"{active_config.home_assistant.entity_id_prefix}_{plant_index}_daily_consumed_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus Protocol v2.7, but need to keep the same object_id for backward compatibility
+            object_id=f"{active_config.home_assistant.entity_id_prefix}_{plant_index}_daily_consumed_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus ProtocolVersion v2.7, but need to keep the same object_id for backward compatibility
             input_type=InputType.INPUT,
             plant_index=plant_index,
             device_address=Constants.PLANT_DEVICE_ADDRESS,
@@ -1228,8 +1228,8 @@ class TotalLoadDailyConsumption(UnpublishResetSensorMixin, ReadOnlySensor, Hybri
             icon="mdi:home-lightning-bolt-outline",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_6,
-            unique_id_override=f"{active_config.home_assistant.entity_id_prefix}_{plant_index}_daily_consumed_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus Protocol v2.7
+            protocol_version=ProtocolVersion.V2_6,
+            unique_id_override=f"{active_config.home_assistant.entity_id_prefix}_{plant_index}_daily_consumed_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus ProtocolVersion v2.7
         )
         self["enabled_by_default"] = True
         self.sanity_check.min_raw = None
@@ -1241,7 +1241,7 @@ class TotalLoadConsumption(UnpublishResetSensorMixin, ReadOnlySensor, HybridInve
     def __init__(self, plant_index: int):
         super().__init__(
             name="Lifetime Consumption",
-            object_id=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_lifetime_consumed_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus Protocol v2.7, but need to keep the same object_id for backward compatibility
+            object_id=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_lifetime_consumed_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus ProtocolVersion v2.7, but need to keep the same object_id for backward compatibility
             input_type=InputType.INPUT,
             plant_index=plant_index,
             device_address=Constants.PLANT_DEVICE_ADDRESS,
@@ -1255,8 +1255,8 @@ class TotalLoadConsumption(UnpublishResetSensorMixin, ReadOnlySensor, HybridInve
             icon="mdi:home-lightning-bolt-outline",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_6,
-            unique_id_override=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_lifetime_consumed_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus Protocol v2.7
+            protocol_version=ProtocolVersion.V2_6,
+            unique_id_override=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_lifetime_consumed_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus ProtocolVersion v2.7
         )
         self["enabled_by_default"] = True
 
@@ -1281,7 +1281,7 @@ class SmartLoadTotalConsumption(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:lightning-bolt-circle",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_6,
+            protocol_version=ProtocolVersion.V2_6,
             smart_load_index=f"{smart_load_index:02}",
         )
 
@@ -1306,7 +1306,7 @@ class SmartLoadPower(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:lightning-bolt-outline",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_6,
+            protocol_version=ProtocolVersion.V2_6,
             smart_load_index=f"{smart_load_index:02}",
         )
 
@@ -1325,13 +1325,13 @@ class ThirdPartyPVPower(ReadOnlySensor, PVPowerSensor, HybridInverter, PVInverte
             count=2,
             data_type=ModbusDataType.INT32,
             scan_interval=ScanInterval.realtime(plant_index),
-            unit=UnitOfPower.WATT,  # Protocol defines kW, but prefer the greater precision of watts
+            unit=UnitOfPower.WATT,  # ProtocolVersion defines kW, but prefer the greater precision of watts
             device_class=DeviceClass.POWER,
             state_class=StateClass.MEASUREMENT,
             icon="mdi:solar-power",
-            gain=None,  # Protocol defines kW, but prefer the greater precision of watts
+            gain=None,  # ProtocolVersion defines kW, but prefer the greater precision of watts
             precision=2,
-            protocol_version=Protocol.V2_7,
+            protocol_version=ProtocolVersion.V2_7,
         )
         self.sanity_check.min_raw = 0
 
@@ -1356,7 +1356,7 @@ class ThirdPartyLifetimePVEnergy(ReadOnlySensor, PVPowerSensor, HybridInverter, 
             icon="mdi:solar-power-variant",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_7,
+            protocol_version=ProtocolVersion.V2_7,
         )
 
 
@@ -1366,7 +1366,7 @@ class ESSTotalChargedEnergy(UnpublishResetSensorMixin, ReadOnlySensor, HybridInv
     def __init__(self, plant_index: int):
         super().__init__(
             name="Lifetime Charge Energy",
-            object_id=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_accumulated_charge_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus Protocol v2.7, but need to keep the same object_id for backward compatibility
+            object_id=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_accumulated_charge_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus ProtocolVersion v2.7, but need to keep the same object_id for backward compatibility
             input_type=InputType.INPUT,
             plant_index=plant_index,
             device_address=Constants.PLANT_DEVICE_ADDRESS,
@@ -1380,8 +1380,8 @@ class ESSTotalChargedEnergy(UnpublishResetSensorMixin, ReadOnlySensor, HybridInv
             icon="mdi:battery-arrow-up",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_7,
-            unique_id_override=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_accumulated_charge_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus Protocol v2.7
+            protocol_version=ProtocolVersion.V2_7,
+            unique_id_override=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_accumulated_charge_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus ProtocolVersion v2.7
         )
         self["enabled_by_default"] = True
 
@@ -1392,7 +1392,7 @@ class ESSTotalDischargedEnergy(UnpublishResetSensorMixin, ReadOnlySensor, Hybrid
     def __init__(self, plant_index: int):
         super().__init__(
             name="Lifetime Discharge Energy",
-            object_id=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_accumulated_discharge_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus Protocol v2.7, but need to keep the same object_id for backward compatibility
+            object_id=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_accumulated_discharge_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus ProtocolVersion v2.7, but need to keep the same object_id for backward compatibility
             input_type=InputType.INPUT,
             plant_index=plant_index,
             device_address=Constants.PLANT_DEVICE_ADDRESS,
@@ -1406,8 +1406,8 @@ class ESSTotalDischargedEnergy(UnpublishResetSensorMixin, ReadOnlySensor, Hybrid
             icon="mdi:battery-arrow-down",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_7,
-            unique_id_override=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_accumulated_discharge_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus Protocol v2.7
+            protocol_version=ProtocolVersion.V2_7,
+            unique_id_override=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_accumulated_discharge_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus ProtocolVersion v2.7
         )
         self["enabled_by_default"] = True
 
@@ -1432,7 +1432,7 @@ class EVDCTotalChargedEnergy(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:ev-station",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_7,
+            protocol_version=ProtocolVersion.V2_7,
         )
 
 
@@ -1456,7 +1456,7 @@ class EVDCTotalDischargedEnergy(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:ev-station",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_7,
+            protocol_version=ProtocolVersion.V2_7,
         )
 
 
@@ -1466,7 +1466,7 @@ class PlantTotalImportedEnergy(UnpublishResetSensorMixin, ReadOnlySensor, Hybrid
     def __init__(self, plant_index: int):
         super().__init__(
             name="Lifetime Imported Energy",
-            object_id=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_grid_sensor_lifetime_import_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus Protocol v2.7, but need to keep the same object_id for backward compatibility
+            object_id=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_grid_sensor_lifetime_import_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus ProtocolVersion v2.7, but need to keep the same object_id for backward compatibility
             input_type=InputType.INPUT,
             plant_index=plant_index,
             device_address=Constants.PLANT_DEVICE_ADDRESS,
@@ -1480,8 +1480,8 @@ class PlantTotalImportedEnergy(UnpublishResetSensorMixin, ReadOnlySensor, Hybrid
             icon="mdi:transmission-tower-import",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_7,
-            unique_id_override=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_grid_sensor_lifetime_import_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus Protocol v2.7
+            protocol_version=ProtocolVersion.V2_7,
+            unique_id_override=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_grid_sensor_lifetime_import_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus ProtocolVersion v2.7
         )
         self["enabled_by_default"] = True
 
@@ -1492,7 +1492,7 @@ class PlantTotalExportedEnergy(UnpublishResetSensorMixin, ReadOnlySensor, Hybrid
     def __init__(self, plant_index: int):
         super().__init__(
             name="Lifetime Exported Energy",
-            object_id=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_grid_sensor_lifetime_export_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus Protocol v2.7, but need to keep the same object_id for backward compatibility
+            object_id=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_grid_sensor_lifetime_export_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus ProtocolVersion v2.7, but need to keep the same object_id for backward compatibility
             input_type=InputType.INPUT,
             plant_index=plant_index,
             device_address=Constants.PLANT_DEVICE_ADDRESS,
@@ -1506,8 +1506,8 @@ class PlantTotalExportedEnergy(UnpublishResetSensorMixin, ReadOnlySensor, Hybrid
             icon="mdi:transmission-tower-export",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_7,
-            unique_id_override=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_grid_sensor_lifetime_export_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus Protocol v2.7
+            protocol_version=ProtocolVersion.V2_7,
+            unique_id_override=f"{active_config.home_assistant.unique_id_prefix}_{plant_index}_grid_sensor_lifetime_export_energy",  # Originally was a ResettableAccumulationSensor prior to Modbus ProtocolVersion v2.7
         )
         self["enabled_by_default"] = True
 
@@ -1532,11 +1532,11 @@ class PlantTotalGeneratorOutputEnergy(ReadOnlySensor, HybridInverter, PVInverter
             icon="mdi:generator-stationary",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_7,
+            protocol_version=ProtocolVersion.V2_7,
         )
 
 
-# region New statistics interface (Modbus Protocol v2.7+)
+# region New statistics interface (Modbus ProtocolVersion v2.7+)
 
 
 class StatisticsInterfaceSensor(ReadOnlySensor, HybridInverter, PVInverter):
@@ -1565,7 +1565,7 @@ class StatisticsInterfaceSensor(ReadOnlySensor, HybridInverter, PVInverter):
             icon=icon,
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_7,
+            protocol_version=ProtocolVersion.V2_7,
         )
 
     def get_attributes(self) -> dict[str, float | int | str]:
@@ -1751,7 +1751,7 @@ class PlantPVTotalGenerationToday(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:solar-power-variant",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1775,7 +1775,7 @@ class PlantPVTotalGenerationYesterday(ReadOnlySensor, HybridInverter, PVInverter
             icon="mdi:solar-power-variant",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1799,7 +1799,7 @@ class GridCodeRatedFrequency(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:sine-wave",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_8,
+            protocol_version=ProtocolVersion.V2_8,
         )
         self.sanity_check.delta = False
         self["entity_category"] = "diagnostic"
@@ -1825,7 +1825,7 @@ class GridCodeRatedVoltage(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:flash",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_8,
+            protocol_version=ProtocolVersion.V2_8,
         )
         self.sanity_check.delta = False
         self["entity_category"] = "diagnostic"
@@ -1851,7 +1851,7 @@ class CurrentControlCommandValue(ReadOnlySensor, HybridInverter, PVInverter):
             icon="mdi:percent",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_8,
+            protocol_version=ProtocolVersion.V2_8,
         )
 
     def get_attributes(self) -> dict[str, float | int | str]:
@@ -1871,7 +1871,7 @@ class Alarm6(AlarmSensor):
             device_address=Constants.PLANT_DEVICE_ADDRESS,
             address=self.ADDRESS,
             alarm_type="Plant",
-            protocol_version=Protocol.V2_8,
+            protocol_version=ProtocolVersion.V2_8,
         )
 
     def decode_alarm_bit(self, bit_position: int):
@@ -1903,7 +1903,7 @@ class Alarm7(AlarmSensor):
             device_address=Constants.PLANT_DEVICE_ADDRESS,
             address=self.ADDRESS,
             alarm_type="Plant",
-            protocol_version=Protocol.V2_8,
+            protocol_version=ProtocolVersion.V2_8,
         )
 
     def decode_alarm_bit(self, bit_position: int):
@@ -1940,13 +1940,13 @@ class GeneralLoadPower(ReadOnlySensor, HybridInverter, PVInverter):
             count=2,
             data_type=ModbusDataType.INT32,
             scan_interval=ScanInterval.realtime(plant_index),
-            unit=UnitOfPower.WATT,  # Protocol defines kW, but prefer the greater precision of watts
+            unit=UnitOfPower.WATT,  # ProtocolVersion defines kW, but prefer the greater precision of watts
             device_class=DeviceClass.POWER,
             state_class=StateClass.MEASUREMENT,
             icon="mdi:meter-electric-outline",
-            gain=None,  # Protocol defines kW, but prefer the greater precision of watts
+            gain=None,  # ProtocolVersion defines kW, but prefer the greater precision of watts
             precision=2,
-            protocol_version=Protocol.V2_8,
+            protocol_version=ProtocolVersion.V2_8,
         )
 
 
@@ -1964,13 +1964,13 @@ class TotalLoadPower(ReadOnlySensor, HybridInverter, PVInverter):
             count=2,
             data_type=ModbusDataType.INT32,
             scan_interval=ScanInterval.realtime(plant_index),
-            unit=UnitOfPower.WATT,  # Protocol defines kW, but prefer the greater precision of watts
+            unit=UnitOfPower.WATT,  # ProtocolVersion defines kW, but prefer the greater precision of watts
             device_class=DeviceClass.POWER,
             state_class=StateClass.MEASUREMENT,
             icon="mdi:meter-electric",
-            gain=None,  # Protocol defines kW, but prefer the greater precision of watts
+            gain=None,  # ProtocolVersion defines kW, but prefer the greater precision of watts
             precision=2,
-            protocol_version=Protocol.V2_8,
+            protocol_version=ProtocolVersion.V2_8,
         )
 
 
@@ -1994,7 +1994,7 @@ class ESSAverageCellTemperature(ReadOnlySensor, HybridInverter):
             icon="mdi:thermometer",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
         self["enabled_by_default"] = True
         self.sanity_check.min_raw = -400  # -40.0 °C

--- a/sigenergy2mqtt/sensors/plant_read_write.py
+++ b/sigenergy2mqtt/sensors/plant_read_write.py
@@ -6,7 +6,7 @@ from typing import cast
 
 import paho.mqtt.client as mqtt
 
-from sigenergy2mqtt.common import PERCENTAGE, Constants, DeviceClass, HybridInverter, InputType, Protocol, PVInverter, UnitOfFrequency, UnitOfPower, UnitOfReactivePower
+from sigenergy2mqtt.common import PERCENTAGE, Constants, DeviceClass, HybridInverter, InputType, ProtocolVersion, PVInverter, UnitOfFrequency, UnitOfPower, UnitOfReactivePower
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.modbus import ModbusClient, ModbusDataType
 from sigenergy2mqtt.sensors.base import (
@@ -34,7 +34,7 @@ class PlantStatus(WriteOnlySensor, HybridInverter, PVInverter):
             plant_index=plant_index,
             device_address=Constants.PLANT_DEVICE_ADDRESS,
             address=self.ADDRESS,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
     def get_attributes(self) -> dict[str, float | int | str]:
@@ -75,7 +75,7 @@ class ActivePowerFixedAdjustmentTargetValue(NumericSensor, HybridInverter, PVInv
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         ## NOTE: Min/Max are set dynamically based on the total rated active power of the plant during main.setup_devices ##
         self._remote_ems_mode: RemoteEMSControlMode = remote_ems_mode
@@ -122,7 +122,7 @@ class ReactivePowerFixedAdjustmentTargetValue(NumericSensor, HybridInverter, PVI
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             minimum=-60.0,
             maximum=60.0,
         )
@@ -171,7 +171,7 @@ class ActivePowerPercentageAdjustmentTargetValue(NumericSensor, HybridInverter, 
             icon="mdi:percent",
             gain=100,
             precision=None,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             minimum=-100.00,
             maximum=100.00,
         )
@@ -219,7 +219,7 @@ class QSAdjustmentTargetValue(NumericSensor, HybridInverter, PVInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=None,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             minimum=-60.0,
             maximum=60.0,
         )
@@ -268,7 +268,7 @@ class PowerFactorAdjustmentTargetValue(NumericSensor, HybridInverter, PVInverter
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             minimum=(-1.0, -0.8),
             maximum=(0.8, 1.0),
         )
@@ -323,7 +323,7 @@ class PhaseActivePowerFixedAdjustmentTargetValue(ThreePhaseAdjustmentTargetValue
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             phase=phase,
             output_type=output_type,
         )
@@ -379,7 +379,7 @@ class PhaseReactivePowerFixedAdjustmentTargetValue(ThreePhaseAdjustmentTargetVal
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             phase=phase,
             output_type=output_type,
         )
@@ -435,7 +435,7 @@ class PhaseActivePowerPercentageAdjustmentTargetValue(ThreePhaseAdjustmentTarget
             icon="mdi:percent",
             gain=100,
             precision=None,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             minimum=-100.00,
             maximum=100.00,
             phase=phase,
@@ -492,7 +492,7 @@ class PhaseQSAdjustmentTargetValue(ThreePhaseAdjustmentTargetValue, HybridInvert
             icon="mdi:percent",
             gain=100,
             precision=None,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             minimum=-60.00,
             maximum=60.00,
             phase=phase,
@@ -545,7 +545,7 @@ class Reserved40026(ReservedSensor, HybridInverter, PVInverter):
             icon="mdi:comment-question",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V2_5,
+            protocol_version=ProtocolVersion.V2_5,
         )
 
 
@@ -561,7 +561,7 @@ class RemoteEMS(SwitchSensor, HybridInverter, PVInverter, AvailabilityMixin):
             device_address=Constants.PLANT_DEVICE_ADDRESS,
             address=self.ADDRESS,
             scan_interval=ScanInterval.high(plant_index),
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
     def get_attributes(self) -> dict[str, float | int | str]:
@@ -593,7 +593,7 @@ class RemoteEMSControlMode(SelectSensor, HybridInverter, PVInverter):
                 "",  # 7,
                 "V2G (Vehicle to Grid)",  # 8
             ],
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
     def configure_mqtt_topics(self, device_id: str) -> str:
@@ -654,7 +654,7 @@ class IndependentPhasePowerControl(SwitchSensor, AvailabilityMixin, HybridInvert
             device_address=Constants.PLANT_DEVICE_ADDRESS,
             address=self.ADDRESS,
             scan_interval=ScanInterval.high(plant_index),
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         if output_type != Constants.THREE_PHASE_OUTPUT_TYPE:  # L1/L2/L3/N
             self.publishable = False
@@ -683,7 +683,7 @@ class RemoteEMSLimit(NumericSensor, HybridInverter, ABC):
         address: int,
         icon: str,
         maximum: float,
-        protocol_version: Protocol,
+        protocol_version: ProtocolVersion,
     ):
         super().__init__(
             availability_control_sensor=availability_control_sensor,
@@ -745,7 +745,7 @@ class MaxChargingLimit(RemoteEMSLimit):
             address=self.ADDRESS,
             icon="mdi:battery-charging-high",
             maximum=rated_charging_power,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self.sanity_check.max_raw = Constants.UINT32_MAX  # This will be the default value read from Modbus if no value is set by user
 
@@ -778,7 +778,7 @@ class MaxDischargingLimit(RemoteEMSLimit):
             address=self.ADDRESS,
             icon="mdi:battery-charging-low",
             maximum=rated_discharging_power,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         self.sanity_check.max_raw = Constants.UINT32_MAX  # This will be the default value read from Modbus if no value is set by user
 
@@ -811,7 +811,7 @@ class PVMaxPowerLimit(RemoteEMSLimit):
             address=self.ADDRESS,
             icon="mdi:solar-power",
             maximum=4294967.295,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
     def get_attributes(self) -> dict[str, float | int | str]:
@@ -848,7 +848,7 @@ class GridMaxExportLimit(NumericSensor, HybridInverter, PVInverter):
             icon="mdi:transmission-tower-export",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_5,
+            protocol_version=ProtocolVersion.V2_5,
             maximum=4294967.295,
         )
 
@@ -878,7 +878,7 @@ class GridMaxImportLimit(NumericSensor, HybridInverter, PVInverter):
             icon="mdi:transmission-tower-import",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_5,
+            protocol_version=ProtocolVersion.V2_5,
             maximum=4294967.295,
         )
 
@@ -910,7 +910,7 @@ class PCSMaxExportLimit(NumericSensor, HybridInverter, PVInverter):
             icon="mdi:battery-negative",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_5,
+            protocol_version=ProtocolVersion.V2_5,
             maximum=4294967.294,
         )
         self.sanity_check.max_raw = Constants.UINT32_MAX
@@ -943,7 +943,7 @@ class PCSMaxImportLimit(NumericSensor, HybridInverter, PVInverter):
             icon="mdi:battery-positive",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_5,
+            protocol_version=ProtocolVersion.V2_5,
             maximum=4294967.294,
         )
         self.sanity_check.max_raw = Constants.UINT32_MAX
@@ -976,7 +976,7 @@ class PCCPowerFactorAdjustmentTargetValueGridImport(NumericSensor, HybridInverte
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
             minimum=(-1.0, -0.8),
             maximum=(0.8, 1.0),
         )
@@ -1009,7 +1009,7 @@ class PCCPowerFactorAdjustmentTargetValueGridExport(NumericSensor, HybridInverte
             icon="mdi:lightning-bolt",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
             minimum=(-1.0, -0.8),
             maximum=(0.8, 1.0),
         )
@@ -1045,7 +1045,7 @@ class ESSBackupSOC(NumericSensor, HybridInverter):
             icon="mdi:percent-box-outline",
             gain=10,
             precision=None,
-            protocol_version=Protocol.V2_6,
+            protocol_version=ProtocolVersion.V2_6,
         )
         self["enabled_by_default"] = True
 
@@ -1075,7 +1075,7 @@ class ESSChargeCutOffSOC(NumericSensor, HybridInverter):
             icon="mdi:percent-box-outline",
             gain=10,
             precision=None,
-            protocol_version=Protocol.V2_6,
+            protocol_version=ProtocolVersion.V2_6,
         )
         self["enabled_by_default"] = True
 
@@ -1105,7 +1105,7 @@ class ESSDischargeCutOffSOC(NumericSensor, HybridInverter):
             icon="mdi:percent-box-outline",
             gain=10,
             precision=None,
-            protocol_version=Protocol.V2_6,
+            protocol_version=ProtocolVersion.V2_6,
         )
         self["enabled_by_default"] = True
 
@@ -1135,7 +1135,7 @@ class ActivePowerRegulationGradient(NumericSensor, HybridInverter, PVInverter):
             icon="mdi:gradient-horizontal",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_8,
+            protocol_version=ProtocolVersion.V2_8,
             maximum=5000,
         )
 
@@ -1157,7 +1157,7 @@ class GridCodeLVRT(SwitchSensor, HybridInverter, PVInverter):
             device_address=Constants.PLANT_DEVICE_ADDRESS,
             address=self.ADDRESS,
             scan_interval=ScanInterval.medium(plant_index),
-            protocol_version=Protocol.V2_8,
+            protocol_version=ProtocolVersion.V2_8,
         )
         self["enabled_by_default"] = True
 
@@ -1182,7 +1182,7 @@ class GridCodeLVRTReactivePowerCompensationFactor(NumericSensor, HybridInverter)
             icon="mdi:counter",
             gain=100,
             precision=1,
-            protocol_version=Protocol.V2_8,
+            protocol_version=ProtocolVersion.V2_8,
             maximum=10.0,
         )
 
@@ -1212,8 +1212,8 @@ class GridCodeLVRTNegativeSequenceReactivePowerCompensationFactor(NumericSensor,
             icon="mdi:counter",
             gain=100,
             precision=1,
-            protocol_version=Protocol.V2_8,
-            maximum=20.0,  # Protocol says 0.0-10.0 but live systems are returning 20.0???? (https://github.com/seud0nym/sigenergy2mqtt/issues/80#issuecomment-3689277867)
+            protocol_version=ProtocolVersion.V2_8,
+            maximum=20.0,  # ProtocolVersion says 0.0-10.0 but live systems are returning 20.0???? (https://github.com/seud0nym/sigenergy2mqtt/issues/80#issuecomment-3689277867)
         )
 
     def get_attributes(self) -> dict[str, float | int | str]:
@@ -1242,7 +1242,7 @@ class GridCodeLVRTMode(SelectSensor, HybridInverter, PVInverter):
                 "Reactive dynamic current, active zero-current mode",  # 4
                 "Reactive power compensation current, active constant-current mode",  # 5
             ],
-            protocol_version=Protocol.V2_8,
+            protocol_version=ProtocolVersion.V2_8,
         )
         self["enabled_by_default"] = True
 
@@ -1259,7 +1259,7 @@ class GridCodeLVRTVoltageProtectionBlocking(SwitchSensor, HybridInverter, PVInve
             device_address=Constants.PLANT_DEVICE_ADDRESS,
             address=self.ADDRESS,
             scan_interval=ScanInterval.medium(plant_index),
-            protocol_version=Protocol.V2_8,
+            protocol_version=ProtocolVersion.V2_8,
         )
 
 
@@ -1275,7 +1275,7 @@ class GridCodeHVRT(SwitchSensor, HybridInverter, PVInverter):
             device_address=Constants.PLANT_DEVICE_ADDRESS,
             address=self.ADDRESS,
             scan_interval=ScanInterval.medium(plant_index),
-            protocol_version=Protocol.V2_8,
+            protocol_version=ProtocolVersion.V2_8,
         )
         self["enabled_by_default"] = True
 
@@ -1300,7 +1300,7 @@ class GridCodeHVRTReactivePowerCompensationFactor(NumericSensor, HybridInverter)
             icon="mdi:counter",
             gain=100,
             precision=1,
-            protocol_version=Protocol.V2_8,
+            protocol_version=ProtocolVersion.V2_8,
             maximum=10.0,
         )
 
@@ -1330,7 +1330,7 @@ class GridCodeHVRTNegativeSequenceReactivePowerCompensationFactor(NumericSensor,
             icon="mdi:counter",
             gain=100,
             precision=1,
-            protocol_version=Protocol.V2_8,
+            protocol_version=ProtocolVersion.V2_8,
             maximum=10.0,
         )
 
@@ -1360,7 +1360,7 @@ class GridCodeHVRTMode(SelectSensor, HybridInverter, PVInverter):
                 "Reactive dynamic current, active hold mode",  # 4
                 "Reactive power compensation current, active constant-current mode",  # 5
             ],
-            protocol_version=Protocol.V2_8,
+            protocol_version=ProtocolVersion.V2_8,
         )
         self["enabled_by_default"] = True
 
@@ -1377,7 +1377,7 @@ class GridCodeHVRTVoltageProtectionBlocking(SwitchSensor, HybridInverter, PVInve
             device_address=Constants.PLANT_DEVICE_ADDRESS,
             address=self.ADDRESS,
             scan_interval=ScanInterval.medium(plant_index),
-            protocol_version=Protocol.V2_8,
+            protocol_version=ProtocolVersion.V2_8,
         )
 
 
@@ -1393,7 +1393,7 @@ class GridCodeOverFrequencyDerating(SwitchSensor, HybridInverter, PVInverter):
             device_address=Constants.PLANT_DEVICE_ADDRESS,
             address=self.ADDRESS,
             scan_interval=ScanInterval.medium(plant_index),
-            protocol_version=Protocol.V2_8,
+            protocol_version=ProtocolVersion.V2_8,
         )
         self["enabled_by_default"] = True
 
@@ -1418,7 +1418,7 @@ class GridCodeOverFrequencyDeratingPowerRampRate(NumericSensor, HybridInverter):
             icon="mdi:percent-box-outline",
             gain=100,
             precision=1,
-            protocol_version=Protocol.V2_8,
+            protocol_version=ProtocolVersion.V2_8,
         )
 
     def get_attributes(self) -> dict[str, float | int | str]:
@@ -1447,7 +1447,7 @@ class GridCodeOverFrequencyDeratingTriggerFrequency(NumericSensor, HybridInverte
             icon="mdi:sine-wave",
             gain=100,
             precision=1,
-            protocol_version=Protocol.V2_8,
+            protocol_version=ProtocolVersion.V2_8,
             minimum=1.0 * rated_frequency,
             maximum=1.2 * rated_frequency,
         )
@@ -1478,7 +1478,7 @@ class GridCodeOverFrequencyDeratingCutOffFrequency(NumericSensor, HybridInverter
             icon="mdi:sine-wave",
             gain=100,
             precision=1,
-            protocol_version=Protocol.V2_8,
+            protocol_version=ProtocolVersion.V2_8,
             minimum=1.0 * rated_frequency,
             maximum=1.2 * rated_frequency,
         )
@@ -1501,7 +1501,7 @@ class GridCodeUnderFrequencyPowerBoost(SwitchSensor, HybridInverter, PVInverter)
             device_address=Constants.PLANT_DEVICE_ADDRESS,
             address=self.ADDRESS,
             scan_interval=ScanInterval.medium(plant_index),
-            protocol_version=Protocol.V2_8,
+            protocol_version=ProtocolVersion.V2_8,
         )
         self["enabled_by_default"] = True
 
@@ -1526,7 +1526,7 @@ class GridCodeUnderFrequencyPowerBoostPowerRampRate(NumericSensor, HybridInverte
             icon="mdi:percent-box-outline",
             gain=100,
             precision=1,
-            protocol_version=Protocol.V2_8,
+            protocol_version=ProtocolVersion.V2_8,
         )
 
     def get_attributes(self) -> dict[str, float | int | str]:
@@ -1555,7 +1555,7 @@ class GridCodeUnderFrequencyPowerBoostTriggerFrequency(NumericSensor, HybridInve
             icon="mdi:sine-wave",
             gain=100,
             precision=1,
-            protocol_version=Protocol.V2_8,
+            protocol_version=ProtocolVersion.V2_8,
             minimum=0.8 * rated_frequency,
             maximum=1.0 * rated_frequency,
         )
@@ -1586,7 +1586,7 @@ class GridCodeUnderFrequencyPowerBoostCutOffFrequency(NumericSensor, HybridInver
             icon="mdi:sine-wave",
             gain=100,
             precision=1,
-            protocol_version=Protocol.V2_8,
+            protocol_version=ProtocolVersion.V2_8,
             minimum=0.8 * rated_frequency,
             maximum=1.0 * rated_frequency,
         )
@@ -1617,7 +1617,7 @@ class Reserved40069(ReservedSensor, HybridInverter, PVInverter):
             icon="mdi:comment-question",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1631,7 +1631,7 @@ class GridPowerLossLockoutAlarmClear(WriteOnlySensor, HybridInverter, PVInverter
             plant_index=plant_index,
             device_address=Constants.PLANT_DEVICE_ADDRESS,
             address=self.ADDRESS,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
             name_off="",
             name_on="Clear",
             icon_on="mdi:lock-reset",

--- a/sigenergy2mqtt/sensors/pss_read_only.py
+++ b/sigenergy2mqtt/sensors/pss_read_only.py
@@ -4,7 +4,7 @@ from sigenergy2mqtt.common import (
     PERCENTAGE,
     DeviceClass,
     InputType,
-    Protocol,
+    ProtocolVersion,
     UnitOfApparentPower,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
@@ -41,7 +41,7 @@ class PSSModelType(ReadOnlySensor, NonInverter):
             icon="mdi:information-outline",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
         self["entity_category"] = "diagnostic"
 
@@ -66,7 +66,7 @@ class PSSSerialNumber(ReadOnlySensor, NonInverter):
             icon="mdi:identifier",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
         self["entity_category"] = "diagnostic"
 
@@ -91,7 +91,7 @@ class PSSCommunicationStatus(ReadOnlySensor, NonInverter):
             icon="mdi:wifi",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
         options: list[str] = [
             "Loading",  # 0
@@ -114,7 +114,7 @@ class PSSTeleindication1(AlarmSensor):
             device_address=device_address,
             address=self.ADDRESS,
             alarm_type="PSS",
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
     def decode_alarm_bit(self, bit_position: int):
@@ -166,7 +166,7 @@ class PSSTeleindication2(AlarmSensor):
             device_address=device_address,
             address=self.ADDRESS,
             alarm_type="PSS",
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
     def decode_alarm_bit(self, bit_position: int):
@@ -218,7 +218,7 @@ class PSSTeleindication3(AlarmSensor):
             device_address=device_address,
             address=self.ADDRESS,
             alarm_type="PSS",
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
     def decode_alarm_bit(self, bit_position: int):
@@ -270,7 +270,7 @@ class PSSTeleindication4(AlarmSensor):
             device_address=device_address,
             address=self.ADDRESS,
             alarm_type="PSS",
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
     def decode_alarm_bit(self, bit_position: int):
@@ -322,7 +322,7 @@ class PSSTeleindication5(AlarmSensor):
             device_address=device_address,
             address=self.ADDRESS,
             alarm_type="PSS",
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
     def decode_alarm_bit(self, bit_position: int):
@@ -373,7 +373,7 @@ class PSSMVPhaseACurrent(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -397,7 +397,7 @@ class PSSMVPhaseBCurrent(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -421,7 +421,7 @@ class PSSMVPhaseCCurrent(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -445,7 +445,7 @@ class PSSMVZeroSequenceCurrent(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -469,7 +469,7 @@ class PSSMVFrequency(NumericSensor, NonInverter):
             icon="mdi:sine-wave",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -493,7 +493,7 @@ class PSSMVTemperature(NumericSensor, NonInverter):
             icon="mdi:thermometer",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -517,7 +517,7 @@ class PSSMVHumidity(NumericSensor, NonInverter):
             icon="mdi:water-percent",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -541,7 +541,7 @@ class PSSMVG1CableL1PhaseTemperature(NumericSensor, NonInverter):
             icon="mdi:thermometer",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -565,7 +565,7 @@ class PSSMVG1CableL2PhaseTemperature(NumericSensor, NonInverter):
             icon="mdi:thermometer",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -589,7 +589,7 @@ class PSSMVG1CableL3PhaseTemperature(NumericSensor, NonInverter):
             icon="mdi:thermometer",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -613,7 +613,7 @@ class PSSMVG2CableL1PhaseTemperature(NumericSensor, NonInverter):
             icon="mdi:thermometer",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -637,7 +637,7 @@ class PSSMVG2CableL2PhaseTemperature(NumericSensor, NonInverter):
             icon="mdi:thermometer",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -661,7 +661,7 @@ class PSSMVG2CableL3PhaseTemperature(NumericSensor, NonInverter):
             icon="mdi:thermometer",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -685,7 +685,7 @@ class PSSMVG3CableL1PhaseTemperature(NumericSensor, NonInverter):
             icon="mdi:thermometer",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -709,7 +709,7 @@ class PSSMVG3CableL2PhaseTemperature(NumericSensor, NonInverter):
             icon="mdi:thermometer",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -733,7 +733,7 @@ class PSSMVG3CableL3PhaseTemperature(NumericSensor, NonInverter):
             icon="mdi:thermometer",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -757,7 +757,7 @@ class PSSLATemperature(NumericSensor, NonInverter):
             icon="mdi:thermometer",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -781,7 +781,7 @@ class PSSLAHumidity(NumericSensor, NonInverter):
             icon="mdi:water-percent",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -805,7 +805,7 @@ class PSSLAPhaseAVoltage(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -829,7 +829,7 @@ class PSSLAPhaseBVoltage(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -853,7 +853,7 @@ class PSSLAPhaseCVoltage(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -877,7 +877,7 @@ class PSSLAABLineVoltage(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -901,7 +901,7 @@ class PSSLABCLineVoltage(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -925,7 +925,7 @@ class PSSLACALineVoltage(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -949,7 +949,7 @@ class PSSLAPhaseACurrent(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -973,7 +973,7 @@ class PSSLAPhaseBCurrent(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -997,7 +997,7 @@ class PSSLAPhaseCCurrent(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1021,7 +1021,7 @@ class PSSLAPhaseAActivePower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1045,7 +1045,7 @@ class PSSLAPhaseBActivePower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1069,7 +1069,7 @@ class PSSLAPhaseCActivePower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1093,7 +1093,7 @@ class PSSLATotalActivePower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1117,7 +1117,7 @@ class PSSLAPhaseAReactivePower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1141,7 +1141,7 @@ class PSSLAPhaseBReactivePower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1165,7 +1165,7 @@ class PSSLAPhaseCReactivePower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1189,7 +1189,7 @@ class PSSLATotalReactivePower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1213,7 +1213,7 @@ class PSSLAPhaseAApparentPower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1237,7 +1237,7 @@ class PSSLAPhaseBApparentPower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1261,7 +1261,7 @@ class PSSLAPhaseCApparentPower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1285,7 +1285,7 @@ class PSSLATotalApparentPower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1309,7 +1309,7 @@ class PSSLAPhaseAPowerFactor(NumericSensor, NonInverter):
             icon="mdi:angle-acute",
             gain=1000,
             precision=3,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1333,7 +1333,7 @@ class PSSLAPhaseBPowerFactor(NumericSensor, NonInverter):
             icon="mdi:angle-acute",
             gain=1000,
             precision=3,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1357,7 +1357,7 @@ class PSSLAPhaseCPowerFactor(NumericSensor, NonInverter):
             icon="mdi:angle-acute",
             gain=1000,
             precision=3,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1381,7 +1381,7 @@ class PSSLATotalPowerFactor(NumericSensor, NonInverter):
             icon="mdi:angle-acute",
             gain=1000,
             precision=3,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1405,7 +1405,7 @@ class PSSLAFrequency(NumericSensor, NonInverter):
             icon="mdi:sine-wave",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1429,7 +1429,7 @@ class PSSLAForwardActiveEnergy(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1453,7 +1453,7 @@ class PSSLAReverseActiveEnergy(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1477,7 +1477,7 @@ class PSSLAForwardReactiveEnergy(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1501,7 +1501,7 @@ class PSSLAReverseReactiveEnergy(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1525,7 +1525,7 @@ class PSSLBTemperature(NumericSensor, NonInverter):
             icon="mdi:thermometer",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1549,7 +1549,7 @@ class PSSLBHumidity(NumericSensor, NonInverter):
             icon="mdi:water-percent",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1573,7 +1573,7 @@ class PSSLBPhaseAVoltage(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1597,7 +1597,7 @@ class PSSLBPhaseBVoltage(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1621,7 +1621,7 @@ class PSSLBPhaseCVoltage(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1645,7 +1645,7 @@ class PSSLBABLineVoltage(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1669,7 +1669,7 @@ class PSSLBBCLineVoltage(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1693,7 +1693,7 @@ class PSSLBCALineVoltage(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1717,7 +1717,7 @@ class PSSLBPhaseACurrent(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1741,7 +1741,7 @@ class PSSLBPhaseBCurrent(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1765,7 +1765,7 @@ class PSSLBPhaseCCurrent(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1789,7 +1789,7 @@ class PSSLBPhaseAActivePower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1813,7 +1813,7 @@ class PSSLBPhaseBActivePower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1837,7 +1837,7 @@ class PSSLBPhaseCActivePower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1861,7 +1861,7 @@ class PSSLBTotalActivePower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1885,7 +1885,7 @@ class PSSLBPhaseAReactivePower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1909,7 +1909,7 @@ class PSSLBPhaseBReactivePower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1933,7 +1933,7 @@ class PSSLBPhaseCReactivePower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1957,7 +1957,7 @@ class PSSLBTotalReactivePower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -1981,7 +1981,7 @@ class PSSLBPhaseAApparentPower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2005,7 +2005,7 @@ class PSSLBPhaseBApparentPower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2029,7 +2029,7 @@ class PSSLBPhaseCApparentPower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2053,7 +2053,7 @@ class PSSLBTotalApparentPower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2077,7 +2077,7 @@ class PSSLBPhaseAPowerFactor(NumericSensor, NonInverter):
             icon="mdi:angle-acute",
             gain=1000,
             precision=3,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2101,7 +2101,7 @@ class PSSLBPhaseBPowerFactor(NumericSensor, NonInverter):
             icon="mdi:angle-acute",
             gain=1000,
             precision=3,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2125,7 +2125,7 @@ class PSSLBPhaseCPowerFactor(NumericSensor, NonInverter):
             icon="mdi:angle-acute",
             gain=1000,
             precision=3,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2149,7 +2149,7 @@ class PSSLBTotalPowerFactor(NumericSensor, NonInverter):
             icon="mdi:angle-acute",
             gain=1000,
             precision=3,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2173,7 +2173,7 @@ class PSSLBFrequency(NumericSensor, NonInverter):
             icon="mdi:sine-wave",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2197,7 +2197,7 @@ class PSSLBForwardActiveEnergy(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2221,7 +2221,7 @@ class PSSLBReverseActiveEnergy(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2245,7 +2245,7 @@ class PSSLBForwardReactiveEnergy(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2269,7 +2269,7 @@ class PSSLBReverseReactiveEnergy(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2293,7 +2293,7 @@ class PSSTransformerOilSurfaceTemperature(NumericSensor, NonInverter):
             icon="mdi:thermometer",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2317,7 +2317,7 @@ class PSSTransformerWindingTemperature(NumericSensor, NonInverter):
             icon="mdi:thermometer",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2341,7 +2341,7 @@ class PSSDistributionCabinetTemperature(NumericSensor, NonInverter):
             icon="mdi:thermometer",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2365,7 +2365,7 @@ class PSSDistributionCabinetHumidity(NumericSensor, NonInverter):
             icon="mdi:water-percent",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2389,7 +2389,7 @@ class PSSDistributionCabinetPhaseAVoltage(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2413,7 +2413,7 @@ class PSSDistributionCabinetPhaseBVoltage(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2437,7 +2437,7 @@ class PSSDistributionCabinetPhaseCVoltage(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2461,7 +2461,7 @@ class PSSDistributionCabinetABLineVoltage(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2485,7 +2485,7 @@ class PSSDistributionCabinetBCLineVoltage(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2509,7 +2509,7 @@ class PSSDistributionCabinetCALineVoltage(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2533,7 +2533,7 @@ class PSSDistributionCabinetPhaseACurrent(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2557,7 +2557,7 @@ class PSSDistributionCabinetPhaseBCurrent(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2581,7 +2581,7 @@ class PSSDistributionCabinetPhaseCCurrent(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2605,7 +2605,7 @@ class PSSDistributionCabinetPhaseAActivePower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2629,7 +2629,7 @@ class PSSDistributionCabinetPhaseBActivePower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2653,7 +2653,7 @@ class PSSDistributionCabinetPhaseCActivePower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2677,7 +2677,7 @@ class PSSDistributionCabinetTotalActivePower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2701,7 +2701,7 @@ class PSSDistributionCabinetPhaseAReactivePower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2725,7 +2725,7 @@ class PSSDistributionCabinetPhaseBReactivePower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2749,7 +2749,7 @@ class PSSDistributionCabinetPhaseCReactivePower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2773,7 +2773,7 @@ class PSSDistributionCabinetTotalReactivePower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2797,7 +2797,7 @@ class PSSDistributionCabinetPhaseAApparentPower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2821,7 +2821,7 @@ class PSSDistributionCabinetPhaseBApparentPower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2845,7 +2845,7 @@ class PSSDistributionCabinetPhaseCApparentPower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2869,7 +2869,7 @@ class PSSDistributionCabinetTotalApparentPower(NumericSensor, NonInverter):
             icon="mdi:flash",
             gain=1000,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2893,7 +2893,7 @@ class PSSDistributionCabinetPhaseAPowerFactor(NumericSensor, NonInverter):
             icon="mdi:angle-acute",
             gain=1000,
             precision=3,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2917,7 +2917,7 @@ class PSSDistributionCabinetPhaseBPowerFactor(NumericSensor, NonInverter):
             icon="mdi:angle-acute",
             gain=1000,
             precision=3,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2941,7 +2941,7 @@ class PSSDistributionCabinetPhaseCPowerFactor(NumericSensor, NonInverter):
             icon="mdi:angle-acute",
             gain=1000,
             precision=3,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2965,7 +2965,7 @@ class PSSDistributionCabinetTotalPowerFactor(NumericSensor, NonInverter):
             icon="mdi:angle-acute",
             gain=1000,
             precision=3,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -2989,7 +2989,7 @@ class PSSDistributionCabinetFrequency(NumericSensor, NonInverter):
             icon="mdi:sine-wave",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -3013,7 +3013,7 @@ class PSSDistributionCabinetForwardActiveEnergy(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -3037,7 +3037,7 @@ class PSSDistributionCabinetReverseActiveEnergy(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -3061,7 +3061,7 @@ class PSSDistributionCabinetForwardReactiveEnergy(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )
 
 
@@ -3085,5 +3085,5 @@ class PSSDistributionCabinetReverseReactiveEnergy(NumericSensor, NonInverter):
             icon="mdi:lightning-bolt",
             gain=100,
             precision=2,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
         )

--- a/sigenergy2mqtt/sensors/pss_read_write.py
+++ b/sigenergy2mqtt/sensors/pss_read_write.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.common.types import NonInverter
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.sensors.base import WriteOnlySensor
@@ -19,7 +19,7 @@ class PSSMVCabinetG3CircuitBreakerSwitchOn(WriteOnlySensor, NonInverter):
             plant_index=plant_index,
             device_address=device_address,
             address=self.ADDRESS,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
             payload_off="no-action",
             payload_on="on",
             name_off="",
@@ -40,7 +40,7 @@ class PSSMVCabinetG3CircuitBreakerSwitchOff(WriteOnlySensor, NonInverter):
             plant_index=plant_index,
             device_address=device_address,
             address=self.ADDRESS,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
             payload_off="no-action",
             payload_on="off",
             name_off="",
@@ -61,7 +61,7 @@ class PSSLALowVoltageCabinetCircuitBreakerSwitchOn(WriteOnlySensor, NonInverter)
             plant_index=plant_index,
             device_address=device_address,
             address=self.ADDRESS,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
             payload_off="no-action",
             payload_on="on",
             name_off="",
@@ -82,7 +82,7 @@ class PSSLALowVoltageCabinetCircuitBreakerSwitchOff(WriteOnlySensor, NonInverter
             plant_index=plant_index,
             device_address=device_address,
             address=self.ADDRESS,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
             payload_off="no-action",
             payload_on="off",
             name_off="",
@@ -103,7 +103,7 @@ class PSSLBLowVoltageCabinetCircuitBreakerSwitchOn(WriteOnlySensor, NonInverter)
             plant_index=plant_index,
             device_address=device_address,
             address=self.ADDRESS,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
             payload_off="no-action",
             payload_on="on",
             name_off="",
@@ -124,7 +124,7 @@ class PSSLBLowVoltageCabinetCircuitBreakerSwitchOff(WriteOnlySensor, NonInverter
             plant_index=plant_index,
             device_address=device_address,
             address=self.ADDRESS,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
             payload_off="no-action",
             payload_on="off",
             name_off="",

--- a/sigenergy2mqtt/translations/de.yaml
+++ b/sigenergy2mqtt/translations/de.yaml
@@ -2441,7 +2441,7 @@ class:
     name: 'Sigenergy-Anlage {plant_suffix}'
   ProtocolPublished:
     name: Protokoll veröffentlicht
-  ProtocolVersion:
+  ProtocolVersionSensor:
     name: Protokollversion
   QSAdjustmentTargetValue:
     attributes:

--- a/sigenergy2mqtt/translations/en.yaml
+++ b/sigenergy2mqtt/translations/en.yaml
@@ -2441,7 +2441,7 @@ class:
     name: Sigenergy Plant {plant_suffix}
   ProtocolPublished:
     name: Protocol Published
-  ProtocolVersion:
+  ProtocolVersionSensor:
     name: Protocol Version
   QSAdjustmentTargetValue:
     attributes:

--- a/sigenergy2mqtt/translations/es.yaml
+++ b/sigenergy2mqtt/translations/es.yaml
@@ -2441,7 +2441,7 @@ class:
     name: 'Planta Sigenergy {plant_suffix}'
   ProtocolPublished:
     name: Protocolo Publicado
-  ProtocolVersion:
+  ProtocolVersionSensor:
     name: Versión del Protocolo
   QSAdjustmentTargetValue:
     attributes:

--- a/sigenergy2mqtt/translations/fr.yaml
+++ b/sigenergy2mqtt/translations/fr.yaml
@@ -2441,7 +2441,7 @@ class:
     name: 'Centrale Sigenergy {plant_suffix}'
   ProtocolPublished:
     name: Protocole Publié
-  ProtocolVersion:
+  ProtocolVersionSensor:
     name: Version du Protocole
   QSAdjustmentTargetValue:
     attributes:

--- a/sigenergy2mqtt/translations/it.yaml
+++ b/sigenergy2mqtt/translations/it.yaml
@@ -2441,7 +2441,7 @@ class:
     name: 'Impianto Sigenergy {plant_suffix}'
   ProtocolPublished:
     name: Protocollo Pubblicato
-  ProtocolVersion:
+  ProtocolVersionSensor:
     name: Versione Protocollo
   QSAdjustmentTargetValue:
     attributes:

--- a/sigenergy2mqtt/translations/ja.yaml
+++ b/sigenergy2mqtt/translations/ja.yaml
@@ -2441,7 +2441,7 @@ class:
     name: 'Sigenergy システム {plant_suffix}'
   ProtocolPublished:
     name: プロトコル公開
-  ProtocolVersion:
+  ProtocolVersionSensor:
     name: プロトコルバージョン
   QSAdjustmentTargetValue:
     attributes:

--- a/sigenergy2mqtt/translations/ko.yaml
+++ b/sigenergy2mqtt/translations/ko.yaml
@@ -2441,7 +2441,7 @@ class:
     name: Sigenergy 발전소 {plant_suffix}
   ProtocolPublished:
     name: 프로토콜 게시됨
-  ProtocolVersion:
+  ProtocolVersionSensor:
     name: 프로토콜 버전
   QSAdjustmentTargetValue:
     attributes:

--- a/sigenergy2mqtt/translations/nl.yaml
+++ b/sigenergy2mqtt/translations/nl.yaml
@@ -2441,7 +2441,7 @@ class:
     name: 'Sigenergy-installatie {plant_suffix}'
   ProtocolPublished:
     name: Protocol Gepubliceerd
-  ProtocolVersion:
+  ProtocolVersionSensor:
     name: Protocolversie
   QSAdjustmentTargetValue:
     attributes:

--- a/sigenergy2mqtt/translations/pt.yaml
+++ b/sigenergy2mqtt/translations/pt.yaml
@@ -2441,7 +2441,7 @@ class:
     name: 'Planta Sigenergy {plant_suffix}'
   ProtocolPublished:
     name: Protocolo Publicado
-  ProtocolVersion:
+  ProtocolVersionSensor:
     name: Versão do Protocolo
   QSAdjustmentTargetValue:
     attributes:

--- a/sigenergy2mqtt/translations/zh-Hans.yaml
+++ b/sigenergy2mqtt/translations/zh-Hans.yaml
@@ -2441,7 +2441,7 @@ class:
     name: 'Sigenergy 电厂 {plant_suffix}'
   ProtocolPublished:
     name: 协议发布
-  ProtocolVersion:
+  ProtocolVersionSensor:
     name: 协议版本
   QSAdjustmentTargetValue:
     attributes:

--- a/tests/integration/test_grid_outage_startup_restart.py
+++ b/tests/integration/test_grid_outage_startup_restart.py
@@ -40,6 +40,6 @@ async def test_setup_ac_chargers_schedules_restart_watcher_on_outage_skip(monkey
     schedule_mock = MagicMock()
     monkeypatch.setattr(main_mod, "_schedule_restart_on_grid_restore", schedule_mock)
 
-    await main_mod._setup_ac_chargers(0, mock_modbus_cfg, mock_plant, AsyncMock(), mock_config, main_mod.Protocol.V2_8, 0, 1)
+    await main_mod._setup_ac_chargers(0, mock_modbus_cfg, mock_plant, AsyncMock(), mock_config, main_mod.ProtocolVersion.V2_8, 0, 1)
 
     schedule_mock.assert_called_once_with(mock_modbus_cfg, 0)

--- a/tests/integration/test_mqtt_publish.py
+++ b/tests/integration/test_mqtt_publish.py
@@ -25,12 +25,12 @@ def mock_modules():
         yield
 
 
-from sigenergy2mqtt.common import (  # noqa: E402
+from sigenergy2mqtt.common import (
     DeviceClass,
-    Protocol,  # noqa: E402
+    ProtocolVersion,
     StateClass,
 )
-from sigenergy2mqtt.sensors.base import Sensor  # noqa: E402
+from sigenergy2mqtt.sensors.base import Sensor
 
 
 # Concrete sensor for testing
@@ -47,7 +47,7 @@ class MockSensor(Sensor):
                 icon="mdi:power",
                 gain=1.0,
                 precision=2,
-                protocol_version=Protocol.V2_4,
+                protocol_version=ProtocolVersion.V2_4,
             )
             self._test_state = 100.5
 

--- a/tests/unit/config/test_switches.py
+++ b/tests/unit/config/test_switches.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from sigenergy2mqtt.common import Protocol  # noqa: E402
+from sigenergy2mqtt.common import ProtocolVersion  # noqa: E402
 from sigenergy2mqtt.config import active_config  # noqa: E402
 from sigenergy2mqtt.config.settings import HomeAssistantConfig  # noqa: E402
 from sigenergy2mqtt.sensors.base import AvailabilityMixin, Sensor  # noqa: E402
@@ -22,7 +22,7 @@ class MockSensor(Sensor):
             icon="mdi:icon",
             gain=1,
             precision=1,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             **kwargs,
         )
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.i18n import _t
 from sigenergy2mqtt.persistence import state_store
 
@@ -14,7 +14,7 @@ mock_types = MagicMock()
 
 class MockHybridInverter:
     def __init__(self, *args, **kwargs):
-        self.protocol_version = kwargs.get("protocol_version", Protocol.N_A)
+        self.protocol_version = kwargs.get("protocol_version", ProtocolVersion.N_A)
 
     def __str__(self) -> str:
         return _t("HybridInverter.name", "Hybrid Inverter")
@@ -22,7 +22,7 @@ class MockHybridInverter:
 
 class MockPVInverter:
     def __init__(self, *args, **kwargs):
-        self.protocol_version = kwargs.get("protocol_version", Protocol.N_A)
+        self.protocol_version = kwargs.get("protocol_version", ProtocolVersion.N_A)
 
     def __str__(self) -> str:
         return _t("PVInverter.name", "PV Inverter")
@@ -30,7 +30,7 @@ class MockPVInverter:
 
 class MockNonInverter:
     def __init__(self, *args, **kwargs):
-        self.protocol_version = kwargs.get("protocol_version", Protocol.N_A)
+        self.protocol_version = kwargs.get("protocol_version", ProtocolVersion.N_A)
 
     def __str__(self) -> str:
         return ""

--- a/tests/unit/devices/test_device_added.py
+++ b/tests/unit/devices/test_device_added.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.devices import Device, DeviceRegistry
 
@@ -23,7 +23,7 @@ def mock_config():
 
 @pytest.mark.asyncio
 async def test_device_online_future_cancel(mock_config):
-    dev = Device("TDev", 0, "uid123", "mf", "mdl", Protocol.V1_8)
+    dev = Device("TDev", 0, "uid123", "mf", "mdl", ProtocolVersion.V1_8)
 
     loop = asyncio.get_running_loop()
     fut = loop.create_future()
@@ -36,7 +36,7 @@ async def test_device_online_future_cancel(mock_config):
 
 
 def test_device_rediscover_setter_and_type_check(mock_config):
-    dev = Device("TDev", 0, "u_idx", "mf", "mdl", Protocol.V1_8)
+    dev = Device("TDev", 0, "u_idx", "mf", "mdl", ProtocolVersion.V1_8)
     dev.rediscover = True
     assert dev.rediscover is True
     dev.rediscover = False
@@ -46,8 +46,8 @@ def test_device_rediscover_setter_and_type_check(mock_config):
 
 
 def test_add_child_device_adds_when_publishable(mock_config):
-    parent = Device("Parent", 0, "p_uid", "mf", "mdl", Protocol.V1_8)
-    child = Device("Child", 0, "c_uid", "mf", "mdl", Protocol.V1_8)
+    parent = Device("Parent", 0, "p_uid", "mf", "mdl", ProtocolVersion.V1_8)
+    child = Device("Child", 0, "c_uid", "mf", "mdl", ProtocolVersion.V1_8)
 
     # create a fake publishable sensor in child's all_sensors
     class S:

--- a/tests/unit/devices/test_device_discovery.py
+++ b/tests/unit/devices/test_device_discovery.py
@@ -2,7 +2,7 @@ import json
 import logging
 from pathlib import Path
 
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.config import Config
 from sigenergy2mqtt.devices import Device
 
@@ -39,7 +39,7 @@ def test_publish_discovery_empty(tmp_path, monkeypatch):
     cfg.home_assistant.discovery_prefix = "homeassistant"
 
     with _swap_active_config(cfg):
-        dev = Device("TestDevice", 0, "uid-123", "mf", "mdl", Protocol.N_A)
+        dev = Device("TestDevice", 0, "uid-123", "mf", "mdl", ProtocolVersion.N_A)
         dev.all_sensors = {}
         dev.publish_discovery(mqtt, clean=True)
 
@@ -63,7 +63,7 @@ def test_publish_discovery_populated_writes_file(tmp_path, monkeypatch):
     cfg.log_level = logging.DEBUG
 
     with _swap_active_config(cfg):
-        dev = Device("TestDevice2", 0, "uid-456", "mf", "mdl", Protocol.N_A)
+        dev = Device("TestDevice2", 0, "uid-456", "mf", "mdl", ProtocolVersion.N_A)
 
         # sensor returns a discovery component
         sensor = FakeSensor("s1", {"comp1": {"k": "v"}})

--- a/tests/unit/devices/test_device_missing.py
+++ b/tests/unit/devices/test_device_missing.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from sigenergy2mqtt.common import HybridInverter, Protocol
+from sigenergy2mqtt.common import HybridInverter, ProtocolVersion
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.devices import Device, DeviceRegistry, ModbusDevice
 from sigenergy2mqtt.sensors.base import (
@@ -58,7 +58,7 @@ class DummyWriteable(WriteableSensorMixin, Sensor):
         object.__setattr__(self, "debug_logging", False)
         object.__setattr__(self, "address", 1)
         object.__setattr__(self, "input_type", "holding")
-        object.__setattr__(self, "protocol_version", Protocol.V1_8)
+        object.__setattr__(self, "protocol_version", ProtocolVersion.V1_8)
         object.__setattr__(self, "parent_device", None)
 
     async def set_value(self, client, userdata, message):
@@ -79,7 +79,7 @@ class DummyWriteOnly(WriteOnlySensor):
         object.__setattr__(self, "unique_id", unique_id)
         object.__setattr__(self, "address", 1)
         object.__setattr__(self, "input_type", "holding")
-        object.__setattr__(self, "protocol_version", Protocol.V1_8)
+        object.__setattr__(self, "protocol_version", ProtocolVersion.V1_8)
         object.__setattr__(self, "debug_logging", False)
         object.__setattr__(self, "_publishable", True)
         self._values = {"off": 0, "on": 1}
@@ -152,7 +152,7 @@ def mock_config():
 
 @pytest.fixture
 def device(mock_config):
-    return Device("TestDev", 0, "uid_1", "mf", "model", Protocol.V1_8)
+    return Device("TestDev", 0, "uid_1", "mf", "model", ProtocolVersion.V1_8)
 
 
 # --- Tests ---
@@ -223,7 +223,7 @@ async def test_device_on_ha_state_change(device):
 
 
 def test_device_get_sensor(device):
-    child = Device("Child", 0, "child_uid", "mf", "model", Protocol.V1_8)
+    child = Device("Child", 0, "child_uid", "mf", "model", ProtocolVersion.V1_8)
     s_child = DummyReadable("s_child", publishable=True)
     child._add_sensor(s_child)
     device._add_child_device(child)
@@ -262,7 +262,7 @@ def test_device_get_sensor_by_type_and_child_alarm(device):
     s_parent = ParentReadable("parent_by_type", publishable=True)
     device._add_sensor(s_parent)
 
-    child = Device("ChildType", 0, "child_uid_type", "mf", "model", Protocol.V1_8)
+    child = Device("ChildType", 0, "child_uid_type", "mf", "model", ProtocolVersion.V1_8)
     s_child = ChildReadable("child_by_type", publishable=True)
     child._add_sensor(s_child)
     device._add_child_device(child)
@@ -303,7 +303,7 @@ def test_modbus_device_checks():
         def __init__(self, *args, **kwargs):
             super().__init__(HybridInverter(), *args, **kwargs)
 
-    dev = InverterDevice("Inv", 0, 1, "model", Protocol.V1_8)
+    dev = InverterDevice("Inv", 0, 1, "model", ProtocolVersion.V1_8)
 
     s_plain = DummyReadable("s_plain")
     assert dev._add_sensor(s_plain) is False
@@ -313,21 +313,21 @@ def test_modbus_device_checks():
             super().__init__(uid)
 
     s_valid = ValidInverterSensor("s_valid")
-    s_valid.protocol_version = Protocol.V1_8
+    s_valid.protocol_version = ProtocolVersion.V1_8
 
     assert dev._add_sensor(s_valid) is True
 
     s_future = ValidInverterSensor("s_future")
-    s_future.protocol_version = Protocol.V2_4
+    s_future.protocol_version = ProtocolVersion.V2_4
     assert dev._add_sensor(s_future) is False
 
 
 def test_device_registry():
     DeviceRegistry._devices.clear()
 
-    d1 = Device("d1", 0, "uid1", "mf", "md", Protocol.V1_8)
-    d2 = Device("d2", 0, "uid2", "mf", "md", Protocol.V1_8)
-    d3 = Device("d3", 1, "uid3", "mf", "md", Protocol.V1_8)
+    d1 = Device("d1", 0, "uid1", "mf", "md", ProtocolVersion.V1_8)
+    d2 = Device("d2", 0, "uid2", "mf", "md", ProtocolVersion.V1_8)
+    d3 = Device("d3", 1, "uid3", "mf", "md", ProtocolVersion.V1_8)
 
     l0 = DeviceRegistry.get(0)
     assert d1 in l0

--- a/tests/unit/devices/test_device_offline_exit.py
+++ b/tests/unit/devices/test_device_offline_exit.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.devices import Device
 from sigenergy2mqtt.devices.base.poller import SensorGroupPoller
@@ -61,7 +61,7 @@ def mock_config():
 @pytest.mark.asyncio
 async def test_device_offline_exits_loop(mock_config):
     # Setup device and sensors
-    device = ConcreteDevice("Test Device 1", 0, "sigen_test_1", "Sigenergy", "Model", Protocol.V2_4)
+    device = ConcreteDevice("Test Device 1", 0, "sigen_test_1", "Sigenergy", "Model", ProtocolVersion.V2_4)
     sensor = MockSensor("sigen_test_sensor_1")
     device._add_sensor(sensor)
 
@@ -95,8 +95,8 @@ async def test_device_offline_exits_loop(mock_config):
 @pytest.mark.asyncio
 async def test_device_offline_cancels_child_sensors(mock_config):
     # Setup parent and child devices
-    parent = ConcreteDevice("Parent 2", 0, "sigen_parent_2", "Sigenergy", "Model", Protocol.V2_4)
-    child = ConcreteDevice("Child 2", 0, "sigen_child_2", "Sigenergy", "Model", Protocol.V2_4)
+    parent = ConcreteDevice("Parent 2", 0, "sigen_parent_2", "Sigenergy", "Model", ProtocolVersion.V2_4)
+    child = ConcreteDevice("Child 2", 0, "sigen_child_2", "Sigenergy", "Model", ProtocolVersion.V2_4)
 
     # Add child sensor
     child_sensor = MockSensor("sigen_child_sensor_2", scan_interval=60)
@@ -139,7 +139,7 @@ async def test_device_offline_cancels_child_sensors(mock_config):
 @pytest.mark.asyncio
 async def test_device_offline_exits_reconnect_loop(mock_config):
     # Setup device
-    device = ConcreteDevice("Test Device 3", 0, "sigen_test_3", "Sigenergy", "Model", Protocol.V2_4)
+    device = ConcreteDevice("Test Device 3", 0, "sigen_test_3", "Sigenergy", "Model", ProtocolVersion.V2_4)
     sensor = MockSensor("sigen_test_sensor_3")
     device._add_sensor(sensor)
     poller = SensorGroupPoller(device)
@@ -178,7 +178,7 @@ async def test_device_offline_exits_reconnect_loop(mock_config):
 @pytest.mark.asyncio
 async def test_device_offline_cancels_device_sleeper_task(mock_config):
     # Setup device
-    device = ConcreteDevice("Test Device 4", 0, "sigen_test_4", "Sigenergy", "Model", Protocol.V2_4)
+    device = ConcreteDevice("Test Device 4", 0, "sigen_test_4", "Sigenergy", "Model", ProtocolVersion.V2_4)
 
     # Set online
     device.online = asyncio.Future()

--- a/tests/unit/devices/test_inverter_device_type.py
+++ b/tests/unit/devices/test_inverter_device_type.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from sigenergy2mqtt.common import HybridInverter, Protocol, PVInverter
+from sigenergy2mqtt.common import HybridInverter, ProtocolVersion, PVInverter
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.devices.inverter.inverter import Inverter
 from sigenergy2mqtt.sensors.base import Sensor
@@ -92,7 +92,7 @@ class TestInverterCreateWithDeviceType:
                 plant_index=0,
                 device_address=1,
                 device_type=device_type,
-                protocol_version=Protocol.V2_4,
+                protocol_version=ProtocolVersion.V2_4,
                 tz=timezone.utc,
                 modbus_client=mock_modbus,
             )
@@ -111,7 +111,7 @@ class TestInverterCreateWithDeviceType:
                 plant_index=0,
                 device_address=1,
                 device_type=device_type,
-                protocol_version=Protocol.V2_4,
+                protocol_version=ProtocolVersion.V2_4,
                 tz=timezone.utc,
                 modbus_client=mock_modbus,
             )
@@ -134,7 +134,7 @@ class TestInverterSensorDeviceTypeInheritance:
                 plant_index=0,
                 device_address=1,
                 device_type=device_type,
-                protocol_version=Protocol.V2_4,
+                protocol_version=ProtocolVersion.V2_4,
                 tz=timezone.utc,
                 modbus_client=mock_modbus,
             )
@@ -153,7 +153,7 @@ class TestInverterSensorDeviceTypeInheritance:
                 plant_index=0,
                 device_address=1,
                 device_type=device_type,
-                protocol_version=Protocol.V2_4,
+                protocol_version=ProtocolVersion.V2_4,
                 tz=timezone.utc,
                 modbus_client=mock_modbus,
             )
@@ -175,7 +175,7 @@ class TestInverterSensorDeviceTypeInheritance:
                 plant_index=0,
                 device_address=1,
                 device_type=HybridInverter(),
-                protocol_version=Protocol.V2_4,
+                protocol_version=ProtocolVersion.V2_4,
                 tz=timezone.utc,
                 modbus_client=mock_modbus,
             )
@@ -186,7 +186,7 @@ class TestInverterSensorDeviceTypeInheritance:
                     plant_index=0,
                     device_address=1,
                     device_type=PVInverter(),
-                    protocol_version=Protocol.V2_4,
+                    protocol_version=ProtocolVersion.V2_4,
                     tz=timezone.utc,
                     modbus_client=mock_modbus,
                 )
@@ -206,7 +206,7 @@ class TestInverterSensorDeviceTypeInheritance:
                 plant_index=0,
                 device_address=1,
                 device_type=HybridInverter(),
-                protocol_version=Protocol.V2_4,
+                protocol_version=ProtocolVersion.V2_4,
                 tz=timezone.utc,
                 modbus_client=mock_modbus,
             )
@@ -220,7 +220,7 @@ class TestInverterSensorDeviceTypeInheritance:
                     plant_index=0,
                     device_address=1,
                     device_type=PVInverter(),
-                    protocol_version=Protocol.V2_4,
+                    protocol_version=ProtocolVersion.V2_4,
                     tz=timezone.utc,
                     modbus_client=mock_modbus,
                 )

--- a/tests/unit/devices/test_polling_and_registry.py
+++ b/tests/unit/devices/test_polling_and_registry.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from pymodbus import ModbusException
 
-from sigenergy2mqtt.common import HybridInverter, InputType, Protocol
+from sigenergy2mqtt.common import HybridInverter, InputType, ProtocolVersion
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.devices import Device, DeviceRegistry, ModbusDevice
 from sigenergy2mqtt.devices.base.poller import SensorGroupPoller
@@ -22,7 +22,7 @@ from sigenergy2mqtt.sensors.base.sanity_check import SanityCheck
 
 
 class DummyReadable(ReadableSensorMixin, Sensor):
-    def __init__(self, unique_id, publishable=True, address=1, count=1, scan_interval=10, protocol_version=Protocol.V1_8):
+    def __init__(self, unique_id, publishable=True, address=1, count=1, scan_interval=10, protocol_version=ProtocolVersion.V1_8):
         self.unique_id = unique_id
         self["unique_id"] = unique_id
         object.__setattr__(self, "unique_id", unique_id)
@@ -84,7 +84,7 @@ class DummyWriteable(WriteableSensorMixin, Sensor):
         object.__setattr__(self, "debug_logging", False)
         object.__setattr__(self, "address", 1)
         object.__setattr__(self, "input_type", InputType.HOLDING)
-        object.__setattr__(self, "protocol_version", Protocol.V1_8)
+        object.__setattr__(self, "protocol_version", ProtocolVersion.V1_8)
         object.__setattr__(self, "parent_device", None)
         object.__setattr__(self, "_derived_sensors", {})
         object.__setattr__(self, "_publishable", True)
@@ -106,7 +106,7 @@ class DummyWriteable(WriteableSensorMixin, Sensor):
 
 
 class DummyWriteOnly(WriteOnlySensor):
-    def __init__(self, unique_id, protocol_version=Protocol.V1_8):
+    def __init__(self, unique_id, protocol_version=ProtocolVersion.V1_8):
         self.unique_id = unique_id
         self["unique_id"] = unique_id
         self["command_topic"] = f"cmd/{unique_id}"
@@ -147,7 +147,7 @@ class DummyObservable(ObservableMixin, ReadableSensorMixin, Sensor):
         object.__setattr__(self, "sleeper_task", None)
         object.__setattr__(self, "debug_logging", False)
         object.__setattr__(self, "scan_interval", 10)
-        object.__setattr__(self, "protocol_version", Protocol.V1_8)
+        object.__setattr__(self, "protocol_version", ProtocolVersion.V1_8)
 
     def observable_topics(self):
         return [self.topic]
@@ -177,7 +177,7 @@ class DummyObservable(ObservableMixin, ReadableSensorMixin, Sensor):
 class DummyDerived(DerivedSensor):
     """Minimal DerivedSensor stub."""
 
-    def __init__(self, unique_id, protocol_version=Protocol.V1_8):
+    def __init__(self, unique_id, protocol_version=ProtocolVersion.V1_8):
         self.unique_id = unique_id
         self["unique_id"] = unique_id
         object.__setattr__(self, "unique_id", unique_id)
@@ -202,7 +202,7 @@ class DummyDerived(DerivedSensor):
 class DummyModbusSensor(ModbusSensorMixin, DummyReadable):
     """A readable sensor that also looks like a Modbus sensor."""
 
-    def __init__(self, unique_id, address=10, count=1, device_address=1, publishable=True, protocol_version=Protocol.V1_8):
+    def __init__(self, unique_id, address=10, count=1, device_address=1, publishable=True, protocol_version=ProtocolVersion.V1_8):
         super().__init__(unique_id, publishable=publishable, address=address, count=count, protocol_version=protocol_version)
         object.__setattr__(self, "device_address", device_address)
         object.__setattr__(self, "input_type", InputType.HOLDING)
@@ -239,7 +239,7 @@ def mock_config(tmp_path):
 
 @pytest.fixture
 def device():
-    return Device("TestDev", 0, "uid_1", "mf", "model", Protocol.V1_8)
+    return Device("TestDev", 0, "uid_1", "mf", "model", ProtocolVersion.V1_8)
 
 
 # ===========================================================================
@@ -250,7 +250,7 @@ def device():
 def test_device_init_ignores_unknown_kwargs():
     """extra kwargs that are not recognised device attributes are logged and dropped."""
     with patch("sigenergy2mqtt.devices.base.device.logger") as mock_log:
-        _ = Device("TestDev", 0, "uid_extra", "mf", "model", Protocol.V1_8, unknown_kwarg="ignored")
+        _ = Device("TestDev", 0, "uid_extra", "mf", "model", ProtocolVersion.V1_8, unknown_kwarg="ignored")
         # 'unknown_kwarg' is not in the allowed set, so it should be logged as ignored
         mock_log.debug.assert_called()
     DeviceRegistry._devices.clear()
@@ -258,7 +258,7 @@ def test_device_init_ignores_unknown_kwargs():
 
 def test_device_log_identity_format_excludes_name():
     """Device log_identity should include plant/dev and not include name."""
-    dev = Device("TestDev", 0, "uid_logid", "mf", "model", Protocol.V1_8)
+    dev = Device("TestDev", 0, "uid_logid", "mf", "model", ProtocolVersion.V1_8)
     assert "plant=0" in dev.log_identity
     assert "dev=n/a" not in dev.log_identity
     assert "name=" not in dev.log_identity
@@ -267,7 +267,7 @@ def test_device_log_identity_format_excludes_name():
 
 def test_modbus_device_log_identity_refreshes_device_address():
     """ModbusDevice should refresh log_identity after setting device_address."""
-    dev = ConcreteModbusDevice(None, "TestModbusDev", 0, 7, "model", Protocol.V1_8)
+    dev = ConcreteModbusDevice(None, "TestModbusDev", 0, 7, "model", ProtocolVersion.V1_8)
     assert "plant=0,dev=7" in dev.log_identity
     assert "name=" not in dev.log_identity
     DeviceRegistry._devices.clear()
@@ -322,7 +322,7 @@ async def test_online_setter_false_cancels_future_and_propagates(device):
     """Line 116-119: setting False cancels the Future and propagates to children."""
     fut = asyncio.get_running_loop().create_future()
     device._online = fut
-    child = Device("Child", 0, "child_uid_x", "mf", "model", Protocol.V1_8)
+    child = Device("Child", 0, "child_uid_x", "mf", "model", ProtocolVersion.V1_8)
     child_fut = asyncio.get_running_loop().create_future()
     child._online = child_fut
     device.children.append(child)
@@ -341,7 +341,7 @@ async def test_online_setter_false_cancels_future_and_propagates(device):
 
 def test_add_child_device_no_publishable_sensors(device):
     """child without publishable sensors is not added to children list."""
-    child = Device("NoSensors", 0, "uid_no_sensors", "mf", "model", Protocol.V1_8)
+    child = Device("NoSensors", 0, "uid_no_sensors", "mf", "model", ProtocolVersion.V1_8)
     # No publishable sensors → child should not be appended
     device._add_child_device(child)
     assert child not in device.children
@@ -349,7 +349,7 @@ def test_add_child_device_no_publishable_sensors(device):
 
 def test_add_child_device_with_publishable_sensor(device):
     """Contrast: child with a publishable sensor IS added."""
-    child = Device("WithSensors", 0, "uid_with_sensors", "mf", "model", Protocol.V1_8)
+    child = Device("WithSensors", 0, "uid_with_sensors", "mf", "model", ProtocolVersion.V1_8)
     s = DummyReadable("s_pub", publishable=True)
     child._add_sensor(s)
     device._add_child_device(child)
@@ -363,12 +363,12 @@ def test_add_child_device_with_publishable_sensor(device):
 
 def test_add_derived_sensor_protocol_version_too_high(device):
     """Lines 323-326: derived sensor with protocol_version > device version is skipped."""
-    device.protocol_version = Protocol.V1_8
+    device.protocol_version = ProtocolVersion.V1_8
     src = DummyReadable("src_sensor")
-    src.protocol_version = Protocol.V1_8
+    src.protocol_version = ProtocolVersion.V1_8
     device._add_sensor(src)
 
-    derived = DummyDerived("derived_high_pv", protocol_version=Protocol.V2_4)
+    derived = DummyDerived("derived_high_pv", protocol_version=ProtocolVersion.V2_4)
     derived._declare_source_sensors(src)
     device._add_sensor(derived)
     # Should not be in all_sensors because its protocol_version > device's
@@ -377,12 +377,12 @@ def test_add_derived_sensor_protocol_version_too_high(device):
 
 def test_add_derived_sensor_source_protocol_version_too_high(device):
     """Lines 323-326: derived sensor skipped when source sensor has protocol_version > device."""
-    device.protocol_version = Protocol.V1_8
+    device.protocol_version = ProtocolVersion.V1_8
     src = DummyReadable("src_sensor_high")
-    src.protocol_version = Protocol.V2_4  # source too new
+    src.protocol_version = ProtocolVersion.V2_4  # source too new
     device._add_sensor(src)
 
-    derived = DummyDerived("derived_ok_pv", protocol_version=Protocol.V1_8)
+    derived = DummyDerived("derived_ok_pv", protocol_version=ProtocolVersion.V1_8)
     derived._declare_source_sensors(src)
     device._add_sensor(derived)
     assert "derived_ok_pv" not in device.all_sensors
@@ -390,7 +390,7 @@ def test_add_derived_sensor_source_protocol_version_too_high(device):
 
 def test_add_derived_sensor_source_not_found(device):
     """warning logged when source sensor is not found in device."""
-    device.protocol_version = Protocol.N_A  # skip protocol checks
+    device.protocol_version = ProtocolVersion.N_A  # skip protocol checks
     src = DummyReadable("nonexistent_src")  # never added to device
     derived = DummyDerived("derived_no_src")
 
@@ -403,7 +403,7 @@ def test_add_derived_sensor_source_not_found(device):
 def test_add_derived_sensor_no_source_sensors_after_none_removal(device):
     """error logged when all source sensors are None."""
     derived = DummyDerived("derived_none_src")
-    device.protocol_version = Protocol.N_A
+    device.protocol_version = ProtocolVersion.N_A
 
     with patch("sigenergy2mqtt.devices.base.device.logger") as mock_log:
         derived._declare_source_sensors()
@@ -764,22 +764,22 @@ def test_subscribe_observable_exception_logged(device):
 
 def test_modbus_device_explicit_unique_id():
     """unique_id kwarg is accepted and used directly."""
-    dev = ConcreteModbusDevice(None, "ExplicitUID", 0, 1, "model", Protocol.V1_8, unique_id="sigen_explicit_uid")
+    dev = ConcreteModbusDevice(None, "ExplicitUID", 0, 1, "model", ProtocolVersion.V1_8, unique_id="sigen_explicit_uid")
     assert dev.unique_id == "sigen_explicit_uid"
 
 
 def test_modbus_device_explicit_unique_id_wrong_prefix():
     """unique_id not starting with the prefix raises ValueError."""
     with pytest.raises(ValueError):
-        ConcreteModbusDevice(None, "BadUID", 0, 1, "model", Protocol.V1_8, unique_id="wrong_prefix_uid")
+        ConcreteModbusDevice(None, "BadUID", 0, 1, "model", ProtocolVersion.V1_8, unique_id="wrong_prefix_uid")
 
 
 def test_modbus_device_invalid_address():
     """ModbusDevice rejects device_address outside 1-247."""
     with pytest.raises(ValueError):
-        ConcreteModbusDevice(None, "Invalid", 0, 0, "model", Protocol.V1_8)
+        ConcreteModbusDevice(None, "Invalid", 0, 0, "model", ProtocolVersion.V1_8)
     with pytest.raises(ValueError):
-        ConcreteModbusDevice(None, "Invalid", 0, 248, "model", Protocol.V1_8)
+        ConcreteModbusDevice(None, "Invalid", 0, 248, "model", ProtocolVersion.V1_8)
 
 
 # ===========================================================================
@@ -789,16 +789,16 @@ def test_modbus_device_invalid_address():
 
 def test_modbus_device_add_read_sensor_protocol_too_high():
     """Lines 962-965: sensor with protocol_version > device is skipped."""
-    dev = ConcreteModbusDevice(None, "Dev", 0, 1, "model", Protocol.V1_8)
-    s = DummyReadable("s_high_pv", protocol_version=Protocol.V2_4)
+    dev = ConcreteModbusDevice(None, "Dev", 0, 1, "model", ProtocolVersion.V1_8)
+    s = DummyReadable("s_high_pv", protocol_version=ProtocolVersion.V2_4)
     result = dev._add_sensor(s)
     assert result is False
 
 
 def test_modbus_device_add_read_sensor_protocol_matches():
     """sensor with matching protocol_version is added."""
-    dev = ConcreteModbusDevice(None, "Dev2", 0, 2, "model", Protocol.V1_8)
-    s = DummyReadable("s_ok_pv", protocol_version=Protocol.V1_8)
+    dev = ConcreteModbusDevice(None, "Dev2", 0, 2, "model", ProtocolVersion.V1_8)
+    s = DummyReadable("s_ok_pv", protocol_version=ProtocolVersion.V1_8)
     result = dev._add_sensor(s)
     assert result is True
 
@@ -815,7 +815,7 @@ def test_modbus_device_add_writeonly_wrong_type():
         def __init__(self, *args, **kwargs):
             super().__init__(HybridInverter(), *args, **kwargs)
 
-    dev = InverterDevice("Inv2", 0, 3, "model", Protocol.V1_8)
+    dev = InverterDevice("Inv2", 0, 3, "model", ProtocolVersion.V1_8)
     wo = DummyWriteOnly("wo_wrong_type")  # Not a HybridInverter subclass
     dev._add_sensor(wo)
     assert "wo_wrong_type" not in dev.write_sensors
@@ -823,16 +823,16 @@ def test_modbus_device_add_writeonly_wrong_type():
 
 def test_modbus_device_add_writeonly_protocol_too_high():
     """Lines 1020-1025: WriteOnly sensor with too-high protocol version is skipped."""
-    dev = ConcreteModbusDevice(None, "Dev3", 0, 4, "model", Protocol.V1_8)
-    wo = DummyWriteOnly("wo_high_pv", protocol_version=Protocol.V2_4)
+    dev = ConcreteModbusDevice(None, "Dev3", 0, 4, "model", ProtocolVersion.V1_8)
+    wo = DummyWriteOnly("wo_high_pv", protocol_version=ProtocolVersion.V2_4)
     dev._add_sensor(wo)
     assert "wo_high_pv" not in dev.write_sensors
 
 
 def test_modbus_device_add_writeonly_valid():
     """Valid WriteOnly sensor is added."""
-    dev = ConcreteModbusDevice(None, "Dev4", 0, 5, "model", Protocol.V1_8)
-    wo = DummyWriteOnly("wo_valid", protocol_version=Protocol.V1_8)
+    dev = ConcreteModbusDevice(None, "Dev4", 0, 5, "model", ProtocolVersion.V1_8)
+    wo = DummyWriteOnly("wo_valid", protocol_version=ProtocolVersion.V1_8)
     dev._add_sensor(wo)
     assert "wo_valid" in dev.write_sensors
 
@@ -923,7 +923,7 @@ def test_add_to_all_sensors_debug_logging_enabled(device):
 
 def test_publish_availability_propagates_to_children(device):
     """publish_availability is called on each child device."""
-    child = Device("Child", 0, "uid_child_avail", "mf", "model", Protocol.V1_8)
+    child = Device("Child", 0, "uid_child_avail", "mf", "model", ProtocolVersion.V1_8)
     device.children.append(child)
 
     mqtt_client = MagicMock()
@@ -961,7 +961,7 @@ def test_publish_discovery_clean(device):
 
 def test_publish_discovery_with_components():
     """Lines 1167+: discovery JSON is published when sensors have components."""
-    dev = Device("Disco", 0, "uid_disco", "mf", "model", Protocol.V1_8)
+    dev = Device("Disco", 0, "uid_disco", "mf", "model", ProtocolVersion.V1_8)
     s = DummyReadable("s_disco")
     s.get_discovery = MagicMock(return_value={"s_disco": {"platform": "sensor"}})
     dev.all_sensors["s_disco"] = s
@@ -981,7 +981,7 @@ def test_publish_discovery_with_components():
 
 def test_publish_attributes_propagates_to_children(device):
     """publish_attributes propagates to child devices."""
-    child = Device("AttrChild", 0, "uid_attr_child", "mf", "model", Protocol.V1_8)
+    child = Device("AttrChild", 0, "uid_attr_child", "mf", "model", ProtocolVersion.V1_8)
     device.children.append(child)
     child.publish_attributes = MagicMock()
     device.publish_attributes(MagicMock(), propagate=True)
@@ -990,7 +990,7 @@ def test_publish_attributes_propagates_to_children(device):
 
 def test_publish_attributes_no_propagation(device):
     """propagate=False does not call children."""
-    child = Device("AttrChild2", 0, "uid_attr_child2", "mf", "model", Protocol.V1_8)
+    child = Device("AttrChild2", 0, "uid_attr_child2", "mf", "model", ProtocolVersion.V1_8)
     device.children.append(child)
     child.publish_attributes = MagicMock()
     device.publish_attributes(MagicMock(), propagate=False)
@@ -1004,8 +1004,8 @@ def test_publish_attributes_no_propagation(device):
 
 def test_device_registry_clear():
     """Lines 1266-1267: DeviceRegistry.clear removes all entries."""
-    Device("R1", 0, "uid_r1", "mf", "m", Protocol.V1_8)
-    Device("R2", 1, "uid_r2", "mf", "m", Protocol.V1_8)
+    Device("R1", 0, "uid_r1", "mf", "m", ProtocolVersion.V1_8)
+    Device("R2", 1, "uid_r2", "mf", "m", ProtocolVersion.V1_8)
     DeviceRegistry.clear()
     assert DeviceRegistry.get(0) == []
     assert DeviceRegistry.get(1) == []
@@ -1020,7 +1020,7 @@ def test_device_registry_get_missing_plant():
 def test_device_registry_returns_copy():
     """DeviceRegistry.get returns a copy so mutations don't affect registry."""
     DeviceRegistry.clear()
-    d = Device("Copy", 0, "uid_copy", "mf", "m", Protocol.V1_8)
+    d = Device("Copy", 0, "uid_copy", "mf", "m", ProtocolVersion.V1_8)
     lst = DeviceRegistry.get(0)
     lst.clear()
     assert d in DeviceRegistry.get(0)

--- a/tests/unit/devices/test_protocol.py
+++ b/tests/unit/devices/test_protocol.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.devices import Device, DeviceRegistry
 from sigenergy2mqtt.sensors.base import DerivedSensor, ReadableSensorMixin, SanityCheck
@@ -36,7 +36,7 @@ def cleanup_registry():
 
 
 class DummyDerived(DerivedSensor):
-    def __init__(self, unique_id, protocol_version=Protocol.N_A):
+    def __init__(self, unique_id, protocol_version=ProtocolVersion.N_A):
         dict.__init__(self)  # Initialize dict!
         self["unique_id"] = unique_id
         object.__setattr__(self, "unique_id", unique_id)
@@ -62,7 +62,7 @@ class DummyDerived(DerivedSensor):
 
 
 class DummySensor(ReadableSensorMixin):
-    def __init__(self, unique_id, protocol_version=Protocol.N_A):
+    def __init__(self, unique_id, protocol_version=ProtocolVersion.N_A):
         dict.__init__(self)  # Initialize dict!
         self["unique_id"] = unique_id
         object.__setattr__(self, "unique_id", unique_id)
@@ -97,11 +97,11 @@ def test_add_derived_sensor_skips_newer_protocol(caplog):
     """Test that a derived sensor with newer protocol version than device is skipped."""
     caplog.set_level(logging.DEBUG)
 
-    device = Device("test_dev", 0, "test_id", "manu", "model", protocol_version=Protocol.V1_8)
+    device = Device("test_dev", 0, "test_id", "manu", "model", protocol_version=ProtocolVersion.V1_8)
 
     # Create a sensor with newer protocol
-    sensor = DummyDerived("newer_sensor", protocol_version=Protocol.V2_0)
-    source = DummySensor("source", protocol_version=Protocol.V1_8)
+    sensor = DummyDerived("newer_sensor", protocol_version=ProtocolVersion.V2_0)
+    source = DummySensor("source", protocol_version=ProtocolVersion.V1_8)
 
     # Add source
     device._add_sensor(source)
@@ -115,17 +115,17 @@ def test_add_derived_sensor_skips_newer_protocol(caplog):
     if "newer_sensor" in device.all_sensors:
         pytest.fail("newer_sensor was added but should have been skipped due to protocol version mismatch")
 
-    assert "skipped adding DummyDerived - Protocol version" in caplog.text
+    assert "skipped adding DummyDerived - ProtocolVersion version" in caplog.text
 
 
 def test_add_derived_sensor_skips_newer_source_protocol(caplog):
     """Test that if a source sensor has newer protocol, the derived sensor is skipped."""
     caplog.set_level(logging.DEBUG)
 
-    device = Device("test_dev", 0, "test_id", "manu", "model", protocol_version=Protocol.V1_8)
+    device = Device("test_dev", 0, "test_id", "manu", "model", protocol_version=ProtocolVersion.V1_8)
 
-    sensor = DummyDerived("ok_sensor", protocol_version=Protocol.V1_8)
-    source = DummySensor("newer_source", protocol_version=Protocol.V2_0)
+    sensor = DummyDerived("ok_sensor", protocol_version=ProtocolVersion.V1_8)
+    source = DummySensor("newer_source", protocol_version=ProtocolVersion.V2_0)
 
     device._add_sensor(source)
 
@@ -135,15 +135,15 @@ def test_add_derived_sensor_skips_newer_source_protocol(caplog):
     if "ok_sensor" in device.all_sensors:
         pytest.fail("ok_sensor was added but should have been skipped due to source sensor protocol version mismatch")
 
-    assert "skipped adding DummyDerived - one or more source sensors have Protocol version" in caplog.text
+    assert "skipped adding DummyDerived - one or more source sensors have ProtocolVersion version" in caplog.text
 
 
 def test_add_derived_sensor_ok_protocol(caplog):
     """Test that compatible protocol versions allow adding."""
-    device = Device("test_dev", 0, "test_id", "manu", "model", protocol_version=Protocol.V2_0)
+    device = Device("test_dev", 0, "test_id", "manu", "model", protocol_version=ProtocolVersion.V2_0)
 
-    sensor = DummyDerived("ok_sensor", protocol_version=Protocol.V1_8)
-    source = DummySensor("source", protocol_version=Protocol.V1_8)
+    sensor = DummyDerived("ok_sensor", protocol_version=ProtocolVersion.V1_8)
+    source = DummySensor("source", protocol_version=ProtocolVersion.V1_8)
 
     device._add_sensor(source)
 

--- a/tests/unit/devices/test_publish.py
+++ b/tests/unit/devices/test_publish.py
@@ -9,7 +9,7 @@ from paho.mqtt.client import Client as MqttClient
 from pymodbus import ModbusException
 from pymodbus.pdu import ExceptionResponse
 
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.devices import Device
 from sigenergy2mqtt.devices.base.poller import SensorGroupPoller
@@ -136,7 +136,7 @@ async def test_publish_updates_runs_one_iteration(monkeypatch):
     monkeypatch.setattr(asyncio, "sleep", mock_sleep)
     # ------------------------------
 
-    dev = Device("devpub", 0, "uidpub", "mf", "mdl", Protocol.V1_8)
+    dev = Device("devpub", 0, "uidpub", "mf", "mdl", ProtocolVersion.V1_8)
 
     # create two modbus sensors
     s1 = DummyModbusSensor("s1", address=1, count=2, device_address=5, scan_interval=1)
@@ -172,7 +172,7 @@ async def test_publish_updates_runs_one_iteration(monkeypatch):
 @pytest.mark.asyncio
 async def test_publish_updates_read_ahead_error_code_switch(monkeypatch):
     """If read_ahead_registers returns code 2 the code should disable multiple pre-reads and still publish sensors."""
-    dev = Device("devpub2", 0, "uidpub2", "mf", "mdl", Protocol.V1_8)
+    dev = Device("devpub2", 0, "uidpub2", "mf", "mdl", ProtocolVersion.V1_8)
     s1 = DummyModbusSensor("s1", address=10, count=2, device_address=7, scan_interval=1)
     s2 = DummyModbusSensor("s2", address=12, count=1, device_address=7, scan_interval=1)
     dev._add_sensor(s1)
@@ -211,7 +211,7 @@ async def test_publish_updates_read_ahead_error_code_switch(monkeypatch):
 async def test_publish_updates_handles_modbus_exception_and_reconnect(monkeypatch):
     """If ModbusException occurs the device attempts to reconnect via modbus.connect."""
 
-    dev = Device("devpub3", 0, "uidpub3", "mf", "mdl", Protocol.V1_8)
+    dev = Device("devpub3", 0, "uidpub3", "mf", "mdl", ProtocolVersion.V1_8)
     s1 = DummyModbusSensor("s1", address=1, count=1, device_address=2, scan_interval=1)
     s2 = DummyModbusSensor("s2", address=2, count=1, device_address=2, scan_interval=1)
     dev._add_sensor(s1)
@@ -275,7 +275,7 @@ async def test_publish_updates_day_change_forces_daily_sensor(monkeypatch):
     """When tm_yday changes between iterations, sensors with EnergyDailyAccumulationSensor
     derived sensors are forced to publish immediately (covers device.py lines 1017-1025)."""
 
-    dev = Device("devpub4", 0, "uidpub4", "mf", "mdl", Protocol.V1_8)
+    dev = Device("devpub4", 0, "uidpub4", "mf", "mdl", ProtocolVersion.V1_8)
 
     # A daily sensor whose derived_sensors include an EnergyDailyAccumulationSensor
     daily = DummyModbusSensor("daily1", address=1, count=1, device_address=3, scan_interval=60)
@@ -359,7 +359,7 @@ async def test_publish_updates_day_change_forces_daily_sensor(monkeypatch):
 @pytest.mark.asyncio
 async def test_poller_skips_unpublishable_sensors(monkeypatch):
     """Ensure _get_sensors_to_publish_now correctly skips sensors where publishable == False."""
-    dev = Device("devpub5", 0, "uidpub5", "mf", "mdl", Protocol.V1_8)
+    dev = Device("devpub5", 0, "uidpub5", "mf", "mdl", ProtocolVersion.V1_8)
 
     s1 = DummyModbusSensor("s1", address=1, count=1, device_address=1, scan_interval=1)
     s2 = DummyModbusSensor("s2", address=2, count=1, device_address=1, scan_interval=1)
@@ -403,7 +403,7 @@ async def test_poller_read_ahead_exception_codes(monkeypatch, caplog):
     import logging
 
     caplog.set_level(logging.WARNING)
-    dev = Device("devpub6", 0, "uidpub6", "mf", "mdl", Protocol.V1_8)
+    dev = Device("devpub6", 0, "uidpub6", "mf", "mdl", ProtocolVersion.V1_8)
     s1 = DummyModbusSensor("s1", address=10, count=2, device_address=7, scan_interval=1)
     s2 = DummyModbusSensor("s2", address=12, count=1, device_address=7, scan_interval=1)
     dev._add_sensor(s1)
@@ -479,7 +479,7 @@ async def test_poller_read_ahead_exception_codes(monkeypatch, caplog):
 @pytest.mark.asyncio
 async def test_poller_reconnect_cancellation(monkeypatch, caplog):
     """Mock modbus.connect to raise asyncio.CancelledError and ensure _reconnect_modbus_with_backoff returns False properly."""
-    dev = Device("devpub7", 0, "uidpub7", "mf", "mdl", Protocol.V1_8)
+    dev = Device("devpub7", 0, "uidpub7", "mf", "mdl", ProtocolVersion.V1_8)
     s1 = DummyModbusSensor("s1", address=10, count=2, device_address=7, scan_interval=1)
     dev._add_sensor(s1)
 
@@ -529,7 +529,7 @@ async def test_poller_run_sleep_cancelled(monkeypatch, caplog):
     """Raise asyncio.CancelledError from the sleep task in run and ensure it's caught."""
     import logging
 
-    dev = Device("devpub8", 0, "uidpub8", "mf", "mdl", Protocol.V1_8)
+    dev = Device("devpub8", 0, "uidpub8", "mf", "mdl", ProtocolVersion.V1_8)
     s1 = DummyModbusSensor("s1", address=10, count=2, device_address=7, scan_interval=1)
     dev._add_sensor(s1)
     dev._online = True
@@ -581,7 +581,7 @@ async def test_poller_run_sleep_cancelled(monkeypatch, caplog):
 @pytest.mark.asyncio
 async def test_poller_run_handles_generic_exception(monkeypatch, caplog):
     """Throw a generic Exception from sensor.publish and verify run catches it and logs an error without crashing."""
-    dev = Device("devpub9", 0, "uidpub9", "mf", "mdl", Protocol.V1_8)
+    dev = Device("devpub9", 0, "uidpub9", "mf", "mdl", ProtocolVersion.V1_8)
     s1 = DummyModbusSensor("s1", address=10, count=2, device_address=7, scan_interval=1)
     dev._add_sensor(s1)
 

--- a/tests/unit/devices/test_resilience.py
+++ b/tests/unit/devices/test_resilience.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 import pytest
 from pymodbus import ModbusException
 
-from sigenergy2mqtt.common import InputType, Protocol
+from sigenergy2mqtt.common import InputType, ProtocolVersion
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.devices import Device, DeviceRegistry
 from sigenergy2mqtt.devices.base.poller import SensorGroupPoller
@@ -87,7 +87,7 @@ async def fast_sleep(duration):
 
 @pytest.mark.asyncio
 async def test_modbus_exception_recovery(mock_config):
-    dev = Device("test", 0, "sigen_uid", "mf", "mdl", Protocol.V1_8)
+    dev = Device("test", 0, "sigen_uid", "mf", "mdl", ProtocolVersion.V1_8)
     sensor1 = DummyModbusSensor("sigen_s1", address=100)
     sensor2 = DummyModbusSensor("sigen_s1b", address=101)  # Add second sensor for multiple-sensor path
     dev._add_sensor(cast(Sensor, sensor1))
@@ -133,7 +133,7 @@ async def test_modbus_exception_recovery(mock_config):
 
 @pytest.mark.asyncio
 async def test_reconnection_interruption_on_offline(mock_config):
-    dev = Device("test", 0, "sigen_uid2", "mf", "mdl", Protocol.V1_8)
+    dev = Device("test", 0, "sigen_uid2", "mf", "mdl", ProtocolVersion.V1_8)
     sensor = DummyModbusSensor("sigen_s2", address=100)
     dev._add_sensor(cast(Sensor, sensor))
 

--- a/tests/unit/devices/test_runtime_behaviors.py
+++ b/tests/unit/devices/test_runtime_behaviors.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 import paho.mqtt.client as mqtt
 import pytest
 
-from sigenergy2mqtt.common import HybridInverter, Protocol
+from sigenergy2mqtt.common import HybridInverter, ProtocolVersion
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.devices import ESS, ACCharger, DCCharger, Device, DeviceRegistry, Inverter, PowerPlant, PVString
 from sigenergy2mqtt.modbus import ModbusClient
@@ -24,7 +24,7 @@ class DummyReadable(ReadableSensorMixin):
         object.__setattr__(self, "device_address", device_address)
         object.__setattr__(self, "input_type", input_type)
         object.__setattr__(self, "debug_logging", debug_logging)
-        object.__setattr__(self, "protocol_version", Protocol.V1_8)
+        object.__setattr__(self, "protocol_version", ProtocolVersion.V1_8)
         object.__setattr__(self, "_publishable", publishable)
         object.__setattr__(self, "_states", [])
         object.__setattr__(self, "derived_sensors", {})
@@ -50,7 +50,7 @@ class DummyReadable(ReadableSensorMixin):
 class DummyDerived(DerivedSensor):
     def __init__(self, unique_id="derived"):
         object.__setattr__(self, "unique_id", unique_id)
-        object.__setattr__(self, "protocol_version", Protocol.V1_8)
+        object.__setattr__(self, "protocol_version", ProtocolVersion.V1_8)
         object.__setattr__(self, "debug_logging", False)
         object.__setattr__(self, "_log_identity", unique_id)
 
@@ -73,7 +73,7 @@ def mock_config():
 
 @pytest.mark.asyncio
 async def test_device_online_setter_and_rediscover():
-    dev = Device("dev", 0, "uid", "mf", "mdl", Protocol.V1_8)
+    dev = Device("dev", 0, "uid", "mf", "mdl", ProtocolVersion.V1_8)
     # set online future
     loop = asyncio.get_running_loop()
     fut = loop.create_future()
@@ -98,8 +98,8 @@ async def test_device_online_setter_and_rediscover():
 
 
 def test_add_child_device_only_when_publishable():
-    parent = Device("parent", 0, "p_uid", "mf", "mdl", Protocol.V1_8)
-    child = Device("child", 0, "c_uid", "mf", "mdl", Protocol.V1_8)
+    parent = Device("parent", 0, "p_uid", "mf", "mdl", ProtocolVersion.V1_8)
+    child = Device("child", 0, "c_uid", "mf", "mdl", ProtocolVersion.V1_8)
     # non-publishable sensor
     s = DummyReadable(unique_id="s1", publishable=False)
     child._add_sensor(cast(Sensor, s))
@@ -107,7 +107,7 @@ def test_add_child_device_only_when_publishable():
     assert child not in parent.children
 
     # publishable sensor
-    child2 = Device("child2", 0, "c2", "mf", "mdl", Protocol.V1_8)
+    child2 = Device("child2", 0, "c2", "mf", "mdl", ProtocolVersion.V1_8)
     s2 = DummyReadable(unique_id="s2", publishable=True)
     child2._add_sensor(cast(Sensor, s2))
     parent._add_child_device(child2)
@@ -115,7 +115,7 @@ def test_add_child_device_only_when_publishable():
 
 
 def test_add_read_sensor_rejects_non_readable_and_add_to_all_sets_parent():
-    dev = Device("dev2", 0, "uid2", "mf", "mdl", Protocol.V1_8)
+    dev = Device("dev2", 0, "uid2", "mf", "mdl", ProtocolVersion.V1_8)
 
     class NotReadable:
         pass
@@ -130,7 +130,7 @@ def test_add_read_sensor_rejects_non_readable_and_add_to_all_sets_parent():
 
 
 def test_add_derived_sensor_handles_none_and_unregistered():
-    dev = Device("dev3", 0, "uid3", "mf", "mdl", Protocol.V1_8)
+    dev = Device("dev3", 0, "uid3", "mf", "mdl", ProtocolVersion.V1_8)
     derived = DummyDerived()
     # all sources None -> no addition
     derived._declare_source_sensors()
@@ -149,16 +149,16 @@ def test_multi_modbus_device_naming_uses_plant_index_and_charger_sequence():
     cfg.modbus = [cfg.modbus[0], copy.deepcopy(cfg.modbus[0])]
 
     with _swap_active_config(cfg):
-        plant0 = PowerPlant(0, HybridInverter(), Protocol.V2_8)
-        plant1 = PowerPlant(1, HybridInverter(), Protocol.V2_8)
+        plant0 = PowerPlant(0, HybridInverter(), ProtocolVersion.V2_8)
+        plant1 = PowerPlant(1, HybridInverter(), ProtocolVersion.V2_8)
 
-        inverter1 = Inverter(1, 1, HybridInverter(), Protocol.V2_8, "SigenStor EC 10.0 SP", "SN123", "V01.01.113")
-        ess1 = ESS(1, 1, HybridInverter(), Protocol.V2_8, "SigenStor EC 10.0 SP", "SN123")
-        pv_string1 = PVString(1, 1, HybridInverter(), "SigenStor EC 10.0 SP", "SN123", 1, 31027, 31028, Protocol.V2_8)
-        ac1 = ACCharger(1, 248 - 1, Protocol.V2_8, sequence_number=1, total_count=2)
-        ac2 = ACCharger(0, 248 - 2, Protocol.V2_8, sequence_number=2, total_count=2)
-        dc1 = DCCharger(1, 248 - 1, Protocol.V2_8, sequence_number=1, total_count=2)
-        dc2 = DCCharger(0, 248 - 2, Protocol.V2_8, sequence_number=2, total_count=2)
+        inverter1 = Inverter(1, 1, HybridInverter(), ProtocolVersion.V2_8, "SigenStor EC 10.0 SP", "SN123", "V01.01.113")
+        ess1 = ESS(1, 1, HybridInverter(), ProtocolVersion.V2_8, "SigenStor EC 10.0 SP", "SN123")
+        pv_string1 = PVString(1, 1, HybridInverter(), "SigenStor EC 10.0 SP", "SN123", 1, 31027, 31028, ProtocolVersion.V2_8)
+        ac1 = ACCharger(1, 248 - 1, ProtocolVersion.V2_8, sequence_number=1, total_count=2)
+        ac2 = ACCharger(0, 248 - 2, ProtocolVersion.V2_8, sequence_number=2, total_count=2)
+        dc1 = DCCharger(1, 248 - 1, ProtocolVersion.V2_8, sequence_number=1, total_count=2)
+        dc2 = DCCharger(0, 248 - 2, ProtocolVersion.V2_8, sequence_number=2, total_count=2)
 
     assert plant0["name"] == "Sigenergy Plant"
     assert plant1["name"] == "Sigenergy Plant 2"

--- a/tests/unit/main/test_device_factories.py
+++ b/tests/unit/main/test_device_factories.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from pymodbus import ModbusException
 
-from sigenergy2mqtt.common import InputType, Protocol
+from sigenergy2mqtt.common import InputType, ProtocolVersion
 from sigenergy2mqtt.config import Config
 from sigenergy2mqtt.main import main as main_mod
 
@@ -45,7 +45,7 @@ async def test_read_registers_holding():
 async def test_make_pid_duplicate_sn():
     mock_client = AsyncMock()
     mock_plant = MagicMock()
-    mock_plant.protocol_version = Protocol.V1_8
+    mock_plant.protocol_version = ProtocolVersion.V1_8
     mock_plant.unique_id = "plant_unique_id"
 
     mock_pid = MagicMock()
@@ -66,7 +66,7 @@ async def test_make_pid_duplicate_sn():
 async def test_make_pid_new_sn():
     mock_client = AsyncMock()
     mock_plant = MagicMock()
-    mock_plant.protocol_version = Protocol.V1_8
+    mock_plant.protocol_version = ProtocolVersion.V1_8
     mock_plant.unique_id = "plant_unique_id"
 
     mock_pid = MagicMock()
@@ -92,7 +92,7 @@ async def test_make_pid_new_sn():
 async def test_make_pss_duplicate_sn():
     mock_client = AsyncMock()
     mock_plant = MagicMock()
-    mock_plant.protocol_version = Protocol.V1_8
+    mock_plant.protocol_version = ProtocolVersion.V1_8
     mock_plant.unique_id = "plant_unique_id"
 
     mock_pss = MagicMock()
@@ -113,7 +113,7 @@ async def test_make_pss_duplicate_sn():
 async def test_make_pss_new_sn():
     mock_client = AsyncMock()
     mock_plant = MagicMock()
-    mock_plant.protocol_version = Protocol.V1_8
+    mock_plant.protocol_version = ProtocolVersion.V1_8
     mock_plant.unique_id = "plant_unique_id"
 
     mock_pss = MagicMock()
@@ -160,7 +160,7 @@ async def test_make_plant_and_inverter_missing_tz_offset():
     with (
         patch("sigenergy2mqtt.main.main.get_state", new_callable=AsyncMock, side_effect=mock_get_state_side_effect),
         patch("sigenergy2mqtt.main.main.probe_optional_interface", new_callable=AsyncMock, return_value=False),
-        patch("sigenergy2mqtt.main.main.probe_protocol", new_callable=AsyncMock, return_value=Protocol.V2_8),
+        patch("sigenergy2mqtt.main.main.probe_protocol", new_callable=AsyncMock, return_value=ProtocolVersion.V2_8),
         patch("sigenergy2mqtt.devices.PowerPlant.create", new_callable=AsyncMock) as mock_plant_create,
         patch("sigenergy2mqtt.devices.Inverter.create", new_callable=AsyncMock),
     ):
@@ -199,7 +199,7 @@ async def test_make_plant_and_inverter_tz_exception():
     with (
         patch("sigenergy2mqtt.main.main.get_state", new_callable=AsyncMock, side_effect=mock_get_state_side_effect),
         patch("sigenergy2mqtt.main.main.probe_optional_interface", new_callable=AsyncMock, return_value=False),
-        patch("sigenergy2mqtt.main.main.probe_protocol", new_callable=AsyncMock, return_value=Protocol.V2_8),
+        patch("sigenergy2mqtt.main.main.probe_protocol", new_callable=AsyncMock, return_value=ProtocolVersion.V2_8),
         patch("sigenergy2mqtt.devices.PowerPlant.create", new_callable=AsyncMock) as mock_plant_create,
         patch("sigenergy2mqtt.devices.Inverter.create", new_callable=AsyncMock),
     ):
@@ -238,7 +238,7 @@ async def test_make_plant_and_inverter_protocol_override():
     with (
         patch("sigenergy2mqtt.main.main.get_state", new_callable=AsyncMock, side_effect=mock_get_state_side_effect),
         patch("sigenergy2mqtt.main.main.probe_optional_interface", new_callable=AsyncMock, return_value=False),
-        patch("sigenergy2mqtt.main.main.probe_protocol", new_callable=AsyncMock, return_value=Protocol.V2_8),
+        patch("sigenergy2mqtt.main.main.probe_protocol", new_callable=AsyncMock, return_value=ProtocolVersion.V2_8),
         patch("sigenergy2mqtt.devices.PowerPlant.create", new_callable=AsyncMock) as mock_plant_create,
         patch("sigenergy2mqtt.devices.Inverter.create", new_callable=AsyncMock),
     ):
@@ -249,4 +249,4 @@ async def test_make_plant_and_inverter_protocol_override():
         await main_mod.make_plant_and_inverter(1, mock_client, 2, None, seen_sn)
 
         mock_plant_create.assert_called_once()
-        assert mock_plant_create.call_args[0][3] == Protocol.V2_9
+        assert mock_plant_create.call_args[0][3] == ProtocolVersion.V2_9

--- a/tests/unit/main/test_main.py
+++ b/tests/unit/main/test_main.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from pymodbus import ModbusException
 
-from sigenergy2mqtt.common import ConsumptionMethod, DeviceClass, FirmwareVersion, InputType, Protocol, StateClass, UnitOfPower
+from sigenergy2mqtt.common import ConsumptionMethod, DeviceClass, FirmwareVersion, InputType, ProtocolVersion, StateClass, UnitOfPower
 from sigenergy2mqtt.config import _swap_active_config, active_config
 from sigenergy2mqtt.main import main as main_mod
 from sigenergy2mqtt.main.restart import restart_controller
@@ -57,7 +57,7 @@ def make_validation_sensor(suffix: str, address: int = 30001):
         icon="mdi:power",
         gain=1.0,
         precision=0,
-        protocol_version=Protocol.V2_4,
+        protocol_version=ProtocolVersion.V2_4,
         unique_id_override=f"sigen_validation_{suffix}",
     )
 
@@ -403,9 +403,9 @@ class TestDiscovery:
         version = await main_mod.probe_protocol(mock_client)
         # Verify it tried only the first candidate (succeeded immediately)
         assert mock_read.await_count == 1
-        # Verify it returns a valid Protocol (not the fallback)
-        assert isinstance(version, Protocol)
-        assert version != Protocol.V1_8
+        # Verify it returns a valid ProtocolVersion (not the fallback)
+        assert isinstance(version, ProtocolVersion)
+        assert version != ProtocolVersion.V1_8
 
     @pytest.mark.asyncio
     async def test_probe_protocol_fallback(self, monkeypatch):
@@ -421,7 +421,7 @@ class TestDiscovery:
         monkeypatch.setattr(main_mod, "read_registers", AsyncMock(return_value=RR()))
 
         version = await main_mod.probe_protocol(mock_client)
-        assert version == Protocol.V1_8
+        assert version == ProtocolVersion.V1_8
 
     @pytest.mark.asyncio
     async def test_probe_optional_interface_error(self, monkeypatch):
@@ -454,7 +454,7 @@ class TestFactories:
     async def test_make_ac_charger(self):
         """Test make_ac_charger factory."""
         mock_client = AsyncMock()
-        mock_plant = MagicMock(unique_id="plant_id", protocol_version=Protocol.V2_8)
+        mock_plant = MagicMock(unique_id="plant_id", protocol_version=ProtocolVersion.V2_8)
         with patch("sigenergy2mqtt.devices.ACCharger.create", new_callable=AsyncMock) as mock_create:
             mock_create.return_value = MagicMock()
             charger = await main_mod.make_ac_charger(0, mock_client, 1, mock_plant)
@@ -465,7 +465,7 @@ class TestFactories:
         """Test make_dc_charger factory."""
         with patch("sigenergy2mqtt.devices.DCCharger.create", new_callable=AsyncMock) as mock_create:
             mock_create.return_value = MagicMock()
-            charger = await main_mod.make_dc_charger(0, 1, Protocol.V2_8, "inverter_id")
+            charger = await main_mod.make_dc_charger(0, 1, ProtocolVersion.V2_8, "inverter_id")
             assert charger.via_device == "inverter_id"
 
     @pytest.mark.asyncio
@@ -494,9 +494,9 @@ class TestFactories:
         # SN, Model, PACKBCUCount (0 for PVInverter), SystemTimeZone, InverterFirmwareVersion, OutputType, ESSPreHeatingEnable
         with (
             patch("sigenergy2mqtt.main.main.get_state", side_effect=["SN1", "MDL1", 0, 600, "V122R001C00SPC112B701P", 1, None]),
-            patch("sigenergy2mqtt.main.main.probe_protocol", AsyncMock(return_value=Protocol.V2_8)),
+            patch("sigenergy2mqtt.main.main.probe_protocol", AsyncMock(return_value=ProtocolVersion.V2_8)),
             patch("sigenergy2mqtt.main.main.probe_optional_interface", AsyncMock(return_value=False)),
-            patch("sigenergy2mqtt.devices.PowerPlant.create", AsyncMock(return_value=MagicMock(protocol_version=Protocol.V2_8, unique_id="p1"))),
+            patch("sigenergy2mqtt.devices.PowerPlant.create", AsyncMock(return_value=MagicMock(protocol_version=ProtocolVersion.V2_8, unique_id="p1"))),
             patch("sigenergy2mqtt.devices.Inverter.create", AsyncMock(return_value=MagicMock())),
         ):
             inv, plant = await main_mod.make_plant_and_inverter(0, mock_client, 1, None, seen)
@@ -513,9 +513,9 @@ class TestFactories:
         clean_config.ems_mode_check = True
         with (
             patch("sigenergy2mqtt.main.main.get_state", side_effect=["SN1", "MDL1", 1, 600, "V122R001C00SPC113B717A", 1, None]),
-            patch("sigenergy2mqtt.main.main.probe_protocol", AsyncMock(return_value=Protocol.V2_8)),
+            patch("sigenergy2mqtt.main.main.probe_protocol", AsyncMock(return_value=ProtocolVersion.V2_8)),
             patch("sigenergy2mqtt.main.main.probe_optional_interface", AsyncMock(return_value=False)),
-            patch("sigenergy2mqtt.devices.PowerPlant.create", AsyncMock(return_value=MagicMock(protocol_version=Protocol.V2_8, unique_id="p1"))),
+            patch("sigenergy2mqtt.devices.PowerPlant.create", AsyncMock(return_value=MagicMock(protocol_version=ProtocolVersion.V2_8, unique_id="p1"))),
             patch("sigenergy2mqtt.sensors.inverter_read_only.InverterFirmwareVersion.get_state", AsyncMock(return_value="V122R001C00SPC113B717A")),
             patch("sigenergy2mqtt.sensors.inverter_read_only.InverterModel.get_state", AsyncMock(return_value="MDL1")),
             patch("sigenergy2mqtt.sensors.inverter_read_only.PACKBCUCount.get_state", AsyncMock(return_value=1)),
@@ -538,9 +538,9 @@ class TestFactories:
         clean_config.ems_mode_check = True
         with (
             patch("sigenergy2mqtt.main.main.get_state", side_effect=["SN1", "MDL1", 1, 600, "V122R001C00SPC112B701P", 1, None]),
-            patch("sigenergy2mqtt.main.main.probe_protocol", AsyncMock(return_value=Protocol.V2_8)),
+            patch("sigenergy2mqtt.main.main.probe_protocol", AsyncMock(return_value=ProtocolVersion.V2_8)),
             patch("sigenergy2mqtt.main.main.probe_optional_interface", AsyncMock(return_value=False)),
-            patch("sigenergy2mqtt.devices.PowerPlant.create", AsyncMock(return_value=MagicMock(protocol_version=Protocol.V2_8, unique_id="p1"))),
+            patch("sigenergy2mqtt.devices.PowerPlant.create", AsyncMock(return_value=MagicMock(protocol_version=ProtocolVersion.V2_8, unique_id="p1"))),
             patch("sigenergy2mqtt.sensors.inverter_read_only.InverterFirmwareVersion.get_state", AsyncMock(return_value="V122R001C00SPC112B701P")),
             patch("sigenergy2mqtt.sensors.inverter_read_only.InverterModel.get_state", AsyncMock(return_value="MDL1")),
             patch("sigenergy2mqtt.sensors.inverter_read_only.PACKBCUCount.get_state", AsyncMock(return_value=1)),
@@ -562,9 +562,9 @@ class TestFactories:
         # SN, Model, PACKBCUCount, SystemTimeZone, InverterFirmwareVersion, OutputType, ESSPreHeatingEnable
         with (
             patch("sigenergy2mqtt.main.main.get_state", side_effect=["SN1", "MDL1", 1, 600, "V122R001C00SPC112B701P", 1, None]),
-            patch("sigenergy2mqtt.main.main.probe_protocol", AsyncMock(return_value=Protocol.V1_8)),
+            patch("sigenergy2mqtt.main.main.probe_protocol", AsyncMock(return_value=ProtocolVersion.V1_8)),
             patch("sigenergy2mqtt.main.main.probe_optional_interface", AsyncMock(return_value=False)),
-            patch("sigenergy2mqtt.devices.PowerPlant.create", AsyncMock(return_value=MagicMock(protocol_version=Protocol.V1_8, unique_id="p1"))),
+            patch("sigenergy2mqtt.devices.PowerPlant.create", AsyncMock(return_value=MagicMock(protocol_version=ProtocolVersion.V1_8, unique_id="p1"))),
             patch("sigenergy2mqtt.devices.Inverter.create", AsyncMock(return_value=MagicMock())),
         ):
             await main_mod.make_plant_and_inverter(0, mock_client, 1, None, seen)
@@ -574,11 +574,11 @@ class TestFactories:
         """Ensure firmware read from inverter is forwarded to PowerPlant.create."""
         mock_client = AsyncMock()
         seen = set()
-        mock_plant = MagicMock(protocol_version=Protocol.V2_8, unique_id="p1")
+        mock_plant = MagicMock(protocol_version=ProtocolVersion.V2_8, unique_id="p1")
 
         with (
             patch("sigenergy2mqtt.main.main.get_state", side_effect=["SN1", "MDL1", 1, 600, "V122R001C00SPC113B717A", 1, None]),
-            patch("sigenergy2mqtt.main.main.probe_protocol", AsyncMock(return_value=Protocol.V2_8)),
+            patch("sigenergy2mqtt.main.main.probe_protocol", AsyncMock(return_value=ProtocolVersion.V2_8)),
             patch("sigenergy2mqtt.main.main.probe_optional_interface", AsyncMock(return_value=False)),
             patch("sigenergy2mqtt.devices.PowerPlant.create", AsyncMock(return_value=mock_plant)) as mock_plant_create,
             patch("sigenergy2mqtt.devices.Inverter.create", AsyncMock(return_value=MagicMock())),
@@ -592,7 +592,7 @@ class TestFactories:
         """When plant already exists, only inverter is created and no plant-only reads occur."""
         mock_client = AsyncMock()
         seen = set()
-        existing_plant = MagicMock(protocol_version=Protocol.V2_8, unique_id="p-existing")
+        existing_plant = MagicMock(protocol_version=ProtocolVersion.V2_8, unique_id="p-existing")
 
         with (
             patch("sigenergy2mqtt.main.main.get_state", side_effect=["SN1", "MDL1", 1, 600]) as mock_get_state,
@@ -616,7 +616,7 @@ class TestFactories:
         # SN, Model, PACKBCUCount, SystemTimeZone, InverterFirmwareVersion, OutputType (returns None)
         with (
             patch("sigenergy2mqtt.main.main.get_state", side_effect=["SN1", "MDL1", 1, 600, "V122R001C00SPC112B701P", None]),
-            patch("sigenergy2mqtt.main.main.probe_protocol", AsyncMock(return_value=Protocol.V2_8)),
+            patch("sigenergy2mqtt.main.main.probe_protocol", AsyncMock(return_value=ProtocolVersion.V2_8)),
             patch("sigenergy2mqtt.main.main.probe_optional_interface", AsyncMock(return_value=False)),
             pytest.raises(ValueError, match="OutputType cannot be None"),
         ):
@@ -654,14 +654,14 @@ async def test_probe_protocol_candidates_and_error(monkeypatch):
     version = await main_mod.probe_protocol(mock_client)
     # Verify it tried exactly 4 candidates before succeeding
     assert mock_read.await_count == 4
-    # Verify it returns a valid Protocol (not the fallback)
-    assert isinstance(version, Protocol)
-    assert version != Protocol.V1_8
+    # Verify it returns a valid ProtocolVersion (not the fallback)
+    assert isinstance(version, ProtocolVersion)
+    assert version != ProtocolVersion.V1_8
 
     # Test complete failure fallback to V1_8
     monkeypatch.setattr(main_mod, "read_registers", AsyncMock(return_value=RR(True)))
     version = await main_mod.probe_protocol(mock_client)
-    assert version == Protocol.V1_8
+    assert version == ProtocolVersion.V1_8
 
 
 @pytest.mark.asyncio
@@ -729,9 +729,9 @@ async def test_coverage_gap_closers(clean_config, monkeypatch):
     clean_config.consumption = ConsumptionMethod.TOTAL
     with (
         patch("sigenergy2mqtt.main.main.get_state", side_effect=["SN1", "MDL1", 1, 600, "V122R001C00SPC112B701P", 1, None]),
-        patch("sigenergy2mqtt.main.main.probe_protocol", AsyncMock(return_value=Protocol.V1_8)),
+        patch("sigenergy2mqtt.main.main.probe_protocol", AsyncMock(return_value=ProtocolVersion.V1_8)),
         patch("sigenergy2mqtt.main.main.probe_optional_interface", AsyncMock(return_value=False)),
-        patch("sigenergy2mqtt.devices.PowerPlant.create", AsyncMock(return_value=MagicMock(protocol_version=Protocol.V1_8, unique_id="p1"))),
+        patch("sigenergy2mqtt.devices.PowerPlant.create", AsyncMock(return_value=MagicMock(protocol_version=ProtocolVersion.V1_8, unique_id="p1"))),
         patch("sigenergy2mqtt.devices.Inverter.create", AsyncMock(return_value=MagicMock())),
         patch("sigenergy2mqtt.main.main.logger.warning") as mock_warn,
     ):
@@ -740,10 +740,10 @@ async def test_coverage_gap_closers(clean_config, monkeypatch):
         assert mock_warn.called
 
     # Line 254: plant already exists branch
-    mock_plant = MagicMock(protocol_version=Protocol.V2_8, unique_id="p1")
+    mock_plant = MagicMock(protocol_version=ProtocolVersion.V2_8, unique_id="p1")
     with (
         patch("sigenergy2mqtt.main.main.get_state", side_effect=["SN2", "MDL1", 1, 600]),
-        patch("sigenergy2mqtt.main.main.probe_protocol", AsyncMock(return_value=Protocol.V2_8)),
+        patch("sigenergy2mqtt.main.main.probe_protocol", AsyncMock(return_value=ProtocolVersion.V2_8)),
         patch("sigenergy2mqtt.main.main.probe_optional_interface", AsyncMock(return_value=False)),
         patch("sigenergy2mqtt.devices.Inverter.create", AsyncMock(return_value=MagicMock())),
     ):
@@ -769,7 +769,7 @@ async def test_coverage_gap_closers(clean_config, monkeypatch):
         icon="mdi:power",
         gain=1.0,
         precision=0,
-        protocol_version=Protocol.V2_4,
+        protocol_version=ProtocolVersion.V2_4,
     )
     device = MagicMock()
     device.get_all_sensors.return_value = {"sensor": sensor}
@@ -925,7 +925,7 @@ async def test_setup_services_comprehensive(clean_config):
         patch("sigenergy2mqtt.main.main.get_pvoutput_services", return_value=[MagicMock()]),
         patch("sigenergy2mqtt.main.main.get_influxdb_services", return_value=[MagicMock()]),
     ):
-        result = main_mod.setup_services(configs, Protocol.V2_8)
+        result = main_mod.setup_services(configs, ProtocolVersion.V2_8)
         # Should have Monitor thread at 0 and Services thread at end
         assert result[0].name == "Monitor"
         assert result[-1].name == "Services"
@@ -964,7 +964,7 @@ async def test_setup_ac_chargers_older_protocol(clean_config):
     mock_plant = MagicMock()
     mock_config = MagicMock()
     with patch("sigenergy2mqtt.main.main.logger.warning") as mock_warn:
-        await main_mod._setup_ac_chargers(0, mock_modbus_cfg, mock_plant, AsyncMock(), mock_config, Protocol.V1_8, 0, 1)
+        await main_mod._setup_ac_chargers(0, mock_modbus_cfg, mock_plant, AsyncMock(), mock_config, ProtocolVersion.V1_8, 0, 1)
         assert mock_warn.called
 
 
@@ -989,7 +989,7 @@ async def test_setup_ac_chargers_outage_failure_skips_and_continues(clean_config
     monkeypatch.setattr(main_mod, "_schedule_restart_on_grid_restore", mock_schedule)
 
     with patch("sigenergy2mqtt.main.main.logger.warning") as mock_warn:
-        next_seq = await main_mod._setup_ac_chargers(0, mock_modbus_cfg, mock_plant, AsyncMock(), mock_config, Protocol.V2_8, 0, 2)
+        next_seq = await main_mod._setup_ac_chargers(0, mock_modbus_cfg, mock_plant, AsyncMock(), mock_config, ProtocolVersion.V2_8, 0, 2)
 
     assert next_seq == 2
     assert mock_config.add_device.call_count == 1
@@ -1007,7 +1007,7 @@ async def test_setup_ac_chargers_non_outage_failure_logs_error(clean_config, mon
     monkeypatch.setattr(main_mod, "_is_grid_outage", AsyncMock(return_value=False))
 
     with patch("sigenergy2mqtt.main.main.logger.error") as mock_err:
-        next_seq = await main_mod._setup_ac_chargers(0, mock_modbus_cfg, mock_plant, AsyncMock(), mock_config, Protocol.V2_8, 0, 1)
+        next_seq = await main_mod._setup_ac_chargers(0, mock_modbus_cfg, mock_plant, AsyncMock(), mock_config, ProtocolVersion.V2_8, 0, 1)
 
     assert next_seq == 1
     mock_config.add_device.assert_not_called()
@@ -1068,7 +1068,7 @@ async def test_async_main_with_full_device_flow(clean_config, monkeypatch):
     monkeypatch.setattr(main_mod.ThreadConfig, "create", lambda *a, **kw: mock_thread_config)
     monkeypatch.setattr(main_mod, "ModbusClient", lambda *a, **k: AsyncMock(__aenter__=AsyncMock(return_value=AsyncMock(connected=True))))
 
-    mock_plant = MagicMock(protocol_version=Protocol.V2_8, has_battery=True, unique_id="p_uid", device_address=247)
+    mock_plant = MagicMock(protocol_version=ProtocolVersion.V2_8, has_battery=True, unique_id="p_uid", device_address=247)
     mock_plant.name = "Plant"
     mock_plant.sensors = {f"{active_config.home_assistant.unique_id_prefix}_0_247_40029": MagicMock()}
 
@@ -1101,7 +1101,7 @@ async def test_async_main_with_no_battery(clean_config, monkeypatch):
     active_config.modbus.clear()
     active_config.modbus.extend([mock_device])
 
-    mock_plant = MagicMock(has_battery=False, protocol_version=Protocol.V1_8, device_address=247)
+    mock_plant = MagicMock(has_battery=False, protocol_version=ProtocolVersion.V1_8, device_address=247)
     mock_plant.name = "Plant"
     mock_plant.sensors = {f"{active_config.home_assistant.unique_id_prefix}_0_247_40029": MagicMock()}
     mock_si_sensor = MagicMock(publishable=True)
@@ -1150,7 +1150,7 @@ async def test_async_main_restarts_when_requested(clean_config, monkeypatch):
     monkeypatch.setattr(main_mod.thread_config_registry, "clear", clear_mock)
 
     monkeypatch.setattr(main_mod, "ModbusClient", lambda *a, **h: AsyncMock(__aenter__=AsyncMock(return_value=AsyncMock(connected=True))))
-    mock_plant = MagicMock(protocol_version=Protocol.V1_8, device_address=247, name="Plant")
+    mock_plant = MagicMock(protocol_version=ProtocolVersion.V1_8, device_address=247, name="Plant")
     mock_plant.sensors = {f"{active_config.home_assistant.unique_id_prefix}_0_247_40029": MagicMock()}
     mock_inverter = MagicMock(unique_id="i_uid", device_address=1, name="Inverter")
     monkeypatch.setattr(main_mod, "make_plant_and_inverter", AsyncMock(return_value=(mock_inverter, mock_plant)))
@@ -1210,7 +1210,7 @@ async def test_async_main_sighup_reload_suppresses_ha_during_restart(clean_confi
     monkeypatch.setattr(main_mod, "start", AsyncMock(side_effect=_start))
     monkeypatch.setattr(main_mod, "ModbusClient", lambda *a, **h: AsyncMock(__aenter__=AsyncMock(return_value=AsyncMock(connected=True))))
 
-    mock_plant = MagicMock(protocol_version=Protocol.V1_8, device_address=247, name="Plant")
+    mock_plant = MagicMock(protocol_version=ProtocolVersion.V1_8, device_address=247, name="Plant")
     mock_plant.sensors = {f"{active_config.home_assistant.unique_id_prefix}_0_247_40029": MagicMock()}
     mock_inverter = MagicMock(unique_id="i_uid", device_address=1, name="Inverter")
     monkeypatch.setattr(main_mod, "make_plant_and_inverter", AsyncMock(return_value=(mock_inverter, mock_plant)))
@@ -1243,7 +1243,7 @@ async def test_async_main_registers_signal_handlers(clean_config, monkeypatch):
     monkeypatch.setattr(main_mod, "start", AsyncMock())
     monkeypatch.setattr(main_mod, "ModbusClient", lambda *a, **h: AsyncMock(__aenter__=AsyncMock(return_value=AsyncMock(connected=True))))
 
-    mock_plant = MagicMock(protocol_version=Protocol.V1_8, device_address=247, name="Plant")
+    mock_plant = MagicMock(protocol_version=ProtocolVersion.V1_8, device_address=247, name="Plant")
     mock_plant.sensors = {f"{active_config.home_assistant.unique_id_prefix}_0_247_40029": MagicMock()}
     mock_inverter = MagicMock(unique_id="i_uid", device_address=1)
     mock_inverter.name = "Inverter"

--- a/tests/unit/main/test_protocol_and_main_helpers.py
+++ b/tests/unit/main/test_protocol_and_main_helpers.py
@@ -4,21 +4,21 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import sigenergy2mqtt.__main__ as main_module
-from sigenergy2mqtt.common.protocol import Protocol, ProtocolApplies
+from sigenergy2mqtt.common.protocol import ProtocolVersion, ProtocolApplies
 from sigenergy2mqtt.influxdb import get_influxdb_services
 
 
 def test_protocol_applies_coverage():
-    assert ProtocolApplies(Protocol.V1_8) == "2024-08-05"
-    assert ProtocolApplies(Protocol.V2_0) == "2024-10-14"
-    assert ProtocolApplies(Protocol.V2_4) == "2025-02-05"
-    assert ProtocolApplies(Protocol.V2_5) == "2025-02-19"
-    assert ProtocolApplies(Protocol.V2_6) == "2025-03-31"
-    assert ProtocolApplies(Protocol.V2_7) == "2025-05-23"
-    assert ProtocolApplies(Protocol.V2_8) == "2025-11-28"
-    assert ProtocolApplies(Protocol.V2_9) == "2026-05-13"
+    assert ProtocolApplies(ProtocolVersion.V1_8) == "2024-08-05"
+    assert ProtocolApplies(ProtocolVersion.V2_0) == "2024-10-14"
+    assert ProtocolApplies(ProtocolVersion.V2_4) == "2025-02-05"
+    assert ProtocolApplies(ProtocolVersion.V2_5) == "2025-02-19"
+    assert ProtocolApplies(ProtocolVersion.V2_6) == "2025-03-31"
+    assert ProtocolApplies(ProtocolVersion.V2_7) == "2025-05-23"
+    assert ProtocolApplies(ProtocolVersion.V2_8) == "2025-11-28"
+    assert ProtocolApplies(ProtocolVersion.V2_9) == "2026-05-13"
     # Coverage for default case
-    assert ProtocolApplies(Protocol.N_A) is not None
+    assert ProtocolApplies(ProtocolVersion.N_A) is not None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/main/test_sanity_check_integration.py
+++ b/tests/unit/main/test_sanity_check_integration.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from sigenergy2mqtt.common import DeviceClass, InputType, Protocol, UnitOfPower
+from sigenergy2mqtt.common import DeviceClass, InputType, ProtocolVersion, UnitOfPower
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.modbus.client import ModbusClient
 from sigenergy2mqtt.sensors.base import NumericSensor, SanityCheckException, SelectSensor
@@ -39,7 +39,7 @@ class TestSanityCheckIntegration:
             icon="mdi:test",
             gain=10,
             precision=1,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             minimum=5.0,  # Display value
             maximum=20.0,  # Display value
         )
@@ -60,7 +60,7 @@ class TestSanityCheckIntegration:
             address=30002,
             scan_interval=60,
             options=options,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
         # Raw values are indices 0, 1, 2
@@ -88,7 +88,7 @@ class TestSanityCheckIntegration:
             icon="mdi:test",
             gain=1,
             precision=1,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             minimum=10,
             maximum=20,
         )
@@ -140,7 +140,7 @@ class TestSanityCheckIntegration:
             icon="mdi:test",
             gain=1,
             precision=1,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             minimum=10,
             maximum=20,
         )

--- a/tests/unit/main/test_setup_pss_and_validation.py
+++ b/tests/unit/main/test_setup_pss_and_validation.py
@@ -5,7 +5,7 @@ import paho.mqtt.client as paho_mqtt
 import pytest
 from pymodbus import ModbusException
 
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.config import Config, active_config
 from sigenergy2mqtt.main import main as main_mod
 
@@ -47,7 +47,7 @@ async def test_setup_pss_normal():
             seen_serial_numbers=set(),
             modbus_client=MagicMock(),
             config=mock_config,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
             sequence_start=0,
             total_count=1,
         )
@@ -72,7 +72,7 @@ async def test_setup_pss_exception_grid_outage(caplog):
         mock_make.side_effect = RuntimeError("Outage error")
         mock_outage.return_value = True
 
-        res = await main_mod._setup_pss(0, mock_device, MagicMock(), set(), MagicMock(), MagicMock(), Protocol.V2_9, 0, 1)
+        res = await main_mod._setup_pss(0, mock_device, MagicMock(), set(), MagicMock(), MagicMock(), ProtocolVersion.V2_9, 0, 1)
 
         assert res == 1
         mock_schedule.assert_called_once()
@@ -90,7 +90,7 @@ async def test_setup_pss_exception_normal(caplog):
         mock_make.side_effect = RuntimeError("Other error")
         mock_outage.return_value = False
 
-        res = await main_mod._setup_pss(0, mock_device, MagicMock(), set(), MagicMock(), MagicMock(), Protocol.V2_9, 0, 1)
+        res = await main_mod._setup_pss(0, mock_device, MagicMock(), set(), MagicMock(), MagicMock(), ProtocolVersion.V2_9, 0, 1)
 
         assert res == 1
         assert "Failed to initialize PSS device at address 1" in caplog.text

--- a/tests/unit/main/test_setup_routines.py
+++ b/tests/unit/main/test_setup_routines.py
@@ -6,7 +6,7 @@ import pytest
 
 from sigenergy2mqtt.main import main as main_mod
 from sigenergy2mqtt.config import active_config, Config
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.devices import Inverter
 from sigenergy2mqtt.sensors.plant_read_write import ActivePowerFixedAdjustmentTargetValue, ReactivePowerFixedAdjustmentTargetValue
 
@@ -80,7 +80,7 @@ async def test_setup_devices_active_power_bounds(caplog):
         mock_client.__aenter__.return_value = mock_client
         
         mock_plant = MagicMock()
-        mock_plant.protocol_version = Protocol.V1_8
+        mock_plant.protocol_version = ProtocolVersion.V1_8
         mock_plant.has_battery = True
         active_power_sensor = MagicMock(spec=ActivePowerFixedAdjustmentTargetValue)
         reactive_power_sensor = MagicMock(spec=ReactivePowerFixedAdjustmentTargetValue)
@@ -145,7 +145,7 @@ async def test_setup_devices_active_power_bounds_missing(caplog):
         mock_client.__aenter__.return_value = mock_client
         
         mock_plant = MagicMock()
-        mock_plant.protocol_version = Protocol.V1_8
+        mock_plant.protocol_version = ProtocolVersion.V1_8
         mock_plant.has_battery = True
         mock_plant.sensors = {}
         
@@ -306,7 +306,7 @@ async def test_setup_dc_chargers_normal():
     mock_config = MagicMock()
     mock_charger = MagicMock()
     mock_plant = MagicMock()
-    mock_plant.protocol_version = Protocol.V1_8
+    mock_plant.protocol_version = ProtocolVersion.V1_8
     
     with patch("sigenergy2mqtt.main.main.make_dc_charger", new_callable=AsyncMock) as mock_make, \
          patch("sigenergy2mqtt.main.main.validate_publishable_sensors", new_callable=AsyncMock) as mock_validate:
@@ -354,7 +354,7 @@ async def test_setup_pid_normal():
             seen_serial_numbers=set(),
             modbus_client=MagicMock(),
             config=mock_config,
-            protocol_version=Protocol.V2_9,
+            protocol_version=ProtocolVersion.V2_9,
             sequence_start=0,
             total_count=1,
         )
@@ -378,7 +378,7 @@ async def test_setup_pid_exception_grid_outage(caplog):
         mock_outage.return_value = True
         
         res = await main_mod._setup_pid(
-            0, mock_device, MagicMock(), set(), MagicMock(), MagicMock(), Protocol.V2_9, 0, 1
+            0, mock_device, MagicMock(), set(), MagicMock(), MagicMock(), ProtocolVersion.V2_9, 0, 1
         )
         
         assert res == 1
@@ -399,7 +399,7 @@ async def test_setup_pid_exception_normal(caplog):
         mock_outage.return_value = False
         
         res = await main_mod._setup_pid(
-            0, mock_device, MagicMock(), set(), MagicMock(), MagicMock(), Protocol.V2_9, 0, 1
+            0, mock_device, MagicMock(), set(), MagicMock(), MagicMock(), ProtocolVersion.V2_9, 0, 1
         )
         
         assert res == 1

--- a/tests/unit/main/test_thread_config.py
+++ b/tests/unit/main/test_thread_config.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.devices import Device
 from sigenergy2mqtt.main.thread_config import ThreadConfig, thread_config_registry
 
@@ -40,7 +40,7 @@ def test_threadconfig_properties_and_methods(monkeypatch):
     assert tc.description == "MyName"
 
     # Create a Device and attach to ThreadConfig
-    dev = Device("D1", 0, "uid-d1", "mf", "mdl", Protocol.N_A)
+    dev = Device("D1", 0, "uid-d1", "mf", "mdl", ProtocolVersion.N_A)
     tc.add_device(dev)
     assert dev in tc.devices
     assert dev in tc.devices

--- a/tests/unit/metrics/test_sensors.py
+++ b/tests/unit/metrics/test_sensors.py
@@ -2,6 +2,9 @@ import time
 from unittest.mock import patch
 
 import pytest
+
+from sigenergy2mqtt.common import ProtocolVersion
+from sigenergy2mqtt.metrics.metrics import Metrics
 from sigenergy2mqtt.metrics.sensors import (
     MetricsSensor,
     ModbusActiveLocks,
@@ -18,7 +21,7 @@ from sigenergy2mqtt.metrics.sensors import (
     ModbusWriteMean,
     ModbusWriteMin,
     ProtocolPublished,
-    ProtocolVersion,
+    ProtocolVersionSensor,
     Started,
     StateStoreLoads,
     StateStoreSaveErrors,
@@ -27,9 +30,6 @@ from sigenergy2mqtt.metrics.sensors import (
     StateStoreSaveMin,
     StateStoreSaves,
 )
-
-from sigenergy2mqtt.common import Protocol
-from sigenergy2mqtt.metrics.metrics import Metrics
 
 
 @pytest.fixture(autouse=True)
@@ -214,19 +214,19 @@ class TestStarted:
         assert sensor.latest_raw_state == "2023-01-01T00:00:00"
 
 
-class TestProtocolVersion:
+class TestProtocolVersionSensor:
     @pytest.mark.asyncio
     async def test_update_internal_state(self):
-        sensor = ProtocolVersion(Protocol.V1_8)
+        sensor = ProtocolVersionSensor(ProtocolVersion.V1_8)
         await sensor._update_internal_state()
-        assert sensor.latest_raw_state == str(Protocol.V1_8.value)
+        assert sensor.latest_raw_state == str(ProtocolVersion.V1_8.value)
 
 
 class TestProtocolPublished:
     @pytest.mark.asyncio
     async def test_update_internal_state(self):
         with patch("sigenergy2mqtt.metrics.sensors.ProtocolApplies", return_value="2024-08-05"):
-            sensor = ProtocolPublished(Protocol.V1_8)
+            sensor = ProtocolPublished(ProtocolVersion.V1_8)
             await sensor._update_internal_state()
             assert sensor.latest_raw_state == "2024-08-05"
 

--- a/tests/unit/metrics/test_service.py
+++ b/tests/unit/metrics/test_service.py
@@ -4,7 +4,7 @@ import paho.mqtt.client as mqtt
 import pytest
 from sigenergy2mqtt.metrics.service import MetricsService
 
-from sigenergy2mqtt.common import PERCENTAGE, Protocol
+from sigenergy2mqtt.common import PERCENTAGE, ProtocolVersion
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.metrics.metrics import Metrics
 
@@ -44,13 +44,13 @@ class TestMetricsService:
         Metrics._started = original_started
 
     def test_init(self):
-        service = MetricsService(Protocol.V2_4)
+        service = MetricsService(ProtocolVersion.V2_4)
         assert service.name == "Sigenergy Metrics"
         assert service.unique_id == "test_prefix_metrics"
         assert len(service.read_sensors) > 0
 
     def test_sensors_added(self):
-        service = MetricsService(Protocol.V2_4)
+        service = MetricsService(ProtocolVersion.V2_4)
         sensors = service.read_sensors
 
         # Verify key sensors are present
@@ -64,7 +64,7 @@ class TestMetricsService:
         assert "test_prefix_modbus_protocol" in sensors
 
     def test_sensor_config(self):
-        service = MetricsService(Protocol.V2_4)
+        service = MetricsService(ProtocolVersion.V2_4)
         sensor = service.read_sensors["test_prefix_modbus_cache_hit_percentage"]
 
         assert sensor.name == "Modbus Cache Hits"
@@ -73,7 +73,7 @@ class TestMetricsService:
         assert sensor.state_topic == "sigenergy2mqtt/metrics/modbus_cache_hit_percentage"
 
     def test_update_workflow(self):
-        service = MetricsService(Protocol.V2_4)
+        service = MetricsService(ProtocolVersion.V2_4)
 
         # Mock Metrics values
         Metrics.sigenergy2mqtt_modbus_reads = 100
@@ -96,7 +96,7 @@ class TestMetricsService:
             assert reads_sensor.latest_raw_state == 10.0  # 100 reads / 10 sec
 
     def test_lock_sensor(self):
-        service = MetricsService(Protocol.V2_4)
+        service = MetricsService(ProtocolVersion.V2_4)
         with patch("sigenergy2mqtt.modbus.lock_factory.ModbusLockFactory.get_waiter_count", return_value=5):
             lock_sensor = service.read_sensors["test_prefix_modbus_locks"]
 
@@ -107,7 +107,7 @@ class TestMetricsService:
             assert lock_sensor.latest_raw_state == 5
 
     def test_topics_structure(self):
-        service = MetricsService(Protocol.V2_4)
+        service = MetricsService(ProtocolVersion.V2_4)
 
         # Check a few specific topics to ensure they match old format
         # existing: sigenergy2mqtt/metrics/modbus_protocol

--- a/tests/unit/metrics/test_service_influx_integration.py
+++ b/tests/unit/metrics/test_service_influx_integration.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 from sigenergy2mqtt.metrics.service import MetricsService
 
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.config import Config
 from sigenergy2mqtt.config.config import _swap_active_config
 
@@ -11,7 +11,7 @@ from sigenergy2mqtt.config.config import _swap_active_config
 class TestMetricsServiceCoverage:
     @pytest.mark.asyncio
     async def test_init_without_influxdb(self):
-        protocol = Protocol.V2_0
+        protocol = ProtocolVersion.V2_0
         # Use _swap_active_config to ensure influxdb is disabled
         with _swap_active_config(Config()) as cfg:
             cfg.influxdb.enabled = False
@@ -25,7 +25,7 @@ class TestMetricsServiceCoverage:
 
     @pytest.mark.asyncio
     async def test_init_with_influxdb_enabled(self):
-        protocol = Protocol.V2_0
+        protocol = ProtocolVersion.V2_0
         with _swap_active_config(Config()) as cfg:
             cfg.home_assistant.unique_id_prefix = "test_prefix"
             cfg.influxdb.enabled = True
@@ -38,7 +38,7 @@ class TestMetricsServiceCoverage:
 
     @pytest.mark.asyncio
     async def test_publish_updates(self):
-        protocol = Protocol.V2_0
+        protocol = ProtocolVersion.V2_0
         with _swap_active_config(Config()) as cfg:
             cfg.home_assistant.unique_id_prefix = "test_prefix"
             cfg.influxdb.enabled = False

--- a/tests/unit/modbus/test_registers_config.py
+++ b/tests/unit/modbus/test_registers_config.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
-from sigenergy2mqtt.common import InputType, Protocol, RegisterAccess
+from sigenergy2mqtt.common import InputType, ProtocolVersion, RegisterAccess
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.config.settings import ModbusConfig
 from sigenergy2mqtt.modbus.client import ModbusClient
@@ -66,7 +66,7 @@ class MockReadableSensor(ReadableSensorMixin, Sensor):
         kwargs.setdefault("icon", "mdi:test")
         kwargs.setdefault("gain", 1.0)
         kwargs.setdefault("precision", 1)
-        kwargs.setdefault("protocol_version", Protocol.V2_4)
+        kwargs.setdefault("protocol_version", ProtocolVersion.V2_4)
         kwargs.setdefault("scan_interval", 60)
         super().__init__(**kwargs)
 
@@ -85,7 +85,7 @@ class MockWriteableSensor(WriteableSensorMixin, Sensor):
         kwargs.setdefault("icon", "mdi:test")
         kwargs.setdefault("gain", 1.0)
         kwargs.setdefault("precision", 1)
-        kwargs.setdefault("protocol_version", Protocol.V2_4)
+        kwargs.setdefault("protocol_version", ProtocolVersion.V2_4)
         kwargs.setdefault("data_type", MODBUS_DATA_TYPE.UINT16)
         kwargs.setdefault("input_type", InputType.HOLDING)
         kwargs.setdefault("plant_index", 1)
@@ -108,7 +108,7 @@ class MockWriteOnlySensor(WriteOnlySensor):
         kwargs.setdefault("plant_index", 1)
         kwargs.setdefault("device_address", 1)
         kwargs.setdefault("address", 40001)
-        kwargs.setdefault("protocol_version", Protocol.V2_4)
+        kwargs.setdefault("protocol_version", ProtocolVersion.V2_4)
         # We don't want to pass data_type or other fields that WriteOnlySensor sets itself
         super().__init__(**kwargs)
 

--- a/tests/unit/mqtt/test_ha_discovery.py
+++ b/tests/unit/mqtt/test_ha_discovery.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from sigenergy2mqtt.common import InputType, Protocol, StateClass, UnitOfPower
+from sigenergy2mqtt.common import InputType, ProtocolVersion, StateClass, UnitOfPower
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.devices import Device, DeviceRegistry
 from sigenergy2mqtt.modbus import ModbusDataType
@@ -644,7 +644,7 @@ def get_discovery_payload(mqtt_mock):
 
 
 def test_discovery_base_structure(mock_config):
-    dev = Device("TestDevice", 0, "sigen_uid", "Sigenergy", "SigenStor", Protocol.V1_8)
+    dev = Device("TestDevice", 0, "sigen_uid", "Sigenergy", "SigenStor", ProtocolVersion.V1_8)
     sensor = DummySensor("TestSensor", "sigen_s1", 100)
     dev._add_sensor(cast(Sensor, sensor))
 
@@ -666,7 +666,7 @@ def test_discovery_base_structure(mock_config):
 
 
 def test_energy_daily_accumulation_discovery(mock_config):
-    dev = Device("TestDevice", 0, "sigen_uid", "Sigenergy", "SigenStor", Protocol.V1_8)
+    dev = Device("TestDevice", 0, "sigen_uid", "Sigenergy", "SigenStor", ProtocolVersion.V1_8)
     source = DummySensor("Power", "sigen_power", 100)
     dev._add_sensor(cast(Sensor, source))
 
@@ -686,13 +686,13 @@ def test_energy_daily_accumulation_discovery(mock_config):
 
 
 def test_alarm_sensor_discovery(mock_config):
-    dev = Device("TestDevice", 0, "sigen_uid", "Sigenergy", "SigenStor", Protocol.V1_8)
+    dev = Device("TestDevice", 0, "sigen_uid", "Sigenergy", "SigenStor", ProtocolVersion.V1_8)
 
     class ConcreteAlarm(AlarmSensor):
         def decode_alarm_bit(self, bit):
             return "Error"
 
-    sensor = ConcreteAlarm("Alarm1", "sigen_alarm1", 0, 1, 30001, Protocol.V1_8, "Equipment")
+    sensor = ConcreteAlarm("Alarm1", "sigen_alarm1", 0, 1, 30001, ProtocolVersion.V1_8, "Equipment")
     dev._add_sensor(cast(Sensor, sensor))
 
     mqtt_client = MagicMock()
@@ -707,10 +707,10 @@ def test_alarm_sensor_discovery(mock_config):
 
 
 def test_timestamp_sensor_discovery(mock_config):
-    dev = Device("TestDevice", 0, "sigen_uid", "Sigenergy", "SigenStor", Protocol.V1_8)
+    dev = Device("TestDevice", 0, "sigen_uid", "Sigenergy", "SigenStor", ProtocolVersion.V1_8)
 
     # name, object_id, input_type, plant_index, device_address, address, scan_interval, protocol_version
-    sensor = TimestampSensor("UpdateTime", "sigen_ts1", InputType.INPUT, 0, 1, 30005, 60, Protocol.V1_8, tz=timezone.utc)
+    sensor = TimestampSensor("UpdateTime", "sigen_ts1", InputType.INPUT, 0, 1, 30005, 60, ProtocolVersion.V1_8, tz=timezone.utc)
     dev._add_sensor(cast(Sensor, sensor))
 
     mqtt_client = MagicMock()
@@ -728,7 +728,7 @@ def test_timestamp_sensor_discovery(mock_config):
 def test_simplified_topics_discovery(mock_config):
     mock_config.home_assistant.use_simplified_topics = True
 
-    dev = Device("TestDevice", 0, "sigen_uid", "Sigenergy", "SigenStor", Protocol.V1_8)
+    dev = Device("TestDevice", 0, "sigen_uid", "Sigenergy", "SigenStor", ProtocolVersion.V1_8)
     sensor = DummySensor("TestSensor", "sigen_s1", 100)
     dev._add_sensor(cast(Sensor, sensor))
 
@@ -742,7 +742,7 @@ def test_simplified_topics_discovery(mock_config):
 
 
 def test_discovery_keys_validity(mock_config):
-    dev = Device("TestDevice", 0, "sigen_uid", "Sigenergy", "SigenStor", Protocol.V1_8)
+    dev = Device("TestDevice", 0, "sigen_uid", "Sigenergy", "SigenStor", ProtocolVersion.V1_8)
     sensor = DummySensor("TestSensor", "sigen_s1", 100)
     dev._add_sensor(cast(Sensor, sensor))
 
@@ -751,7 +751,7 @@ def test_discovery_keys_validity(mock_config):
     dev._add_sensor(cast(Sensor, source))
     energy_sensor = EnergyDailyAccumulationSensor("Daily Energy", "sigen_daily", "sigen_daily", source)
     dev._add_to_all_sensors(energy_sensor)
-    ts_sensor = TimestampSensor("UpdateTime", "sigen_ts1", InputType.INPUT, 0, 1, 30005, 60, Protocol.V1_8, tz=timezone.utc)
+    ts_sensor = TimestampSensor("UpdateTime", "sigen_ts1", InputType.INPUT, 0, 1, 30005, 60, ProtocolVersion.V1_8, tz=timezone.utc)
     dev._add_sensor(cast(Sensor, ts_sensor))
 
     mqtt_client = MagicMock()

--- a/tests/unit/sensors/test_accumulation_sensors.py
+++ b/tests/unit/sensors/test_accumulation_sensors.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from sigenergy2mqtt.common import DeviceClass, Protocol, StateClass
+from sigenergy2mqtt.common import DeviceClass, ProtocolVersion, StateClass
 from sigenergy2mqtt.modbus import ModbusDataType
 from sigenergy2mqtt.sensors.base import ResettableAccumulationSensor, Sensor
 
@@ -379,7 +379,7 @@ class TestEnergyDailyAccumulationSensor:
         string.device_class = DeviceClass.POWER
         string.state_class = StateClass.MEASUREMENT
         string.precision = 2
-        string.protocol_version = Protocol.V1_8
+        string.protocol_version = ProtocolVersion.V1_8
 
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
             import time

--- a/tests/unit/sensors/test_advanced.py
+++ b/tests/unit/sensors/test_advanced.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
-from sigenergy2mqtt.common import DeviceClass, Protocol, StateClass, UnitOfPower
+from sigenergy2mqtt.common import DeviceClass, ProtocolVersion, StateClass, UnitOfPower
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.sensors.base import Sensor
 
@@ -39,7 +39,7 @@ class ConcreteSensor(Sensor):
                 icon="mdi:power",
                 gain=1.0,
                 precision=2,
-                protocol_version=Protocol.V2_4,
+                protocol_version=ProtocolVersion.V2_4,
             )
             self._test_value: float | None = None
 

--- a/tests/unit/sensors/test_alarms.py
+++ b/tests/unit/sensors/test_alarms.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import MagicMock, patch
 
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.config import Config, _swap_active_config, active_config
 from sigenergy2mqtt.sensors.base.alarms import AlarmSensor, AlarmCombinedSensor, RunningStateSensor
 from sigenergy2mqtt.sensors.base import Sensor
@@ -41,7 +41,7 @@ class DummyAlarmSensor(AlarmSensor):
 
 @pytest.mark.asyncio
 async def test_alarm_sensor_coverage():
-    sensor = DummyAlarmSensor("Dummy", "sigen_dummy", 0, 1, 30000, Protocol.V2_5, "Dummy")
+    sensor = DummyAlarmSensor("Dummy", "sigen_dummy", 0, 1, 30000, ProtocolVersion.V2_5, "Dummy")
     
     # Test state2raw
     assert sensor.state2raw(AlarmSensor.NO_ALARM) == 0
@@ -67,18 +67,18 @@ async def test_alarm_sensor_coverage():
 
 @pytest.mark.asyncio
 async def test_alarm_combined_sensor_coverage():
-    alarm1 = DummyAlarmSensor("A1", "sigen_a1", 0, 1, 30000, Protocol.V2_5, "Dummy")
-    alarm2 = DummyAlarmSensor("A2", "sigen_a2", 0, 1, 30001, Protocol.V2_5, "Dummy")
+    alarm1 = DummyAlarmSensor("A1", "sigen_a1", 0, 1, 30000, ProtocolVersion.V2_5, "Dummy")
+    alarm2 = DummyAlarmSensor("A2", "sigen_a2", 0, 1, 30001, ProtocolVersion.V2_5, "Dummy")
     
     # Test init exceptions
     with pytest.raises(ValueError, match="At least one alarm sensor required"):
         AlarmCombinedSensor("Comb", "sigen_comb", "sigen_comb")
         
-    alarm_diff_dev = DummyAlarmSensor("A3", "sigen_a3", 0, 2, 30002, Protocol.V2_5, "Dummy")
+    alarm_diff_dev = DummyAlarmSensor("A3", "sigen_a3", 0, 2, 30002, ProtocolVersion.V2_5, "Dummy")
     with pytest.raises(ValueError, match="same device address"):
         AlarmCombinedSensor("Comb", "sigen_comb", "sigen_comb", alarm1, alarm_diff_dev)
         
-    alarm_non_contig = DummyAlarmSensor("A4", "sigen_a4", 0, 1, 30003, Protocol.V2_5, "Dummy")
+    alarm_non_contig = DummyAlarmSensor("A4", "sigen_a4", 0, 1, 30003, ProtocolVersion.V2_5, "Dummy")
     with pytest.raises(ValueError, match="contiguous address ranges"):
         AlarmCombinedSensor("Comb", "sigen_comb", "sigen_comb", alarm1, alarm_non_contig)
         
@@ -90,7 +90,7 @@ async def test_alarm_combined_sensor_coverage():
     
     # Test protocol_version setter
     with pytest.raises(NotImplementedError):
-        combined.protocol_version = Protocol.V2_5
+        combined.protocol_version = ProtocolVersion.V2_5
         
     # Test state2raw
     assert combined.state2raw(AlarmSensor.NO_ALARM) == 0
@@ -107,8 +107,8 @@ async def test_alarm_combined_sensor_coverage():
         def decode_alarm_bit(self, bit_position: int) -> str | None:
             return "Very long string with lots of text " * 10
             
-    long_alarm1 = LongAlarmSensor("LA1", "sigen_la1", 0, 1, 30100, Protocol.V2_5, "Dummy")
-    long_alarm2 = LongAlarmSensor("LA2", "sigen_la2", 0, 1, 30101, Protocol.V2_5, "Dummy")
+    long_alarm1 = LongAlarmSensor("LA1", "sigen_la1", 0, 1, 30100, ProtocolVersion.V2_5, "Dummy")
+    long_alarm2 = LongAlarmSensor("LA2", "sigen_la2", 0, 1, 30101, ProtocolVersion.V2_5, "Dummy")
     comb_long = AlarmCombinedSensor("CL", "sigen_cl", "sigen_cl", long_alarm1, long_alarm2)
     
     with patch("sigenergy2mqtt.sensors.base.readable.ReadOnlySensor.get_state") as mock_super_get_state:
@@ -119,7 +119,7 @@ async def test_alarm_combined_sensor_coverage():
 
 @pytest.mark.asyncio
 async def test_running_state_sensor_coverage():
-    sensor = RunningStateSensor("Run", "sigen_run", 0, 1, 30000, Protocol.V2_5)
+    sensor = RunningStateSensor("Run", "sigen_run", 0, 1, 30000, ProtocolVersion.V2_5)
     
     with patch("sigenergy2mqtt.sensors.base.readable.ReadOnlySensor.get_state") as mock_super_get_state:
         # Test raw=True

--- a/tests/unit/sensors/test_all_state_and_discovery.py
+++ b/tests/unit/sensors/test_all_state_and_discovery.py
@@ -9,7 +9,7 @@ import sigenergy2mqtt.sensors.inverter_derived as idrv
 import sigenergy2mqtt.sensors.inverter_read_only as iro
 import sigenergy2mqtt.sensors.inverter_read_write as irw
 import sigenergy2mqtt.sensors.plant_derived as pdrv
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.sensors.base import AvailabilityMixin, Sensor
 
 
@@ -38,7 +38,7 @@ class MockAvailabilitySensor(AvailabilityMixin):
         self.object_id = "sigen_mock_avail"
         self.get_state = AsyncMock(return_value=1)
         self.address = 30000
-        self._protocol_version = Protocol.V1_8
+        self._protocol_version = ProtocolVersion.V1_8
         self.publishable = True
 
     def items(self):
@@ -105,7 +105,7 @@ async def run_coverage_on_module(module):
                     m.device_address = 247
                     m.address = 30000
                     m.count = 1
-                    m.protocol_version = Protocol.V1_8
+                    m.protocol_version = ProtocolVersion.V1_8
                     kwargs[name] = [m]
                 elif issubclass(param.annotation, AvailabilityMixin) if hasattr(param.annotation, "__mro__") else False:
                     kwargs[name] = MockAvailabilitySensor()

--- a/tests/unit/sensors/test_base.py
+++ b/tests/unit/sensors/test_base.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from sigenergy2mqtt.common import DeviceClass, Protocol, StateClass, UnitOfPower
+from sigenergy2mqtt.common import DeviceClass, ProtocolVersion, StateClass, UnitOfPower
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.sensors.base import Sensor
 
@@ -33,7 +33,7 @@ class TestSensorBase:
                     icon="mdi:solar-power",
                     gain=1.0,
                     precision=2,
-                    protocol_version=Protocol.V2_4,
+                    protocol_version=ProtocolVersion.V2_4,
                 )
                 yield s
 
@@ -42,7 +42,7 @@ class TestSensorBase:
         assert sensor["unique_id"] == "sigen_test_unique_id"
         assert sensor.gain == 1.0
         assert sensor.precision == 2
-        assert sensor.protocol_version == Protocol.V2_4.value
+        assert sensor.protocol_version == ProtocolVersion.V2_4.value
 
     def test_apply_gain_and_precision(self, sensor):
         # Default gain=1.0, precision=2
@@ -94,11 +94,11 @@ class TestSensorBase:
 
         # protocol_version setter
         # Accept enum
-        sensor.protocol_version = Protocol.V2_4
-        assert sensor.protocol_version == Protocol.V2_4.value
-        # Accept float value corresponding to Protocol
-        sensor.protocol_version = float(Protocol.V2_4.value)
-        assert sensor.protocol_version == Protocol.V2_4.value
+        sensor.protocol_version = ProtocolVersion.V2_4
+        assert sensor.protocol_version == ProtocolVersion.V2_4.value
+        # Accept float value corresponding to ProtocolVersion
+        sensor.protocol_version = float(ProtocolVersion.V2_4.value)
+        assert sensor.protocol_version == ProtocolVersion.V2_4.value
         # Invalid value
         with pytest.raises(TypeError):
             sensor.protocol_version = "invalid"  # type: ignore
@@ -165,7 +165,7 @@ class TestSensorLogic:
                     def decode_alarm_bit(self, bit_position: int) -> str | None:
                         return "Error"
 
-                sensor = ConcreteAlarm("Alarm", "sigen_alarm", 0, 1, 30001, Protocol.V2_4, "Equipment")
+                sensor = ConcreteAlarm("Alarm", "sigen_alarm", 0, 1, 30001, ProtocolVersion.V2_4, "Equipment")
                 assert sensor.state2raw("No Alarm") == 0
                 assert sensor.state2raw(1) == 1
 
@@ -250,7 +250,7 @@ class TestSensorLogic:
         with _swap_active_config(cfg):
             with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
                 # name, object_id, plant_index, device_address, address, protocol_version
-                s = WriteOnlySensor("WO", "sigen_wo", 0, 1, 30001, Protocol.V2_4)
+                s = WriteOnlySensor("WO", "sigen_wo", 0, 1, 30001, ProtocolVersion.V2_4)
                 assert s.publishable is True
                 assert s.publish_raw is False
 

--- a/tests/unit/sensors/test_base_additional.py
+++ b/tests/unit/sensors/test_base_additional.py
@@ -45,7 +45,7 @@ def test_latest_state_and_interval():
         icon="mdi:test",
         gain=None,
         precision=None,
-        protocol_version=base.Protocol.N_A,
+        protocol_version=base.ProtocolVersion.N_A,
     )
 
     assert s.publishable is False
@@ -83,7 +83,7 @@ async def test_publish_state_calls_mqtt():
 
 
 def test_timestamp_sensor_conversion():
-    ts = base.TimestampSensor(name="t", object_id="sigen_ts", input_type=InputType.INPUT, plant_index=0, device_address=1, address=30010, scan_interval=1, protocol_version=base.Protocol.N_A, tz=UTC)
+    ts = base.TimestampSensor(name="t", object_id="sigen_ts", input_type=InputType.INPUT, plant_index=0, device_address=1, address=30010, scan_interval=1, protocol_version=base.ProtocolVersion.N_A, tz=UTC)
     assert ts.state2raw("--") == 0
     now = int(time.time())
     ts.set_latest_state(now)
@@ -94,7 +94,7 @@ def test_timestamp_sensor_conversion():
 
 
 def test_select_options_and_indexing():
-    sel = base.SelectSensor(None, name="sel", object_id="sigen_sel", plant_index=0, device_address=1, address=30020, scan_interval=1, options=["A", "B", "C"], protocol_version=base.Protocol.N_A)
+    sel = base.SelectSensor(None, name="sel", object_id="sigen_sel", plant_index=0, device_address=1, address=30020, scan_interval=1, options=["A", "B", "C"], protocol_version=base.ProtocolVersion.N_A)
     assert sel._get_option(1) == "B"
     assert sel._get_option_index("B") == 1
     assert sel._get_option_index(2) == 2
@@ -109,7 +109,7 @@ def test_state2raw_and_gain():
 
 
 def test_writeonly_get_discovery_components():
-    w = base.WriteOnlySensor(name="w", object_id="sigen_btn", plant_index=0, device_address=1, address=30030, protocol_version=base.Protocol.N_A)
+    w = base.WriteOnlySensor(name="w", object_id="sigen_btn", plant_index=0, device_address=1, address=30030, protocol_version=base.ProtocolVersion.N_A)
     comps = w.get_discovery_components()
     assert any(k.endswith("_on") for k in comps.keys())
 
@@ -131,7 +131,7 @@ def test_numeric_min_max_behavior():
         icon="mdi:test",
         gain=1,
         precision=0,
-        protocol_version=base.Protocol.N_A,
+        protocol_version=base.ProtocolVersion.N_A,
         minimum=0.0,
         maximum=100.0,
     )
@@ -143,7 +143,7 @@ def test_numeric_min_max_behavior():
 
 
 def test_alarm_decoding_and_truncate():
-    a = base.Alarm1Sensor(name="a1", object_id="sigen_a_obj", plant_index=0, device_address=1, address=30050, protocol_version=base.Protocol.N_A)
+    a = base.Alarm1Sensor(name="a1", object_id="sigen_a_obj", plant_index=0, device_address=1, address=30050, protocol_version=base.ProtocolVersion.N_A)
     bits = 1 << 2
     decoded = a._decode_alarm_bits(bits, bits)
     assert any("Over-temperature" in s or "Unknown" in s for s in decoded)
@@ -172,7 +172,7 @@ def test_numeric_min_max_tuple_validation():
             icon="mdi:test",
             gain=None,
             precision=None,
-            protocol_version=base.Protocol.N_A,
+            protocol_version=base.ProtocolVersion.N_A,
             minimum=(0, 1),
             maximum=(0, 1, 2),
         )
@@ -191,7 +191,7 @@ def test_get_base_topic_variants():
 
 
 def test_select_get_state_unknown_mode():
-    sel = base.SelectSensor(None, name="selx", object_id="sigen_selx", plant_index=0, device_address=1, address=30020, scan_interval=1, options=["A", "B"], protocol_version=base.Protocol.N_A)
+    sel = base.SelectSensor(None, name="selx", object_id="sigen_selx", plant_index=0, device_address=1, address=30020, scan_interval=1, options=["A", "B"], protocol_version=base.ProtocolVersion.N_A)
     sel.set_latest_state(0)
     loop = asyncio.new_event_loop()
     val = loop.run_until_complete(sel.get_state(raw=False, republish=True))
@@ -200,7 +200,7 @@ def test_select_get_state_unknown_mode():
 
 
 def test_switch_value_is_valid_and_set_value(monkeypatch):
-    sw = base.SwitchSensor(None, name="sw", object_id="sigen_sw", plant_index=0, device_address=1, address=30021, scan_interval=1, protocol_version=base.Protocol.N_A)
+    sw = base.SwitchSensor(None, name="sw", object_id="sigen_sw", plant_index=0, device_address=1, address=30021, scan_interval=1, protocol_version=base.ProtocolVersion.N_A)
     loop = asyncio.new_event_loop()
     res_invalid = loop.run_until_complete(sw.value_is_valid(None, 5))
     loop.close()
@@ -218,8 +218,8 @@ def test_switch_value_is_valid_and_set_value(monkeypatch):
 
 
 def test_alarmcombined_get_state_combines_alarms():
-    a1 = base.Alarm1Sensor("a1", "sigen_a1", plant_index=0, device_address=1, address=30050, protocol_version=base.Protocol.N_A)
-    a2 = base.Alarm2Sensor("a2", "sigen_a2", plant_index=0, device_address=1, address=30051, protocol_version=base.Protocol.N_A)
+    a1 = base.Alarm1Sensor("a1", "sigen_a1", plant_index=0, device_address=1, address=30050, protocol_version=base.ProtocolVersion.N_A)
+    a2 = base.Alarm2Sensor("a2", "sigen_a2", plant_index=0, device_address=1, address=30051, protocol_version=base.ProtocolVersion.N_A)
     a1.set_latest_state(1 << 2)
     a2.set_latest_state(1 << 1)
 

--- a/tests/unit/sensors/test_base_overrides_and_edge_cases.py
+++ b/tests/unit/sensors/test_base_overrides_and_edge_cases.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from sigenergy2mqtt.common import DeviceClass, Protocol, RegisterAccess, StateClass, UnitOfPower
+from sigenergy2mqtt.common import DeviceClass, ProtocolVersion, RegisterAccess, StateClass, UnitOfPower
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.modbus import ModbusDataType
 from sigenergy2mqtt.sensors.base import (
@@ -47,7 +47,7 @@ def _make_sensor(name="Test", uid_suffix="x", debug=False, **kwargs):
                 icon="mdi:solar-power",
                 gain=1.0,
                 precision=2,
-                protocol_version=Protocol.V2_4,
+                protocol_version=ProtocolVersion.V2_4,
                 debug_logging=debug,
                 **kwargs,
             )
@@ -150,7 +150,7 @@ class TestApplySensorOverrides:
                 icon="mdi:flash",
                 gain=1.0,
                 precision=2,
-                protocol_version=Protocol.V2_4,
+                protocol_version=ProtocolVersion.V2_4,
             )
         cfg = Config()
         cfg.sensor_overrides = {f"sigen_{suffix}": overrides}
@@ -232,7 +232,7 @@ class TestApplySensorOverrides:
                 icon="mdi:flash",
                 gain=1.0,
                 precision=2,
-                protocol_version=Protocol.V2_4,
+                protocol_version=ProtocolVersion.V2_4,
             )
         registers = MagicMock(spec=RegisterAccess)
         registers.no_remote_ems = False
@@ -257,7 +257,7 @@ class TestApplySensorOverrides:
                 icon="mdi:flash",
                 gain=1.0,
                 precision=2,
-                protocol_version=Protocol.V2_4,
+                protocol_version=ProtocolVersion.V2_4,
             )
         s._remote_ems = True  # mark as remote EMS sensor
         registers = MagicMock(spec=RegisterAccess)
@@ -281,7 +281,7 @@ class TestAlarmSensorBranches:
                 def decode_alarm_bit(self, bit_position: int):
                     return f"Error bit {bit_position}" if bit_position == 0 else None
 
-            return ConcreteAlarm("Alarm", f"sigen_{suffix}", 0, 1, 30001, Protocol.V2_4, "Equipment")
+            return ConcreteAlarm("Alarm", f"sigen_{suffix}", 0, 1, 30001, ProtocolVersion.V2_4, "Equipment")
 
     def test_alarm_state2raw_string_no_alarm(self):
         s = self._make_alarm("alrm_s2r_na")
@@ -412,7 +412,7 @@ class TestReservedSensor:
                 None,
                 None,
                 None,
-                Protocol.V2_4,
+                ProtocolVersion.V2_4,
             )
         return s
 
@@ -442,7 +442,7 @@ class TestWriteableSensorOverrides:
         """WriteableSensorMixin sensor becomes unpublishable when read_write=False."""
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
             # WriteOnlySensor is a concrete WriteableSensorMixin subclass
-            wo = WriteOnlySensor("WO", "sigen_wo_rw", 0, 1, 30001, Protocol.V2_4)
+            wo = WriteOnlySensor("WO", "sigen_wo_rw", 0, 1, 30001, ProtocolVersion.V2_4)
         registers = MagicMock(spec=RegisterAccess)
         registers.no_remote_ems = False
         registers.write_only = False
@@ -453,7 +453,7 @@ class TestWriteableSensorOverrides:
     def test_write_only_sensor_write_only_false_unpublishable(self):
         """WriteOnlySensor (not WriteableSensorMixin ReadWrite) also respects write_only override."""
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
-            wo = WriteOnlySensor("WO2", "sigen_wo_wo", 0, 1, 30001, Protocol.V2_4)
+            wo = WriteOnlySensor("WO2", "sigen_wo_wo", 0, 1, 30001, ProtocolVersion.V2_4)
         registers = MagicMock(spec=RegisterAccess)
         registers.no_remote_ems = False
         registers.write_only = False
@@ -480,7 +480,7 @@ class TestSensorEqualityAndHash:
                 icon=None,
                 gain=None,
                 precision=None,
-                protocol_version=Protocol.V2_4,
+                protocol_version=ProtocolVersion.V2_4,
             )
             s2 = ConcreteSensor(
                 name="S2",
@@ -492,7 +492,7 @@ class TestSensorEqualityAndHash:
                 icon=None,
                 gain=None,
                 precision=None,
-                protocol_version=Protocol.V2_4,
+                protocol_version=ProtocolVersion.V2_4,
             )
         assert s1 == s2
 
@@ -508,7 +508,7 @@ class TestSensorEqualityAndHash:
                 icon=None,
                 gain=None,
                 precision=None,
-                protocol_version=Protocol.V2_4,
+                protocol_version=ProtocolVersion.V2_4,
             )
             s2 = ConcreteSensor(
                 name="S2",
@@ -520,7 +520,7 @@ class TestSensorEqualityAndHash:
                 icon=None,
                 gain=None,
                 precision=None,
-                protocol_version=Protocol.V2_4,
+                protocol_version=ProtocolVersion.V2_4,
             )
         assert s1 != s2
 

--- a/tests/unit/sensors/test_base_publish_and_discovery.py
+++ b/tests/unit/sensors/test_base_publish_and_discovery.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pymodbus import ModbusException
 
-from sigenergy2mqtt.common import DeviceClass, Protocol, StateClass, UnitOfPower
+from sigenergy2mqtt.common import DeviceClass, ProtocolVersion, StateClass, UnitOfPower
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.sensors.base import (
     Sensor,
@@ -43,7 +43,7 @@ def _make_sensor(name="Test", uid_suffix="x", debug=False, **kwargs):
             icon="mdi:solar-power",
             gain=1.0,
             precision=2,
-            protocol_version=Protocol.V2_4,
+            protocol_version=ProtocolVersion.V2_4,
             debug_logging=debug,
             **kwargs,
         )
@@ -388,7 +388,7 @@ class TestGetAttributes:
                 icon=None,
                 gain=None,
                 precision=None,
-                protocol_version=Protocol.V2_4,
+                protocol_version=ProtocolVersion.V2_4,
             )
         cfg = Config()
         cfg.home_assistant.enabled = False
@@ -397,10 +397,10 @@ class TestGetAttributes:
         assert "unit-of-measurement" not in attrs
 
     def test_get_attributes_protocol_na_omits_since_protocol(self):
-        """Protocol.N_A omits since-protocol from attributes."""
+        """ProtocolVersion.N_A omits since-protocol from attributes."""
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
             s = ConcreteSensor(
-                name="NA Protocol",
+                name="NA ProtocolVersion",
                 unique_id="sigen_na_proto",
                 object_id="sigen_na_proto",
                 unit=None,
@@ -409,7 +409,7 @@ class TestGetAttributes:
                 icon=None,
                 gain=None,
                 precision=None,
-                protocol_version=Protocol.N_A,
+                protocol_version=ProtocolVersion.N_A,
             )
         attrs = s.get_attributes()
         assert "since-protocol" not in attrs
@@ -553,7 +553,7 @@ class TestGetDiscoveryComponents:
                 icon=None,
                 gain=None,
                 precision=None,
-                protocol_version=Protocol.V2_4,
+                protocol_version=ProtocolVersion.V2_4,
             )
         s["options"] = ["Option A", "Option B", ""]  # empty string should be filtered
         components = s.get_discovery_components()

--- a/tests/unit/sensors/test_base_registration_and_identity.py
+++ b/tests/unit/sensors/test_base_registration_and_identity.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from sigenergy2mqtt.common import DeviceClass, Protocol, StateClass
+from sigenergy2mqtt.common import DeviceClass, ProtocolVersion, StateClass
 from sigenergy2mqtt.config.models.persistence import PersistenceConfig
 from sigenergy2mqtt.modbus import ModbusDataType
 from sigenergy2mqtt.persistence import state_store
@@ -51,7 +51,7 @@ class TestResettableAccumulationSensorCoverage:
             source.latest_interval = 3600.0
             source.__getitem__.side_effect = lambda x: "sigenergy2mqtt_source_obj" if x == DiscoveryKeys.OBJECT_ID else MagicMock()
             source.latest_raw_state = 0.0
-            source.protocol_version = Protocol.V1_8
+            source.protocol_version = ProtocolVersion.V1_8
             source.state_count = 2
             source.previous_time = now - 3600
             source.latest_time = now
@@ -191,7 +191,7 @@ class TestEnergyLifetimeAccumulationSensorCoverage:
         source.state_class = StateClass.TOTAL_INCREASING
         source.gain = 1.0
         source.precision = 2
-        source.protocol_version = Protocol.V1_8
+        source.protocol_version = ProtocolVersion.V1_8
         source.__getitem__.side_effect = lambda x: "sigenergy2mqtt_source_obj"
         sensor = EnergyLifetimeAccumulationSensor("Test", "sigen_life", "sigenergy2mqtt_obj", source)
         assert sensor.state_class == StateClass.TOTAL_INCREASING
@@ -201,7 +201,7 @@ class TestEnergyLifetimeAccumulationSensorCoverage:
         source = MagicMock()
         source.unique_id = "sigen_source"
         source.data_type = ModbusDataType.UINT32
-        source.protocol_version = Protocol.V1_8
+        source.protocol_version = ProtocolVersion.V1_8
         source.__getitem__.side_effect = lambda x: "sigenergy2mqtt_source_obj"
         with pytest.raises(AssertionError, match="does not start with"):
             EnergyLifetimeAccumulationSensor("Test", "sigen_life", "bad_prefix", source)
@@ -220,7 +220,7 @@ class TestEnergyDailyAccumulationSensorCoverageExtended:
             source.gain = 1.0
             source.precision = 2
             source.latest_raw_state = 100.0
-            source.protocol_version = Protocol.V1_8
+            source.protocol_version = ProtocolVersion.V1_8
             source.state_count = 2
 
         return EnergyDailyAccumulationSensor(name="Test Daily", unique_id=kwargs.pop("unique_id", "sigen_daily_uid"), object_id="sigenergy2mqtt_daily_obj", source=source, **kwargs)
@@ -230,7 +230,7 @@ class TestEnergyDailyAccumulationSensorCoverageExtended:
         source = MagicMock()
         source.unique_id = "sigen_source_id"
         source.data_type = ModbusDataType.UINT32
-        source.protocol_version = Protocol.V1_8
+        source.protocol_version = ProtocolVersion.V1_8
         source.__getitem__.side_effect = lambda x: "sigenergy2mqtt_source_obj"
         with pytest.raises(AssertionError, match="does not start with"):
             EnergyDailyAccumulationSensor("Test", "sigen_daily", "bad_prefix", source)

--- a/tests/unit/sensors/test_base_sensor_branches.py
+++ b/tests/unit/sensors/test_base_sensor_branches.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from sigenergy2mqtt.common import DeviceClass, InputType, Protocol, RegisterAccess, StateClass, UnitOfPower
+from sigenergy2mqtt.common import DeviceClass, InputType, ProtocolVersion, RegisterAccess, StateClass, UnitOfPower
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.modbus import ModbusDataType
 from sigenergy2mqtt.sensors.base import ReadOnlySensor, Sensor
@@ -50,7 +50,7 @@ def _make_sensor(uid_suffix: str = "x", debug: bool = False, cfg: Config | None 
             icon="mdi:solar-power",
             gain=1.0,
             precision=2,
-            protocol_version=Protocol.V2_4,
+            protocol_version=ProtocolVersion.V2_4,
             debug_logging=debug,
         )
     return s
@@ -94,15 +94,15 @@ class TestSensorInitValidation:
                     icon="bad_icon",  # Triggers line 105
                     gain=None,
                     precision=None,
-                    protocol_version=Protocol.V2_4,
+                    protocol_version=ProtocolVersion.V2_4,
                 )
 
     def test_invalid_protocol_version_type_raises(self):
-        """Line 109: TypeError when protocol_version is not a Protocol instance."""
+        """Line 109: TypeError when protocol_version is not a ProtocolVersion instance."""
         cfg = _make_cfg()
         with _swap_active_config(cfg), patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True), pytest.raises(TypeError, match="protocol_version.*is invalid"):
             _ConcreteSensor(
-                name="Bad Protocol",
+                name="Bad ProtocolVersion",
                 unique_id="sigen_bad_proto",
                 object_id="sigen_bad_proto",
                 unit=None,
@@ -136,7 +136,7 @@ class TestSensorIDValidation:
                     icon=None,
                     gain=None,
                     precision=None,
-                    protocol_version=Protocol.V2_4,
+                    protocol_version=ProtocolVersion.V2_4,
                 )
 
     def test_object_id_wrong_prefix_raises(self):
@@ -154,7 +154,7 @@ class TestSensorIDValidation:
                     icon=None,
                     gain=None,
                     precision=None,
-                    protocol_version=Protocol.V2_4,
+                    protocol_version=ProtocolVersion.V2_4,
                 )
 
 
@@ -165,10 +165,10 @@ class TestSensorIDValidation:
 
 class TestProtocolVersionSetter:
     def test_float_invalid_protocol_version_raises(self):
-        """Line 328: AssertionError when float value not in Protocol enum."""
+        """Line 328: AssertionError when float value not in ProtocolVersion enum."""
         s = _make_sensor("proto_invalid")
         with pytest.raises(AssertionError, match="Invalid protocol_version"):
-            s.protocol_version = 999.9  # Not a valid Protocol value
+            s.protocol_version = 999.9  # Not a valid ProtocolVersion value
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -249,7 +249,7 @@ class TestApplyDeviceOverrides:
                 icon=None,
                 gain=None,
                 precision=None,
-                protocol_version=Protocol.V2_4,
+                protocol_version=ProtocolVersion.V2_4,
             )
             registers = MagicMock(spec=RegisterAccess)
             registers.no_remote_ems = False
@@ -287,7 +287,7 @@ class TestApplyDeviceOverrides:
                 icon=None,
                 gain=None,
                 precision=None,
-                protocol_version=Protocol.V2_4,
+                protocol_version=ProtocolVersion.V2_4,
                 debug_logging=True,
             )
 

--- a/tests/unit/sensors/test_base_types.py
+++ b/tests/unit/sensors/test_base_types.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from pymodbus.client import AsyncModbusTcpClient as ModbusClient
 
-from sigenergy2mqtt.common import DeviceClass, InputType, Protocol, StateClass, UnitOfPower
+from sigenergy2mqtt.common import DeviceClass, InputType, ProtocolVersion, StateClass, UnitOfPower
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.modbus import ModbusDataType
 from sigenergy2mqtt.sensors.base import EnergyDailyAccumulationSensor, EnergyLifetimeAccumulationSensor, NumericSensor, ReadOnlySensor, SelectSensor, Sensor, TimestampSensor
@@ -58,7 +58,7 @@ class TestModbusSensor:
                     icon="mdi:power",
                     gain=1.0,
                     precision=0,
-                    protocol_version=Protocol.V2_4,
+                    protocol_version=ProtocolVersion.V2_4,
                 )
             # Invalid address
             with pytest.raises(AssertionError, match="Invalid address"):
@@ -78,7 +78,7 @@ class TestModbusSensor:
                     icon="mdi:power",
                     gain=1.0,
                     precision=0,
-                    protocol_version=Protocol.V2_4,
+                    protocol_version=ProtocolVersion.V2_4,
                 )
 
     def test_modbus_sensor_uses_sigenergy_local_modbus_mapping_when_enabled(self, mock_config_all):
@@ -105,7 +105,7 @@ class TestModbusSensor:
                     icon="mdi:power",
                     gain=1.0,
                     precision=0,
-                    protocol_version=Protocol.V2_4,
+                    protocol_version=ProtocolVersion.V2_4,
                     unique_id_override="sigen_override_uid",
                 )
 
@@ -138,7 +138,7 @@ class TestModbusSensor:
                     icon="mdi:power",
                     gain=1.0,
                     precision=0,
-                    protocol_version=Protocol.V2_4,
+                    protocol_version=ProtocolVersion.V2_4,
                     unique_id_override="sigen_override_uid",
                 )
 
@@ -172,7 +172,7 @@ class TestModbusSensor:
                     icon="mdi:power",
                     gain=1.0,
                     precision=2,
-                    protocol_version=Protocol.V2_4,
+                    protocol_version=ProtocolVersion.V2_4,
                 )
 
             assert sensor.object_id == "sigen_local_name"
@@ -204,7 +204,7 @@ class TestModbusSensor:
                     icon="mdi:power",
                     gain=1.0,
                     precision=2,
-                    protocol_version=Protocol.V2_4,
+                    protocol_version=ProtocolVersion.V2_4,
                 )
 
             assert sensor.object_id == "sigen_local_name"
@@ -235,7 +235,7 @@ class TestModbusSensor:
                     icon="mdi:power",
                     gain=1.0,
                     precision=2,
-                    protocol_version=Protocol.V2_4,
+                    protocol_version=ProtocolVersion.V2_4,
                 )
 
             assert sensor.object_id == "sigen_local_name"
@@ -250,7 +250,7 @@ class TestModbusSensor:
                 {30005: {"object_id": "sigen_local_ts_name", "gain": 1.0, "unit": "s"}},
                 clear=True,
             ):
-                sensor = TimestampSensor("TS", "sigen_ts", InputType.INPUT, 0, 1, 30005, 10, Protocol.V2_4, tz=datetime.timezone.utc)
+                sensor = TimestampSensor("TS", "sigen_ts", InputType.INPUT, 0, 1, 30005, 10, ProtocolVersion.V2_4, tz=datetime.timezone.utc)
 
             assert sensor.object_id == "sigen_local_ts_name"
             assert getattr(sensor, "unit", sensor.get("unit_of_measurement")) is None
@@ -276,7 +276,7 @@ class TestReadOnlySensor:
                 icon="mdi:power",
                 gain=1.0,
                 precision=2,
-                protocol_version=Protocol.V2_4,
+                protocol_version=ProtocolVersion.V2_4,
             )
 
             mock_modbus = AsyncMock()
@@ -297,7 +297,7 @@ class TestTimestampSensor:
     @pytest.mark.asyncio
     async def test_get_state_timestamp(self):
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
-            sensor = TimestampSensor("TS", "sigen_ts", InputType.INPUT, 0, 1, 30005, 10, Protocol.V2_4, tz=datetime.timezone.utc)
+            sensor = TimestampSensor("TS", "sigen_ts", InputType.INPUT, 0, 1, 30005, 10, ProtocolVersion.V2_4, tz=datetime.timezone.utc)
 
             ts = 1700000000  # 2023-11-14 22:13:20 UTC
             with patch("sigenergy2mqtt.sensors.base.ReadOnlySensor.get_state", new_callable=AsyncMock) as mock_super_get:
@@ -309,7 +309,7 @@ class TestTimestampSensor:
 
     def test_state2raw_timestamp(self):
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
-            sensor = TimestampSensor("TS", "sigen_ts", InputType.INPUT, 0, 1, 30005, 10, Protocol.V2_4, tz=datetime.timezone.utc)
+            sensor = TimestampSensor("TS", "sigen_ts", InputType.INPUT, 0, 1, 30005, 10, ProtocolVersion.V2_4, tz=datetime.timezone.utc)
             iso_str = "2023-11-14T22:13:20+00:00"
             raw = sensor.state2raw(iso_str)
             assert raw == 1700000000
@@ -335,7 +335,7 @@ class TestNumericSensor:
                 "mdi:power",
                 1.0,
                 2,
-                Protocol.V2_4,
+                ProtocolVersion.V2_4,
                 minimum=0,
                 maximum=100,
             )
@@ -350,7 +350,7 @@ class TestSelectSensor:
     async def test_select_sensor_logic(self):
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
             options = ["A", "B", "C"]
-            sensor = SelectSensor(None, "Sel", "sigen_sel", 0, 1, 30200, 10, options, Protocol.V2_4)
+            sensor = SelectSensor(None, "Sel", "sigen_sel", 0, 1, 30200, 10, options, ProtocolVersion.V2_4)
 
             with patch("sigenergy2mqtt.sensors.base.ReadOnlySensor.get_state", new_callable=AsyncMock) as mock_super_get:
                 mock_super_get.return_value = 1
@@ -395,7 +395,7 @@ class TestEnergyAccumulationSensors:
         cfg.persistent_state_path = tmp_path
         with _swap_active_config(cfg):
             source = ReadOnlySensor(
-                "Source", "sigen_source", InputType.HOLDING, 0, 1, 30001, 1, ModbusClient.DATATYPE.UINT32, 10, "kWh", DeviceClass.ENERGY, StateClass.TOTAL_INCREASING, "mdi:energy", 1.0, 2, Protocol.V2_4
+                "Source", "sigen_source", InputType.HOLDING, 0, 1, 30001, 1, ModbusClient.DATATYPE.UINT32, 10, "kWh", DeviceClass.ENERGY, StateClass.TOTAL_INCREASING, "mdi:energy", 1.0, 2, ProtocolVersion.V2_4
             )
 
             with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
@@ -431,12 +431,12 @@ class TestEnergyAccumulationSensors:
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
             # name, object_id, input_type, plant_index, device_address, address, count, data_type, scan_interval, unit, device_class, state_class, icon, gain, precision, protocol_version
             with pytest.raises(AssertionError, match="Invalid data type UNKNOWN"):
-                ReadOnlySensor("RO", "sigen_ro", InputType.HOLDING, 0, 1, 30001, 1, "UNKNOWN", 10, "W", DeviceClass.POWER, StateClass.MEASUREMENT, "mdi:p", 1.0, 2, Protocol.V2_4)  # type: ignore
+                ReadOnlySensor("RO", "sigen_ro", InputType.HOLDING, 0, 1, 30001, 1, "UNKNOWN", 10, "W", DeviceClass.POWER, StateClass.MEASUREMENT, "mdi:p", 1.0, 2, ProtocolVersion.V2_4)  # type: ignore
 
     @pytest.mark.asyncio
     async def test_readonly_update_internal_state_failed(self):
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
-            sensor = ReadOnlySensor("RO", "sigen_ro", InputType.HOLDING, 0, 1, 30001, 1, ModbusDataType.UINT16, 10, "W", DeviceClass.POWER, StateClass.MEASUREMENT, "mdi:p", 1.0, 2, Protocol.V2_4)
+            sensor = ReadOnlySensor("RO", "sigen_ro", InputType.HOLDING, 0, 1, 30001, 1, ModbusDataType.UINT16, 10, "W", DeviceClass.POWER, StateClass.MEASUREMENT, "mdi:p", 1.0, 2, ProtocolVersion.V2_4)
             client = AsyncMock()
             rr = MagicMock()
             rr.isError.return_value = False  # So it doesn't raise Exception from _check_register_response
@@ -452,7 +452,7 @@ class TestReadWriteSensor:
 
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
             # availability, name, object_id, input_type, plant_index, device_address, address, count, data_type, scan_interval, unit, device_class, state_class, icon, gain, precision, protocol_version
-            sensor = ReadWriteSensor(None, "RW", "sigen_rw", InputType.HOLDING, 0, 1, 30001, 1, ModbusDataType.UINT16, 10, "W", DeviceClass.POWER, StateClass.MEASUREMENT, "mdi:p", 1.0, 2, Protocol.V2_4)
+            sensor = ReadWriteSensor(None, "RW", "sigen_rw", InputType.HOLDING, 0, 1, 30001, 1, ModbusDataType.UINT16, 10, "W", DeviceClass.POWER, StateClass.MEASUREMENT, "mdi:p", 1.0, 2, ProtocolVersion.V2_4)
             sensor.configure_mqtt_topics("sigen")
             client = AsyncMock()
             client.write_register.return_value = MagicMock(isError=lambda: False)

--- a/tests/unit/sensors/test_base_types_and_protocol.py
+++ b/tests/unit/sensors/test_base_types_and_protocol.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from sigenergy2mqtt.common import DeviceClass, Protocol, RegisterAccess, StateClass, UnitOfPower
+from sigenergy2mqtt.common import DeviceClass, ProtocolVersion, RegisterAccess, StateClass, UnitOfPower
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.modbus import ModbusDataType
 from sigenergy2mqtt.sensors.base import (
@@ -48,7 +48,7 @@ def _make_sensor(name="Test", uid_suffix="x", debug=False, **kwargs):
                 icon="mdi:solar-power",
                 gain=1.0,
                 precision=2,
-                protocol_version=Protocol.V2_4,
+                protocol_version=ProtocolVersion.V2_4,
                 debug_logging=debug,
                 **kwargs,
             )
@@ -80,7 +80,7 @@ class TestState2Raw:
                 icon=None,
                 gain=None,
                 precision=None,
-                protocol_version=Protocol.V2_4,
+                protocol_version=ProtocolVersion.V2_4,
             )
         s["options"] = options
         return s
@@ -130,9 +130,9 @@ class TestState2Raw:
 class TestProtocolVersionSetter:
     def test_protocol_version_float_valid(self):
         s = _make_sensor(uid_suffix="pv_float")
-        valid_float = Protocol.V2_4.value
+        valid_float = ProtocolVersion.V2_4.value
         s.protocol_version = float(valid_float)
-        assert s.protocol_version == Protocol.V2_4
+        assert s.protocol_version == ProtocolVersion.V2_4
 
     def test_protocol_version_float_invalid_raises(self):
         s = _make_sensor(uid_suffix="pv_bad")

--- a/tests/unit/sensors/test_base_validation_rules.py
+++ b/tests/unit/sensors/test_base_validation_rules.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from pymodbus import ModbusException
 
-from sigenergy2mqtt.common import DeviceClass, Protocol, StateClass, UnitOfPower
+from sigenergy2mqtt.common import DeviceClass, ProtocolVersion, StateClass, UnitOfPower
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.modbus import ModbusDataType
 from sigenergy2mqtt.sensors.base import (
@@ -45,7 +45,7 @@ def _make_sensor(name="Test", uid_suffix="x", debug=False, **kwargs):
             icon="mdi:solar-power",
             gain=1.0,
             precision=2,
-            protocol_version=Protocol.V2_4,
+            protocol_version=ProtocolVersion.V2_4,
             debug_logging=debug,
             **kwargs,
         )
@@ -85,7 +85,7 @@ class TestCheckRegisterResponse:
                 icon="mdi:flash",
                 gain=1.0,
                 precision=2,
-                protocol_version=Protocol.V2_4,
+                protocol_version=ProtocolVersion.V2_4,
             )
         return s
 
@@ -189,7 +189,7 @@ class TestReadOnlySensorUpdateInternalState:
                 icon="mdi:flash",
                 gain=1.0,
                 precision=2,
-                protocol_version=Protocol.V2_4,
+                protocol_version=ProtocolVersion.V2_4,
             )
 
     @pytest.mark.asyncio
@@ -243,7 +243,7 @@ class TestReadOnlySensorUpdateInternalState:
                 icon="mdi:flash",
                 gain=1.0,
                 precision=2,
-                protocol_version=Protocol.V2_4,
+                protocol_version=ProtocolVersion.V2_4,
             )
 
         rr = MagicMock()
@@ -393,6 +393,6 @@ class TestReadableSensorScanIntervalOverride:
                 icon="mdi:flash",
                 gain=1.0,
                 precision=2,
-                protocol_version=Protocol.V2_4,
+                protocol_version=ProtocolVersion.V2_4,
             )
         assert s.scan_interval == 99

--- a/tests/unit/sensors/test_decode_alarm_bit.py
+++ b/tests/unit/sensors/test_decode_alarm_bit.py
@@ -23,7 +23,7 @@ def setup_configs():
         yield
 
 
-from sigenergy2mqtt.common import Protocol  # noqa: E402
+from sigenergy2mqtt.common import ProtocolVersion  # noqa: E402
 from sigenergy2mqtt.sensors.ac_charger_read_only import ACChargerAlarm1, ACChargerAlarm2, ACChargerAlarm3  # noqa: E402
 from sigenergy2mqtt.sensors.base import Alarm1Sensor, Alarm2Sensor, Alarm3Sensor, Alarm4Sensor, Alarm5Sensor, Sensor  # noqa: E402
 from sigenergy2mqtt.sensors.plant_read_only import Alarm6, Alarm7  # noqa: E402
@@ -52,7 +52,7 @@ def clear_sensor_registries():
     ],
 )
 def test_base_alarms(sensor_class, bit, expected):
-    sensor = sensor_class("Alarm", f"{ENTITY_PREFIX}_obj", 0, 1, 30001, Protocol.V2_5)
+    sensor = sensor_class("Alarm", f"{ENTITY_PREFIX}_obj", 0, 1, 30001, ProtocolVersion.V2_5)
     assert sensor.decode_alarm_bit(bit) == expected
 
 

--- a/tests/unit/sensors/test_derived.py
+++ b/tests/unit/sensors/test_derived.py
@@ -26,7 +26,7 @@ def mock_modules():
         yield
 
 
-from sigenergy2mqtt.common import ConsumptionMethod, DeviceClass, Protocol, StateClass  # noqa: E402
+from sigenergy2mqtt.common import ConsumptionMethod, DeviceClass, ProtocolVersion, StateClass  # noqa: E402
 from sigenergy2mqtt.config import Config, _swap_active_config  # noqa: E402
 from sigenergy2mqtt.sensors.base import PVPowerSensor, Sensor  # noqa: E402
 from sigenergy2mqtt.sensors.plant_derived import (  # noqa: E402
@@ -65,7 +65,7 @@ class TestBatteryDerivedPower:
         proxy_battery = MagicMock(spec=BatteryPower)
         proxy_battery.device_class = DeviceClass.POWER
         proxy_battery.state_class = StateClass.MEASUREMENT
-        proxy_battery.protocol_version = Protocol.V2_4
+        proxy_battery.protocol_version = ProtocolVersion.V2_4
         proxy_battery.latest_raw_state = 1000.5
 
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
@@ -80,7 +80,7 @@ class TestBatteryDerivedPower:
         proxy_battery = MagicMock(spec=BatteryPower)
         proxy_battery.device_class = DeviceClass.POWER
         proxy_battery.state_class = StateClass.MEASUREMENT
-        proxy_battery.protocol_version = Protocol.V2_4
+        proxy_battery.protocol_version = ProtocolVersion.V2_4
         proxy_battery.latest_raw_state = 100.5
 
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
@@ -97,7 +97,7 @@ class TestGridDerivedPower:
         proxy_grid = MagicMock(spec=GridSensorActivePower)
         proxy_grid.device_class = DeviceClass.POWER
         proxy_grid.state_class = StateClass.MEASUREMENT
-        proxy_grid.protocol_version = Protocol.V2_4
+        proxy_grid.protocol_version = ProtocolVersion.V2_4
         proxy_grid.precision = 1
         proxy_grid.latest_raw_state = -100.2
 
@@ -110,7 +110,7 @@ class TestGridDerivedPower:
         proxy_grid = MagicMock(spec=GridSensorActivePower)
         proxy_grid.device_class = DeviceClass.POWER
         proxy_grid.state_class = StateClass.MEASUREMENT
-        proxy_grid.protocol_version = Protocol.V2_4
+        proxy_grid.protocol_version = ProtocolVersion.V2_4
         proxy_grid.precision = 1
         proxy_grid.latest_raw_state = 100.2
 

--- a/tests/unit/sensors/test_inverter.py
+++ b/tests/unit/sensors/test_inverter.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.sensors.base import Sensor
 from sigenergy2mqtt.sensors.inverter_derived import InverterBatteryChargingPower, InverterBatteryDischargingPower, PVStringPower
@@ -97,8 +97,8 @@ class TestInverterDerived:
 
     @pytest.mark.asyncio
     async def test_pv_string_power(self, mock_config):
-        v = PVVoltageSensor(0, 1, 31000, 1, Protocol.V1_8)
-        c = PVCurrentSensor(0, 1, 31001, 1, Protocol.V1_8)
+        v = PVVoltageSensor(0, 1, 31000, 1, ProtocolVersion.V1_8)
+        c = PVCurrentSensor(0, 1, 31001, 1, ProtocolVersion.V1_8)
 
         p = PVStringPower(0, 1, 1, v, c)
         assert "plant=0,dev=1,string=1" in p.log_identity

--- a/tests/unit/sensors/test_inverter_derived_edge_cases.py
+++ b/tests/unit/sensors/test_inverter_derived_edge_cases.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.sensors.base import Sensor
 from sigenergy2mqtt.sensors.inverter_derived import (
@@ -47,10 +47,10 @@ def _make_pv_string_power() -> PVStringPower:
     """Helper to create PVStringPower with mocked source sensors."""
     v = MagicMock(spec=PVVoltageSensor)
     v.gain = 10
-    v.protocol_version = Protocol.V2_4
+    v.protocol_version = ProtocolVersion.V2_4
     c = MagicMock(spec=PVCurrentSensor)
     c.gain = 100
-    c.protocol_version = Protocol.V2_4
+    c.protocol_version = ProtocolVersion.V2_4
     return PVStringPower(0, 1, 1, v, c)
 
 
@@ -66,7 +66,7 @@ class TestInverterBatteryChargingPowerNoneState:
             cdp = MagicMock(spec=ChargeDischargePower)
             cdp.device_class = "power"
             cdp.state_class = "measurement"
-            cdp.protocol_version = Protocol.V2_4
+            cdp.protocol_version = ProtocolVersion.V2_4
             sensor = InverterBatteryChargingPower(0, 1, cdp)
 
             source = MagicMock(spec=ChargeDischargePower)
@@ -80,7 +80,7 @@ class TestInverterBatteryChargingPowerNoneState:
             cdp = MagicMock(spec=ChargeDischargePower)
             cdp.device_class = "power"
             cdp.state_class = "measurement"
-            cdp.protocol_version = Protocol.V2_4
+            cdp.protocol_version = ProtocolVersion.V2_4
             sensor = InverterBatteryChargingPower(0, 1, cdp)
 
             source = MagicMock(spec=ChargeDischargePower)
@@ -102,7 +102,7 @@ class TestInverterBatteryDischargingPowerNoneState:
             cdp = MagicMock(spec=ChargeDischargePower)
             cdp.device_class = "power"
             cdp.state_class = "measurement"
-            cdp.protocol_version = Protocol.V2_4
+            cdp.protocol_version = ProtocolVersion.V2_4
             sensor = InverterBatteryDischargingPower(0, 1, cdp)
 
             source = MagicMock(spec=ChargeDischargePower)
@@ -222,12 +222,12 @@ class TestInverterSelfConsumedPowerEdgeCases:
         """Line 264: early-return when sensor.latest_raw_state is None."""
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
             ap = MagicMock(spec=ActivePower)
-            ap.protocol_version = Protocol.V2_4
+            ap.protocol_version = ProtocolVersion.V2_4
             bp = MagicMock(spec=ChargeDischargePower)
-            bp.protocol_version = Protocol.V2_4
+            bp.protocol_version = ProtocolVersion.V2_4
             pv1 = MagicMock(spec=PVStringPower)
             pv1.string_number = 1
-            pv1.protocol_version = Protocol.V2_4
+            pv1.protocol_version = ProtocolVersion.V2_4
 
             sensor = InverterSelfConsumedPower(0, 1, ap, bp, pv1)
 
@@ -241,12 +241,12 @@ class TestInverterSelfConsumedPowerEdgeCases:
         caplog.set_level(logging.DEBUG)
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
             ap = MagicMock(spec=ActivePower)
-            ap.protocol_version = Protocol.V2_4
+            ap.protocol_version = ProtocolVersion.V2_4
             bp = MagicMock(spec=ChargeDischargePower)
-            bp.protocol_version = Protocol.V2_4
+            bp.protocol_version = ProtocolVersion.V2_4
             pv1 = MagicMock(spec=PVStringPower)
             pv1.string_number = 1
-            pv1.protocol_version = Protocol.V2_4
+            pv1.protocol_version = ProtocolVersion.V2_4
 
             sensor = InverterSelfConsumedPower(0, 1, ap, bp, pv1)
             sensor.debug_logging = True
@@ -274,12 +274,12 @@ class TestInverterSelfConsumedPowerEdgeCases:
         caplog.set_level(logging.DEBUG)
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
             ap = MagicMock(spec=ActivePower)
-            ap.protocol_version = Protocol.V2_4
+            ap.protocol_version = ProtocolVersion.V2_4
             bp = MagicMock(spec=ChargeDischargePower)
-            bp.protocol_version = Protocol.V2_4
+            bp.protocol_version = ProtocolVersion.V2_4
             pv1 = MagicMock(spec=PVStringPower)
             pv1.string_number = 1
-            pv1.protocol_version = Protocol.V2_4
+            pv1.protocol_version = ProtocolVersion.V2_4
 
             sensor = InverterSelfConsumedPower(0, 1, ap, bp, pv1)
             sensor.debug_logging = True

--- a/tests/unit/sensors/test_inverter_derived_values.py
+++ b/tests/unit/sensors/test_inverter_derived_values.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.sensors.base import Sensor
 from sigenergy2mqtt.sensors.inverter_derived import (
@@ -42,7 +42,7 @@ class TestBatteryDerivedPowerCoverage:
             cdp = MagicMock(spec=ChargeDischargePower)
             cdp.device_class = "power"
             cdp.state_class = "measurement"
-            cdp.protocol_version = Protocol.V2_4
+            cdp.protocol_version = ProtocolVersion.V2_4
             sensor = InverterBatteryChargingPower(0, 1, cdp)
             assert "ChargeDischargePower > 0" in sensor.get_attributes()["source"]
 
@@ -51,7 +51,7 @@ class TestBatteryDerivedPowerCoverage:
             cdp = MagicMock(spec=ChargeDischargePower)
             cdp.device_class = "power"
             cdp.state_class = "measurement"
-            cdp.protocol_version = Protocol.V2_4
+            cdp.protocol_version = ProtocolVersion.V2_4
             sensor = InverterBatteryChargingPower(0, 1, cdp)
 
             # Wrong sensor type
@@ -63,7 +63,7 @@ class TestBatteryDerivedPowerCoverage:
             cdp = MagicMock(spec=ChargeDischargePower)
             cdp.device_class = "power"
             cdp.state_class = "measurement"
-            cdp.protocol_version = Protocol.V2_4
+            cdp.protocol_version = ProtocolVersion.V2_4
             sensor = InverterBatteryDischargingPower(0, 1, cdp)
             assert "ChargeDischargePower < 0" in sensor.get_attributes()["source"]
 
@@ -72,7 +72,7 @@ class TestBatteryDerivedPowerCoverage:
             cdp = MagicMock(spec=ChargeDischargePower)
             cdp.device_class = "power"
             cdp.state_class = "measurement"
-            cdp.protocol_version = Protocol.V2_4
+            cdp.protocol_version = ProtocolVersion.V2_4
             sensor = InverterBatteryDischargingPower(0, 1, cdp)
 
             # Wrong sensor type
@@ -85,10 +85,10 @@ class TestPVStringPowerCoverage:
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
             v = MagicMock(spec=PVVoltageSensor)
             v.gain = 10
-            v.protocol_version = Protocol.V2_4
+            v.protocol_version = ProtocolVersion.V2_4
             c = MagicMock(spec=PVCurrentSensor)
             c.gain = 100
-            c.protocol_version = Protocol.V2_4
+            c.protocol_version = ProtocolVersion.V2_4
             sensor = PVStringPower(0, 1, 1, v, c)
             assert "PVVoltageSensor × PVCurrentSensor" in sensor.get_attributes()["source"]
 
@@ -98,10 +98,10 @@ class TestPVStringPowerCoverage:
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
             v = MagicMock(spec=PVVoltageSensor)
             v.gain = 10
-            v.protocol_version = Protocol.V2_4
+            v.protocol_version = ProtocolVersion.V2_4
             c = MagicMock(spec=PVCurrentSensor)
             c.gain = 100
-            c.protocol_version = Protocol.V2_4
+            c.protocol_version = ProtocolVersion.V2_4
             sensor = PVStringPower(0, 1, 1, v, c)
             sensor.debug_logging = True
 
@@ -122,10 +122,10 @@ class TestPVStringPowerCoverage:
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
             v = MagicMock(spec=PVVoltageSensor)
             v.gain = 10
-            v.protocol_version = Protocol.V2_4
+            v.protocol_version = ProtocolVersion.V2_4
             c = MagicMock(spec=PVCurrentSensor)
             c.gain = 100
-            c.protocol_version = Protocol.V2_4
+            c.protocol_version = ProtocolVersion.V2_4
             sensor = PVStringPower(0, 1, 1, v, c)
 
             # Wrong sensor type
@@ -138,10 +138,10 @@ class TestPVStringEnergyCoverage:
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
             v = MagicMock(spec=PVVoltageSensor)
             v.gain = 10
-            v.protocol_version = Protocol.V2_4
+            v.protocol_version = ProtocolVersion.V2_4
             c = MagicMock(spec=PVCurrentSensor)
             c.gain = 100
-            c.protocol_version = Protocol.V2_4
+            c.protocol_version = ProtocolVersion.V2_4
 
             power = PVStringPower(0, 1, 1, v, c)
             power.unique_id = "power_uid"
@@ -164,12 +164,12 @@ class TestInverterSelfConsumedPowerCoverage:
 
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
             ap = MagicMock(spec=ActivePower)
-            ap.protocol_version = Protocol.V2_4
+            ap.protocol_version = ProtocolVersion.V2_4
             bp = MagicMock(spec=ChargeDischargePower)
-            bp.protocol_version = Protocol.V2_4
+            bp.protocol_version = ProtocolVersion.V2_4
             pv1 = MagicMock(spec=PVStringPower)
             pv1.string_number = 1
-            pv1.protocol_version = Protocol.V2_4
+            pv1.protocol_version = ProtocolVersion.V2_4
 
             sensor = InverterSelfConsumedPower(0, 1, ap, bp, pv1)
             assert "ActivePower − ChargeDischargePower" in sensor.get_attributes()["source"]
@@ -184,12 +184,12 @@ class TestInverterSelfConsumedPowerCoverage:
         caplog.set_level(logging.DEBUG)
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
             ap = MagicMock(spec=ActivePower)
-            ap.protocol_version = Protocol.V2_4
+            ap.protocol_version = ProtocolVersion.V2_4
             bp = MagicMock(spec=ChargeDischargePower)
-            bp.protocol_version = Protocol.V2_4
+            bp.protocol_version = ProtocolVersion.V2_4
             pv1 = MagicMock(spec=PVStringPower)
             pv1.string_number = 1
-            pv1.protocol_version = Protocol.V2_4
+            pv1.protocol_version = ProtocolVersion.V2_4
 
             sensor = InverterSelfConsumedPower(0, 1, ap, bp, pv1)
             sensor.debug_logging = True
@@ -215,12 +215,12 @@ class TestInverterSelfConsumedPowerCoverage:
 
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
             ap = MagicMock(spec=ActivePower)
-            ap.protocol_version = Protocol.V2_4
+            ap.protocol_version = ProtocolVersion.V2_4
             bp = MagicMock(spec=ChargeDischargePower)
-            bp.protocol_version = Protocol.V2_4
+            bp.protocol_version = ProtocolVersion.V2_4
             pv1 = MagicMock(spec=PVStringPower)
             pv1.string_number = 1
-            pv1.protocol_version = Protocol.V2_4
+            pv1.protocol_version = ProtocolVersion.V2_4
 
             sensor = InverterSelfConsumedPower(0, 1, ap, bp, pv1)
             sensor.debug_logging = True

--- a/tests/unit/sensors/test_mixins_coverage.py
+++ b/tests/unit/sensors/test_mixins_coverage.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pymodbus.pdu import ExceptionResponse
 
-from sigenergy2mqtt.common import DeviceClass, InputType, Protocol
+from sigenergy2mqtt.common import DeviceClass, InputType, ProtocolVersion
 from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.modbus import ModbusDataType
 from sigenergy2mqtt.sensors.base import DiscoveryKeys
@@ -32,7 +32,7 @@ class DummyReadable(ReadableSensorMixin, Sensor):
         kwargs.setdefault("icon", None)
         kwargs.setdefault("gain", 1)
         kwargs.setdefault("precision", 0)
-        kwargs.setdefault("protocol_version", Protocol.V2_9)
+        kwargs.setdefault("protocol_version", ProtocolVersion.V2_9)
         kwargs.setdefault("data_type", ModbusDataType.UINT16)
         super().__init__(**kwargs)
 
@@ -47,7 +47,7 @@ class DummyModbus(ModbusSensorMixin, Sensor):
         kwargs.setdefault("icon", None)
         kwargs.setdefault("gain", 1)
         kwargs.setdefault("precision", 0)
-        kwargs.setdefault("protocol_version", Protocol.V2_9)
+        kwargs.setdefault("protocol_version", ProtocolVersion.V2_9)
         kwargs.setdefault("data_type", ModbusDataType.UINT16)
         super().__init__(**kwargs)
 
@@ -145,7 +145,7 @@ def test_writable_sensor_mixin_raw2state_writeonly():
         plant_index=0,
         device_address=1,
         address=30000,
-        protocol_version=Protocol.V2_9
+        protocol_version=ProtocolVersion.V2_9
     )
     sensor._values = {"off": "0", "on": "1"}
     sensor._names = {"off": "Disabled", "on": "Enabled"}
@@ -164,7 +164,7 @@ def test_writable_sensor_mixin_raw2state_switch():
         device_address=1,
         address=30000,
         scan_interval=10,
-        protocol_version=Protocol.V2_9,
+        protocol_version=ProtocolVersion.V2_9,
         payload_off="OFF_VAL",
         payload_on="ON_VAL"
     )

--- a/tests/unit/sensors/test_non_modbus_writeable_sensors.py
+++ b/tests/unit/sensors/test_non_modbus_writeable_sensors.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.sensors.base import (
     NumericSensorMixin,
@@ -66,7 +66,7 @@ def sensor_kwargs(name: str) -> dict:
         "icon": "mdi:test-tube",
         "gain": 1,
         "precision": 0,
-        "protocol_version": Protocol.V2_4,
+        "protocol_version": ProtocolVersion.V2_4,
     }
 
 

--- a/tests/unit/sensors/test_persistence.py
+++ b/tests/unit/sensors/test_persistence.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
-from sigenergy2mqtt.common import InputType, Protocol, StateClass, UnitOfPower
+from sigenergy2mqtt.common import InputType, ProtocolVersion, StateClass, UnitOfPower
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.config.models.persistence import PersistenceConfig
 from sigenergy2mqtt.modbus import ModbusDataType
@@ -32,7 +32,7 @@ class MockSource(ReadOnlySensor):
             count=1,
             data_type=ModbusDataType.UINT16,
             scan_interval=10,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             unit=UnitOfPower.WATT,
             device_class="power",
             state_class=StateClass.MEASUREMENT,

--- a/tests/unit/sensors/test_plant_derived_battery_status.py
+++ b/tests/unit/sensors/test_plant_derived_battery_status.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from sigenergy2mqtt.common import DeviceClass, Protocol, StateClass
+from sigenergy2mqtt.common import DeviceClass, ProtocolVersion, StateClass
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.sensors.base import Sensor
 from sigenergy2mqtt.sensors.plant_derived import (
@@ -54,19 +54,19 @@ def _make_battery_status():
     bp = MagicMock(spec=BatteryPower)
     bp.device_class = DeviceClass.POWER
     bp.state_class = StateClass.MEASUREMENT
-    bp.protocol_version = Protocol.V2_9
+    bp.protocol_version = ProtocolVersion.V2_9
 
     backup_soc = MagicMock(spec=ESSBackupSOC)
-    backup_soc.protocol_version = Protocol.V2_9
+    backup_soc.protocol_version = ProtocolVersion.V2_9
 
     discharge_soc = MagicMock(spec=ESSDischargeCutOffSOC)
-    discharge_soc.protocol_version = Protocol.V2_9
+    discharge_soc.protocol_version = ProtocolVersion.V2_9
 
     charge_soc = MagicMock(spec=ESSChargeCutOffSOC)
-    charge_soc.protocol_version = Protocol.V2_9
+    charge_soc.protocol_version = ProtocolVersion.V2_9
 
     current_soc = MagicMock(spec=PlantBatterySoC)
-    current_soc.protocol_version = Protocol.V2_9
+    current_soc.protocol_version = ProtocolVersion.V2_9
 
     sensor = BatteryStatus(0, bp, current_soc, backup_soc, discharge_soc, charge_soc)
     return sensor, bp, backup_soc, discharge_soc, charge_soc, current_soc
@@ -80,7 +80,7 @@ class TestBatteryChargingPowerNoneState:
             bp = MagicMock(spec=BatteryPower)
             bp.device_class = DeviceClass.POWER
             bp.state_class = StateClass.MEASUREMENT
-            bp.protocol_version = Protocol.V2_4
+            bp.protocol_version = ProtocolVersion.V2_4
 
             sensor = BatteryChargingPower(0, bp)
             source = MagicMock(spec=BatteryPower)
@@ -97,7 +97,7 @@ class TestBatteryDischargingPowerNoneState:
             bp = MagicMock(spec=BatteryPower)
             bp.device_class = DeviceClass.POWER
             bp.state_class = StateClass.MEASUREMENT
-            bp.protocol_version = Protocol.V2_4
+            bp.protocol_version = ProtocolVersion.V2_4
 
             sensor = BatteryDischargingPower(0, bp)
             source = MagicMock(spec=BatteryPower)

--- a/tests/unit/sensors/test_plant_derived_values.py
+++ b/tests/unit/sensors/test_plant_derived_values.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from sigenergy2mqtt.common import ConsumptionMethod, DeviceClass, Protocol, StateClass
+from sigenergy2mqtt.common import ConsumptionMethod, DeviceClass, ProtocolVersion, StateClass
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.modbus import ModbusDataType
 from sigenergy2mqtt.sensors.base import PVPowerSensor, Sensor
@@ -52,7 +52,7 @@ class TestBasicDerivedSensorsCoverage:
             bp = MagicMock(spec=BatteryPower)
             bp.device_class = DeviceClass.POWER
             bp.state_class = StateClass.MEASUREMENT
-            bp.protocol_version = Protocol.V2_4
+            bp.protocol_version = ProtocolVersion.V2_4
             sensor = BatteryChargingPower(0, bp)
             assert "BatteryPower > 0" in str(sensor.get_attributes()["source"])
 
@@ -67,7 +67,7 @@ class TestBasicDerivedSensorsCoverage:
             bp = MagicMock(spec=BatteryPower)
             bp.device_class = DeviceClass.POWER
             bp.state_class = StateClass.MEASUREMENT
-            bp.protocol_version = Protocol.V2_4
+            bp.protocol_version = ProtocolVersion.V2_4
             sensor = BatteryDischargingPower(0, bp)
             assert "BatteryPower < 0" in str(sensor.get_attributes()["source"])
 
@@ -83,7 +83,7 @@ class TestBasicDerivedSensorsCoverage:
             gp.device_class = DeviceClass.POWER
             gp.state_class = StateClass.MEASUREMENT
             gp.precision = 2
-            gp.protocol_version = Protocol.V2_4
+            gp.protocol_version = ProtocolVersion.V2_4
             sensor = GridSensorExportPower(0, gp)
             assert "GridSensorActivePower < 0" in str(sensor.get_attributes()["source"])
 
@@ -99,7 +99,7 @@ class TestBasicDerivedSensorsCoverage:
             gp.device_class = DeviceClass.POWER
             gp.state_class = StateClass.MEASUREMENT
             gp.precision = 2
-            gp.protocol_version = Protocol.V2_4
+            gp.protocol_version = ProtocolVersion.V2_4
             sensor = GridSensorImportPower(0, gp)
             assert "GridSensorActivePower > 0" in str(sensor.get_attributes()["source"])
 
@@ -116,7 +116,7 @@ class TestBasicDerivedSensorsCoverage:
             source_exp = MagicMock(spec=PlantTotalExportedEnergy)
             source_exp.unique_id = "exp_uid"
             source_exp.data_type = ModbusDataType.UINT32
-            source_exp.protocol_version = Protocol.V2_4
+            source_exp.protocol_version = ProtocolVersion.V2_4
             source_exp.unit = "kWh"
             source_exp.object_id = "exp_oid"
             source_exp.device_class = DeviceClass.ENERGY
@@ -129,7 +129,7 @@ class TestBasicDerivedSensorsCoverage:
             source_imp = MagicMock(spec=PlantTotalImportedEnergy)
             source_imp.unique_id = "imp_uid"
             source_imp.data_type = ModbusDataType.UINT32
-            source_imp.protocol_version = Protocol.V2_4
+            source_imp.protocol_version = ProtocolVersion.V2_4
             source_imp.unit = "kWh"
             source_imp.object_id = "imp_oid"
             source_imp.device_class = DeviceClass.ENERGY
@@ -142,7 +142,7 @@ class TestBasicDerivedSensorsCoverage:
             source_tpv = MagicMock(spec=PlantPVTotalGeneration)
             source_tpv.unique_id = "tpv_uid"
             source_tpv.data_type = ModbusDataType.UINT32
-            source_tpv.protocol_version = Protocol.V2_4
+            source_tpv.protocol_version = ProtocolVersion.V2_4
             source_tpv.unit = "kWh"
             source_tpv.object_id = "tpv_oid"
             source_tpv.device_class = DeviceClass.ENERGY
@@ -161,7 +161,7 @@ class TestBasicDerivedSensorsCoverage:
             source_charge = MagicMock(spec=ESSTotalChargedEnergy)
             source_charge.unique_id = "ch_uid"
             source_charge.data_type = ModbusDataType.UINT32
-            source_charge.protocol_version = Protocol.V2_4
+            source_charge.protocol_version = ProtocolVersion.V2_4
             source_charge.unit = "kWh"
             source_charge.object_id = "ch_oid"
             source_charge.device_class = DeviceClass.ENERGY
@@ -174,7 +174,7 @@ class TestBasicDerivedSensorsCoverage:
             source_discharge = MagicMock(spec=ESSTotalDischargedEnergy)
             source_discharge.unique_id = "dis_uid"
             source_discharge.data_type = ModbusDataType.UINT32
-            source_discharge.protocol_version = Protocol.V2_4
+            source_discharge.protocol_version = ProtocolVersion.V2_4
             source_discharge.unit = "kWh"
             source_discharge.object_id = "dis_oid"
             source_discharge.device_class = DeviceClass.ENERGY
@@ -248,14 +248,14 @@ class TestPlantConsumedPowerCoverage:
         ac_sensor.unique_id = "ac_uid"
         ac_sensor.gain = 1.0
         ac_sensor.scan_interval = 10
-        ac_sensor.protocol_version = Protocol.V1_8
+        ac_sensor.protocol_version = ProtocolVersion.V1_8
         ac_sensor._publishable = True
         charger.get_all_sensors = MagicMock(return_value={"ac_uid": ac_sensor})
         charger.get_sensor = MagicMock(return_value=ac_sensor)
 
         sensor = PlantConsumedPower(0, ConsumptionMethod.CALCULATED)
         sensor.debug_logging = True
-        sensor.parent_device = type("Parent", (), {"protocol_version": Protocol.V1_8})()
+        sensor.parent_device = type("Parent", (), {"protocol_version": ProtocolVersion.V1_8})()
 
         with patch("sigenergy2mqtt.devices.base.registry.DeviceRegistry.get", return_value=[charger]):
             result = sensor.finalise_binding(0)
@@ -409,7 +409,7 @@ class TestPlantSelfConsumedPowerCoverage:
             sensor = PlantSelfConsumedPower(0)
             DeviceRegistry.clear()
 
-            dev = Device(name="Dev", plant_index=0, unique_id="uid", manufacturer="m", model="m", protocol_version=Protocol.V1_8)
+            dev = Device(name="Dev", plant_index=0, unique_id="uid", manufacturer="m", model="m", protocol_version=ProtocolVersion.V1_8)
             DeviceRegistry.add(0, dev)
 
             inv_sensor = MagicMock(spec=InverterSelfConsumedPower)

--- a/tests/unit/sensors/test_plant_read_write_ems_validation.py
+++ b/tests/unit/sensors/test_plant_read_write_ems_validation.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from sigenergy2mqtt.common import Constants, Protocol
+from sigenergy2mqtt.common import Constants, ProtocolVersion
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.sensors.base import AvailabilityMixin, Sensor
 from sigenergy2mqtt.sensors.plant_read_write import (

--- a/tests/unit/sensors/test_plant_sensor_state_and_discovery.py
+++ b/tests/unit/sensors/test_plant_sensor_state_and_discovery.py
@@ -6,7 +6,7 @@ import pytest
 
 import sigenergy2mqtt.sensors.plant_read_only as pro
 import sigenergy2mqtt.sensors.plant_read_write as prw
-from sigenergy2mqtt.common import ConsumptionMethod, Protocol, FirmwareVersion
+from sigenergy2mqtt.common import ConsumptionMethod, ProtocolVersion, FirmwareVersion
 from sigenergy2mqtt.devices.plant.plant import PowerPlant
 from sigenergy2mqtt.sensors.base import AvailabilityMixin, Sensor
 
@@ -36,7 +36,7 @@ class MockAvailabilitySensor(AvailabilityMixin):
         self.object_id = "sigen_mock_avail"
         self.get_state = AsyncMock(return_value=1)
         self.address = 30000
-        self._protocol_version = Protocol.V1_8
+        self._protocol_version = ProtocolVersion.V1_8
 
     def items(self):
         return [].items()
@@ -89,7 +89,7 @@ async def test_plant_read_only_coverage():
                     mock_alarm.device_address = 247
                     mock_alarm.address = 30000
                     mock_alarm.count = 1
-                    mock_alarm.protocol_version = Protocol.V1_8
+                    mock_alarm.protocol_version = ProtocolVersion.V1_8
                     kwargs[name] = [mock_alarm]
                 elif issubclass(param.annotation, AvailabilityMixin) if hasattr(param.annotation, "__mro__") else False:
                     kwargs[name] = MockAvailabilitySensor()
@@ -187,7 +187,7 @@ async def test_plant_read_write_coverage():
 
 
 def test_powerplant_register_sensors_calculated_consumption_uses_grid_sensors_by_type():
-    plant = PowerPlant(0, MagicMock(), Protocol.V2_8)
+    plant = PowerPlant(0, MagicMock(), ProtocolVersion.V2_8)
     plant._consumption_source = ConsumptionMethod.CALCULATED
 
     class FakeTotalPV:

--- a/tests/unit/sensors/test_scan_groups.py
+++ b/tests/unit/sensors/test_scan_groups.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import paho.mqtt.client as mqtt
 import pytest
 
-from sigenergy2mqtt.common import Constants, InputType, Protocol
+from sigenergy2mqtt.common import Constants, InputType, ProtocolVersion
 from sigenergy2mqtt.config import Config
 from sigenergy2mqtt.devices import Device, DeviceRegistry
 from sigenergy2mqtt.devices.base.poller import SensorGroupPoller
@@ -47,7 +47,7 @@ class DummyModbusSensor(ModbusSensorMixin, ReadableSensorMixin):
 
 
 class DummyAlarmSensor(ModbusSensorMixin, ReadableSensorMixin):
-    def __init__(self, name, plant_index, device_address, address, protocol_version=Protocol.V2_4):
+    def __init__(self, name, plant_index, device_address, address, protocol_version=ProtocolVersion.V2_4):
         super().__init__(
             input_type=InputType.INPUT,
             plant_index=plant_index,
@@ -140,7 +140,7 @@ class TestCreateSensorScanGroups:
 
     def test_ignores_scan_interval(self, mock_config):
         """Sensors with different scan_intervals but same device_address and contiguous addresses should be grouped together."""
-        dev = Device("test", 0, "uid", "mf", "mdl", Protocol.V1_8)
+        dev = Device("test", 0, "uid", "mf", "mdl", ProtocolVersion.V1_8)
 
         # Create sensors with different scan_intervals but contiguous addresses
         s1 = DummyModbusSensor("s1", address=100, count=1, device_address=1, scan_interval=5)
@@ -160,7 +160,7 @@ class TestCreateSensorScanGroups:
 
     def test_splits_by_device_address(self, mock_config):
         """Sensors with different device_address should be in separate groups."""
-        dev = Device("test", 0, "uid", "mf", "mdl", Protocol.V1_8)
+        dev = Device("test", 0, "uid", "mf", "mdl", ProtocolVersion.V1_8)
 
         s1 = DummyModbusSensor("s1", address=100, count=1, device_address=1, scan_interval=10)
         s2 = DummyModbusSensor("s2", address=101, count=1, device_address=2, scan_interval=10)
@@ -176,7 +176,7 @@ class TestCreateSensorScanGroups:
 
     def test_splits_on_address_gap(self, mock_config):
         """Sensors with non-contiguous addresses should be in separate groups."""
-        dev = Device("test", 0, "uid", "mf", "mdl", Protocol.V1_8)
+        dev = Device("test", 0, "uid", "mf", "mdl", ProtocolVersion.V1_8)
 
         s1 = DummyModbusSensor("s1", address=100, count=1, device_address=1, scan_interval=10)
         s2 = DummyModbusSensor("s2", address=200, count=1, device_address=1, scan_interval=10)  # Gap
@@ -192,7 +192,7 @@ class TestCreateSensorScanGroups:
 
     def test_respects_max_registers(self, mock_config):
         """Groups should be split when exceeding Constants.MAX_MODBUS_REGISTERS_PER_REQUEST."""
-        dev = Device("test", 0, "uid", "mf", "mdl", Protocol.V1_8)
+        dev = Device("test", 0, "uid", "mf", "mdl", ProtocolVersion.V1_8)
 
         # Create sensors that exceed the max register limit
         sensors = []
@@ -214,7 +214,7 @@ class TestCreateSensorScanGroups:
     def test_handles_reserved_sensors(self, mock_config):
         """Reserved sensors should not start or end a group."""
 
-        dev = Device("test", 0, "uid", "mf", "mdl", Protocol.V1_8)
+        dev = Device("test", 0, "uid", "mf", "mdl", ProtocolVersion.V1_8)
 
         # Create sequence: Reserved, Real, Reserved, Real, Reserved
         r1 = DummyReservedSensor(100)
@@ -246,7 +246,7 @@ class TestCreateSensorScanGroups:
     def test_respects_disable_chunking_true(self, mock_config):
         """Verify that contiguous sensors are NOT grouped when disable_chunking is True."""
         mock_config.modbus[0].disable_chunking = True
-        dev = Device("test", 0, "uid", "mf", "mdl", Protocol.V1_8)
+        dev = Device("test", 0, "uid", "mf", "mdl", ProtocolVersion.V1_8)
 
         s1 = DummyModbusSensor("s1", address=100, count=1, device_address=1)
         s2 = DummyModbusSensor("s2", address=101, count=1, device_address=1)
@@ -265,7 +265,7 @@ class TestCreateSensorScanGroups:
     def test_respects_disable_chunking_false(self, mock_config):
         """Verify that contiguous sensors ARE grouped when disable_chunking is False."""
         mock_config.modbus[0].disable_chunking = False
-        dev = Device("test", 0, "uid", "mf", "mdl", Protocol.V1_8)
+        dev = Device("test", 0, "uid", "mf", "mdl", ProtocolVersion.V1_8)
 
         s1 = DummyModbusSensor("s1", address=100, count=1, device_address=1)
         s2 = DummyModbusSensor("s2", address=101, count=1, device_address=1)
@@ -283,7 +283,7 @@ class TestCreateSensorScanGroups:
     def test_named_groups_ignore_disable_chunking(self, mock_config):
         """Verify that sensors in a named group REMAIN grouped even when disable_chunking is True."""
         mock_config.modbus[0].disable_chunking = True
-        dev = Device("test", 0, "uid", "mf", "mdl", Protocol.V1_8)
+        dev = Device("test", 0, "uid", "mf", "mdl", ProtocolVersion.V1_8)
 
         s1 = DummyModbusSensor("s1", address=100, count=1, device_address=1)
         s2 = DummyModbusSensor("s2", address=101, count=1, device_address=1)
@@ -307,7 +307,7 @@ class TestPublishUpdates:
     @pytest.mark.asyncio
     async def test_respects_individual_scan_intervals(self, mock_config):
         """Sensors with different scan_intervals should publish at their own rates."""
-        dev = Device("test", 0, "uid", "mf", "mdl", Protocol.V1_8)
+        dev = Device("test", 0, "uid", "mf", "mdl", ProtocolVersion.V1_8)
 
         # Fast sensor (1s) and slow sensor (5s) - both with force_publish to trigger immediate publish
         fast = DummyModbusSensor("fast", address=100, count=1, device_address=1, scan_interval=1)
@@ -354,7 +354,7 @@ class TestPublishUpdates:
     @pytest.mark.asyncio
     async def test_handles_force_publish(self, mock_config):
         """Setting force_publish should cause immediate publishing."""
-        dev = Device("test", 0, "uid", "mf", "mdl", Protocol.V1_8)
+        dev = Device("test", 0, "uid", "mf", "mdl", ProtocolVersion.V1_8)
 
         sensor = DummyModbusSensor("s1", address=100, count=1, device_address=1, scan_interval=60)
         sensor.force_publish = True  # Force immediate publish
@@ -396,9 +396,9 @@ class TestPublishUpdates:
 class TestSensorScanGroupsRecursion:
     def test_recursive_sensor_grouping(self, mock_config):
         """Verify that sensors from child and grandchild devices are grouped by the root device."""
-        root = Device("root", 0, "root_uid", "mf", "mdl", Protocol.V1_8)
-        child = Device("child", 0, "child_uid", "mf", "mdl", Protocol.V1_8)
-        grandchild = Device("grandchild", 0, "grandchild_uid", "mf", "mdl", Protocol.V1_8)
+        root = Device("root", 0, "root_uid", "mf", "mdl", ProtocolVersion.V1_8)
+        child = Device("child", 0, "child_uid", "mf", "mdl", ProtocolVersion.V1_8)
+        grandchild = Device("grandchild", 0, "grandchild_uid", "mf", "mdl", ProtocolVersion.V1_8)
 
         s_root = DummyModbusSensor("s_root", 30100)
         s_child = DummyModbusSensor("s_child", 30101)
@@ -426,7 +426,7 @@ class TestSensorScanGroupsRecursion:
     @pytest.mark.asyncio
     async def test_alarm_combined_sensor_read_ahead(self, mock_config):
         """Verify that AlarmCombinedSensor triggers read-ahead for its entire range."""
-        root = Device("root", 0, "root_uid", "mf", "mdl", Protocol.V1_8)
+        root = Device("root", 0, "root_uid", "mf", "mdl", ProtocolVersion.V1_8)
 
         a1 = DummyAlarmSensor("a1", 0, 1, 30605)
         a2 = DummyAlarmSensor("a2", 0, 1, 30606)
@@ -482,7 +482,7 @@ class TestSensorScanGroupsEdgeCases:
 
     def test_splits_on_single_register_gap(self, mock_config):
         """Verify that a gap of even 1 register causes a split."""
-        dev = Device("test", 0, "uid", "mf", "mdl", Protocol.V1_8)
+        dev = Device("test", 0, "uid", "mf", "mdl", ProtocolVersion.V1_8)
 
         # Gap of 1 register:
         # Sensor 1: 100 (count 1)
@@ -504,7 +504,7 @@ class TestSensorScanGroupsEdgeCases:
 
     def test_max_registers_boundary_exact(self, mock_config):
         """Verify grouping behavior exactly at and exceeding the MAX_MODBUS_REGISTERS_PER_REQUEST limit."""
-        dev = Device("test", 0, "uid", "mf", "mdl", Protocol.V1_8)
+        dev = Device("test", 0, "uid", "mf", "mdl", ProtocolVersion.V1_8)
 
         sensors_exact = []
         for i in range(Constants.MAX_MODBUS_REGISTERS_PER_REQUEST):
@@ -536,7 +536,7 @@ class TestSensorScanGroupsEdgeCases:
 
     def test_named_groups_interaction(self, mock_config):
         """Verify interaction between named groups and auto-grouped sensors."""
-        dev = Device("test", 0, "uid", "mf", "mdl", Protocol.V1_8)
+        dev = Device("test", 0, "uid", "mf", "mdl", ProtocolVersion.V1_8)
 
         # Define 3 contiguous sensors
         # s1: 100
@@ -575,7 +575,7 @@ class TestSensorScanGroupsEdgeCases:
     @pytest.mark.asyncio
     async def test_oversized_named_group_skips_preread(self, mock_config):
         """Verify that a named group exceeding MAX_MODBUS_REGISTERS_PER_REQUEST skips read_ahead_registers."""
-        dev = Device("test", 0, "uid", "mf", "mdl", Protocol.V1_8)
+        dev = Device("test", 0, "uid", "mf", "mdl", ProtocolVersion.V1_8)
 
         # Create sensors for a named group "BigGroup" that is oversized
         # MAX = 125, so let's make it 130 registers
@@ -636,7 +636,7 @@ class TestSensorScanGroupsEdgeCases:
 
     def test_named_sensors_bridge_gap_different_groups(self, mock_config):
         """Verify that sensors in DIFFERENT named groups bridge gaps for auto-grouped sensors."""
-        dev = Device("test", 0, "uid", "mf", "mdl", Protocol.V1_8)
+        dev = Device("test", 0, "uid", "mf", "mdl", ProtocolVersion.V1_8)
 
         # Scenario:
         # S1 (Auto) @ 100

--- a/tests/unit/sensors/test_sensors_cross_device_binding.py
+++ b/tests/unit/sensors/test_sensors_cross_device_binding.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from sigenergy2mqtt.common import Protocol
+from sigenergy2mqtt.common import ProtocolVersion
 from sigenergy2mqtt.devices.base.device import Device, bind_cross_device_sensors
 from sigenergy2mqtt.devices.base.registry import DeviceRegistry
 from sigenergy2mqtt.modbus import ModbusDataType
@@ -11,7 +11,7 @@ from sigenergy2mqtt.sensors.base import CrossDeviceDerivedSensor, ReadableSensor
 
 
 class MockSensor(ReadableSensorMixin, Sensor):
-    def __init__(self, plant_index, device_address, name, unique_id, protocol_version=Protocol.V1_8):
+    def __init__(self, plant_index, device_address, name, unique_id, protocol_version=ProtocolVersion.V1_8):
         self.plant_index = plant_index
         self.device_address = device_address
         super().__init__(
@@ -64,7 +64,7 @@ def clear_registries():
 
 def test_cross_device_sensor_registration():
     """Test that CrossDeviceDerivedSensor can be added to a device without sources."""
-    dev = Device(name="Test Device", plant_index=0, unique_id="sigen_test_uid", manufacturer="M", model="M", protocol_version=Protocol.V1_8)
+    dev = Device(name="Test Device", plant_index=0, unique_id="sigen_test_uid", manufacturer="M", model="M", protocol_version=ProtocolVersion.V1_8)
     
     # Create a cross-device sensor
     sensor = MockCrossSensor(0, 100, "Cross", "sigen_cross_uid")
@@ -76,16 +76,16 @@ def test_cross_device_sensor_registration():
 def test_bind_cross_device_sensors_success():
     """Test successful binding across two devices."""
     # Device 1 with a source sensor
-    dev1 = Device(name="Dev1", plant_index=0, unique_id="sigen_dev1_uid", manufacturer="M", model="M", protocol_version=Protocol.V1_8)
+    dev1 = Device(name="Dev1", plant_index=0, unique_id="sigen_dev1_uid", manufacturer="M", model="M", protocol_version=ProtocolVersion.V1_8)
     source = MockSensor(0, 1, "Source", "sigen_source_uid")
     dev1._add_sensor(source)
     
     # Device 2 with a cross-device sensor
-    dev2 = Device(name="Dev2", plant_index=0, unique_id="sigen_dev2_uid", manufacturer="M", model="M", protocol_version=Protocol.V1_8)
+    dev2 = Device(name="Dev2", plant_index=0, unique_id="sigen_dev2_uid", manufacturer="M", model="M", protocol_version=ProtocolVersion.V1_8)
     # Use a dummy source object just to record the unique_id we want
     dummy_source = MagicMock(spec=Sensor)
     dummy_source.unique_id = "sigen_source_uid"
-    dummy_source.protocol_version = Protocol.V1_8
+    dummy_source.protocol_version = ProtocolVersion.V1_8
     
     cross = MockCrossSensor(0, 2, "Cross", "sigen_cross_uid", sources=[dummy_source])
     dev2._add_sensor(cross)
@@ -105,17 +105,17 @@ def test_bind_cross_device_sensors_success():
 def test_bind_cross_device_sensors_protocol_mismatch():
     """Test that binding is skipped if source protocol > device protocol."""
     # Device 1 with a V2.8 source
-    dev1 = Device(name="Dev1", plant_index=0, unique_id="sigen_dev1_uid", manufacturer="M", model="M", protocol_version=Protocol.V1_8)
-    source = MockSensor(0, 1, "Source", "sigen_source_uid", protocol_version=Protocol.V2_8)
+    dev1 = Device(name="Dev1", plant_index=0, unique_id="sigen_dev1_uid", manufacturer="M", model="M", protocol_version=ProtocolVersion.V1_8)
+    source = MockSensor(0, 1, "Source", "sigen_source_uid", protocol_version=ProtocolVersion.V2_8)
     dev1._add_sensor(source)
     
     # Device 2 with V1.8 protocol
-    dev2 = Device(name="Dev2", plant_index=0, unique_id="sigen_dev2_uid", manufacturer="M", model="M", protocol_version=Protocol.V1_8)
-    dev2.protocol_version = Protocol.V1_8
+    dev2 = Device(name="Dev2", plant_index=0, unique_id="sigen_dev2_uid", manufacturer="M", model="M", protocol_version=ProtocolVersion.V1_8)
+    dev2.protocol_version = ProtocolVersion.V1_8
     
     dummy_source = MagicMock(spec=Sensor)
     dummy_source.unique_id = "sigen_source_uid"
-    dummy_source.protocol_version = Protocol.V2_8
+    dummy_source.protocol_version = ProtocolVersion.V2_8
     
     cross = MockCrossSensor(0, 2, "Cross", "sigen_cross_uid", sources=[dummy_source])
     dev2._add_sensor(cross)
@@ -129,11 +129,11 @@ def test_bind_cross_device_sensors_protocol_mismatch():
 
 def test_bind_cross_device_sensors_missing_source(caplog):
     """Test warning when a declared cross-device source is missing."""
-    dev = Device(name="Dev", plant_index=0, unique_id="sigen_dev_uid", manufacturer="M", model="M", protocol_version=Protocol.V1_8)
+    dev = Device(name="Dev", plant_index=0, unique_id="sigen_dev_uid", manufacturer="M", model="M", protocol_version=ProtocolVersion.V1_8)
     
     dummy_source = MagicMock(spec=Sensor)
     dummy_source.unique_id = "sigen_missing_uid"
-    dummy_source.protocol_version = Protocol.V1_8
+    dummy_source.protocol_version = ProtocolVersion.V1_8
     
     cross = MockCrossSensor(0, 1, "Cross", "sigen_cross_uid", sources=[dummy_source])
     dev._add_sensor(cross)
@@ -162,7 +162,7 @@ def test_finalise_binding_requires_parent_device():
 
 
 def test_finalise_binding_logs_when_no_pending_sources(caplog):
-    dev = Device(name="Dev", plant_index=0, unique_id="sigen_dev_no_pending_uid", manufacturer="M", model="M", protocol_version=Protocol.V1_8)
+    dev = Device(name="Dev", plant_index=0, unique_id="sigen_dev_no_pending_uid", manufacturer="M", model="M", protocol_version=ProtocolVersion.V1_8)
     cross = MockCrossSensor(0, 1, "Cross No Pending", "sigen_cross_no_pending_uid")
     dev._add_sensor(cross)
 
@@ -173,18 +173,18 @@ def test_finalise_binding_logs_when_no_pending_sources(caplog):
 
 
 def test_finalise_binding_uses_explicit_sources_and_debug_logs(caplog):
-    dev1 = Device(name="Dev Source", plant_index=0, unique_id="sigen_dev_explicit_src_uid", manufacturer="M", model="M", protocol_version=Protocol.V1_8)
+    dev1 = Device(name="Dev Source", plant_index=0, unique_id="sigen_dev_explicit_src_uid", manufacturer="M", model="M", protocol_version=ProtocolVersion.V1_8)
     source = MockSensor(0, 1, "Source Explicit", "sigen_source_explicit_uid")
     dev1._add_sensor(source)
 
-    dev2 = Device(name="Dev Cross", plant_index=0, unique_id="sigen_dev_explicit_cross_uid", manufacturer="M", model="M", protocol_version=Protocol.V1_8)
+    dev2 = Device(name="Dev Cross", plant_index=0, unique_id="sigen_dev_explicit_cross_uid", manufacturer="M", model="M", protocol_version=ProtocolVersion.V1_8)
     cross = MockCrossSensor(0, 2, "Cross Explicit", "sigen_cross_explicit_uid")
     cross.debug_logging = True
     dev2._add_sensor(cross)
 
     pending = MagicMock(spec=Sensor)
     pending.unique_id = "sigen_source_explicit_uid"
-    pending.protocol_version = Protocol.V1_8
+    pending.protocol_version = ProtocolVersion.V1_8
 
     with caplog.at_level(logging.DEBUG):
         assert cross.finalise_binding(0, pending, None) is True

--- a/tests/unit/sensors/test_state_helpers.py
+++ b/tests/unit/sensors/test_state_helpers.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from sigenergy2mqtt.common import DeviceClass, InputType, Protocol, UnitOfPower
+from sigenergy2mqtt.common import DeviceClass, InputType, ProtocolVersion, UnitOfPower
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.modbus import ModbusDataType
 from sigenergy2mqtt.sensors.base import AlarmCombinedSensor, AlarmSensor, NumericSensor, RunningStateSensor, SelectSensor, Sensor
@@ -46,7 +46,7 @@ class TestSelectSensor:
             address=30000,
             scan_interval=60,
             options=["Option A", "Option B"],
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
 
         # Valid cases
@@ -82,7 +82,7 @@ class TestNumericSensor:
             count=1,
             data_type=ModbusDataType.UINT16,
             scan_interval=60,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             minimum=10.0,
             maximum=20.0,
             unit=UnitOfPower.WATT,
@@ -128,7 +128,7 @@ class TestNumericSensor:
             count=1,
             data_type=ModbusDataType.UINT16,
             scan_interval=60,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             minimum=(-20.0, -10.0),
             maximum=(10.0, 20.0),
             unit=UnitOfPower.WATT,
@@ -170,7 +170,7 @@ class ConcreteAlarmSensor(AlarmSensor):
 class TestAlarmSensor:
     @pytest.mark.asyncio
     async def test_get_state_logic(self):
-        sensor = ConcreteAlarmSensor(name="Test Alarm", object_id="sigen_test_alarm", plant_index=0, device_address=1, address=30000, protocol_version=Protocol.V1_8, alarm_type="TestType")
+        sensor = ConcreteAlarmSensor(name="Test Alarm", object_id="sigen_test_alarm", plant_index=0, device_address=1, address=30000, protocol_version=ProtocolVersion.V1_8, alarm_type="TestType")
         with patch("sigenergy2mqtt.sensors.base.Sensor.get_state", new_callable=AsyncMock) as mock_super:
             # 1. No Alarm cases
             mock_super.return_value = 0
@@ -220,8 +220,8 @@ class TestAlarmCombinedSensor:
     @pytest.mark.asyncio
     async def test_get_state_aggregation(self):
         # Create child sensors with mocked get_state
-        a1 = ConcreteAlarmSensor("A1", "sigen_a1", 0, 1, 30000, Protocol.V1_8, alarm_type="TypeA")
-        a2 = ConcreteAlarmSensor("A2", "sigen_a2", 0, 1, 30001, Protocol.V1_8, alarm_type="TypeB")
+        a1 = ConcreteAlarmSensor("A1", "sigen_a1", 0, 1, 30000, ProtocolVersion.V1_8, alarm_type="TypeA")
+        a2 = ConcreteAlarmSensor("A2", "sigen_a2", 0, 1, 30001, ProtocolVersion.V1_8, alarm_type="TypeB")
 
         combined = AlarmCombinedSensor("Combined", "sigen_combined_uid", "sigen_combined_oid", a1, a2)
         # Test 1: All No Alarm
@@ -249,7 +249,7 @@ class TestAlarmCombinedSensor:
 class TestRunningStateSensor:
     @pytest.mark.asyncio
     async def test_get_state_invalid_index(self):
-        sensor = RunningStateSensor(name="Run State", object_id="sigen_run_state", plant_index=0, device_address=1, address=30000, protocol_version=Protocol.V1_8)
+        sensor = RunningStateSensor(name="Run State", object_id="sigen_run_state", plant_index=0, device_address=1, address=30000, protocol_version=ProtocolVersion.V1_8)
         # RunningStateSensor defines options in __init__
 
         with patch("sigenergy2mqtt.sensors.base.ReadOnlySensor.get_state", new_callable=AsyncMock) as mock_super:

--- a/tests/unit/sensors/test_value_is_valid.py
+++ b/tests/unit/sensors/test_value_is_valid.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
-from sigenergy2mqtt.common import InputType, Protocol, UnitOfPower
+from sigenergy2mqtt.common import InputType, ProtocolVersion, UnitOfPower
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.modbus import ModbusDataType
 from sigenergy2mqtt.sensors.base import (
@@ -69,7 +69,7 @@ class TestValueIsValidBase:
             icon="mdi:test",
             gain=1.0,
             precision=2,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             data_type=ModbusDataType.UINT16,
             input_type=InputType.HOLDING,
             plant_index=0,
@@ -88,7 +88,7 @@ class TestValueIsValidBase:
             plant_index=0,
             device_address=247,
             address=40000,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             value_off=0,
             value_on=1,
         )
@@ -114,7 +114,7 @@ class TestValueIsValidBase:
             icon="mdi:test",
             gain=1.0,
             precision=1,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             minimum=0.0,
             maximum=100.0,
         )
@@ -143,7 +143,7 @@ class TestValueIsValidBase:
             icon="mdi:test",
             gain=1.0,
             precision=1,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
             minimum=(-10.0, -5.0),
             maximum=(5.0, 10.0),
         )
@@ -166,7 +166,7 @@ class TestValueIsValidBase:
             address=40001,
             scan_interval=60,
             options=["A", "B", "C"],
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         assert await sensor.value_is_valid(None, "A") is True
         assert await sensor.value_is_valid(None, "B") is True
@@ -185,7 +185,7 @@ class TestValueIsValidBase:
             device_address=247,
             address=40001,
             scan_interval=60,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         assert await sensor.value_is_valid(None, 0) is True
         assert await sensor.value_is_valid(None, 1) is True
@@ -227,7 +227,7 @@ class TestValueIsValidPlant:
             address=40032,
             icon="mdi:test",
             maximum=10.0,
-            protocol_version=Protocol.V1_8,
+            protocol_version=ProtocolVersion.V1_8,
         )
         assert await sensor.value_is_valid(None, 5) is True
 

--- a/tests/unit/sensors/test_writeable.py
+++ b/tests/unit/sensors/test_writeable.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 # Imported here (no hacks needed for mqtt any more)
-from sigenergy2mqtt.common import InputType, Protocol
+from sigenergy2mqtt.common import InputType, ProtocolVersion
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.modbus import ModbusClient
 from sigenergy2mqtt.sensors.base import NumericSensor, SelectSensor, Sensor, SwitchSensor, WriteOnlySensor
@@ -74,7 +74,7 @@ class TestWriteableSensorMixin:
     @pytest.mark.asyncio
     async def test_write_registers_single_uint16(self, mock_lock_factory, mock_modbus):
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
-            sensor = WriteOnlySensor("Test", "sigen_test", 0, 1, 30001, Protocol.V2_4)
+            sensor = WriteOnlySensor("Test", "sigen_test", 0, 1, 30001, ProtocolVersion.V2_4)
             mock_mqtt = MagicMock()
 
             mock_rr = MagicMock()
@@ -90,7 +90,7 @@ class TestWriteableSensorMixin:
     @pytest.mark.asyncio
     async def test_write_registers_multiple_registers(self, mock_lock_factory, mock_modbus):
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
-            sensor = NumericSensor(None, "Test", "sigen_test", InputType.HOLDING, 0, 1, 30001, 2, ModbusClient.DATATYPE.UINT32, 10, "U", None, "mdi:power", 1.0, 2, Protocol.V2_4)
+            sensor = NumericSensor(None, "Test", "sigen_test", InputType.HOLDING, 0, 1, 30001, 2, ModbusClient.DATATYPE.UINT32, 10, "U", None, "mdi:power", 1.0, 2, ProtocolVersion.V2_4)
 
             mock_mqtt = MagicMock()
             # Disable side_effect to use return_value
@@ -109,7 +109,7 @@ class TestWriteableSensorMixin:
     @pytest.mark.asyncio
     async def test_write_registers_error_response(self, mock_lock_factory, mock_modbus):
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
-            sensor = WriteOnlySensor("Test", "sigen_test", 0, 1, 30001, Protocol.V2_4)
+            sensor = WriteOnlySensor("Test", "sigen_test", 0, 1, 30001, ProtocolVersion.V2_4)
 
             mock_rr = MagicMock()
             mock_rr.isError.return_value = True
@@ -123,7 +123,7 @@ class TestWriteableSensorMixin:
     @pytest.mark.asyncio
     async def test_write_registers_timeout(self, mock_modbus):
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
-            sensor = WriteOnlySensor("Test", "sigen_test", 0, 1, 30001, Protocol.V2_4)
+            sensor = WriteOnlySensor("Test", "sigen_test", 0, 1, 30001, ProtocolVersion.V2_4)
 
             with patch("sigenergy2mqtt.sensors.base.ModbusLockFactory.get") as mock_lock_factory_get:
                 mock_lock = MagicMock()
@@ -143,7 +143,7 @@ class TestWriteableSensorMixin:
     @pytest.mark.asyncio
     async def test_write_registers_cancelled(self, mock_lock_factory, mock_modbus):
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
-            sensor = WriteOnlySensor("Test", "sigen_test", 0, 1, 30001, Protocol.V2_4)
+            sensor = WriteOnlySensor("Test", "sigen_test", 0, 1, 30001, ProtocolVersion.V2_4)
             mock_modbus.write_register.side_effect = asyncio.CancelledError()
 
             result = await sensor._write_registers(mock_modbus, 1, MagicMock())
@@ -155,7 +155,7 @@ class TestWriteOnlySensorLogic:
     @pytest.mark.asyncio
     async def test_write_only_sensor_set_value(self, mock_lock_factory, mock_modbus):
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
-            sensor = WriteOnlySensor("Test", "sigen_test", 0, 1, 30001, Protocol.V2_4, payload_on="on", payload_off="off", value_on=1, value_off=0)
+            sensor = WriteOnlySensor("Test", "sigen_test", 0, 1, 30001, ProtocolVersion.V2_4, payload_on="on", payload_off="off", value_on=1, value_off=0)
             sensor.configure_mqtt_topics("test_device")
 
             mock_mqtt = MagicMock()
@@ -172,7 +172,7 @@ class TestNumericSensorWriteable:
     @pytest.mark.asyncio
     async def test_numeric_sensor_set_value_with_gain(self, mock_lock_factory, mock_modbus):
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
-            sensor = NumericSensor(None, "Test", "sigen_test", InputType.HOLDING, 0, 1, 30100, 1, ModbusClient.DATATYPE.UINT16, 10, "W", None, "mdi:power", 10.0, 0, Protocol.V2_4, minimum=0, maximum=1000)
+            sensor = NumericSensor(None, "Test", "sigen_test", InputType.HOLDING, 0, 1, 30100, 1, ModbusClient.DATATYPE.UINT16, 10, "W", None, "mdi:power", 10.0, 0, ProtocolVersion.V2_4, minimum=0, maximum=1000)
             sensor.configure_mqtt_topics("test_device")
 
             mock_rr = MagicMock()
@@ -203,7 +203,7 @@ class TestNumericSensorWriteable:
                 "mdi:power",
                 1.0,
                 0,
-                Protocol.V2_4,
+                ProtocolVersion.V2_4,
                 minimum=0,
                 maximum=100,
             )
@@ -241,7 +241,7 @@ class TestNumericSensorWriteable:
                 "mdi:power",
                 10.0,
                 0,
-                Protocol.V2_4,
+                ProtocolVersion.V2_4,
                 minimum=0,
                 maximum=1000,
             )
@@ -261,7 +261,7 @@ class TestNumericSensorWriteable:
         """When raw=True and value is out-of-range the raw return should NOT include gain."""
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
             sensor = NumericSensor(
-                None, "NumRaw", "sigen_numraw", InputType.HOLDING, 0, 1, 30103, 1, ModbusClient.DATATYPE.UINT16, 10, "W", None, "mdi:power", 2.0, 1, Protocol.V2_4, minimum=10.0, maximum=100.0
+                None, "NumRaw", "sigen_numraw", InputType.HOLDING, 0, 1, 30103, 1, ModbusClient.DATATYPE.UINT16, 10, "W", None, "mdi:power", 2.0, 1, ProtocolVersion.V2_4, minimum=10.0, maximum=100.0
             )
 
             with patch("sigenergy2mqtt.sensors.base.ReadWriteSensor.get_state", new_callable=AsyncMock) as mock_super:
@@ -276,7 +276,7 @@ class TestSelectSensorWriteable:
     async def test_select_sensor_set_value_index(self, mock_lock_factory, mock_modbus):
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
             options = ["Off", "On", "Auto"]
-            sensor = SelectSensor(None, "Test", "sigen_test", 0, 1, 30200, 10, options, Protocol.V2_4)
+            sensor = SelectSensor(None, "Test", "sigen_test", 0, 1, 30200, 10, options, ProtocolVersion.V2_4)
             sensor.configure_mqtt_topics("test_device")
 
             mock_rr = MagicMock()
@@ -292,7 +292,7 @@ class TestSelectSensorWriteable:
         """SelectSensor should accept numeric index strings and reject invalid values."""
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
             options = ["Off", "On", "Auto"]
-            sensor = SelectSensor(None, "Test", "sigen_test", 0, 1, 30201, 10, options, Protocol.V2_4)
+            sensor = SelectSensor(None, "Test", "sigen_test", 0, 1, 30201, 10, options, ProtocolVersion.V2_4)
             sensor.configure_mqtt_topics("test_device")
 
             mock_rr = MagicMock()
@@ -320,7 +320,7 @@ class TestSelectSensorWriteable:
         """Covers translated-option matching and empty-option handling."""
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
             options = ["Off", "", "Auto"]
-            sensor = SelectSensor(None, "Test", "sigen_test_trans", 0, 1, 30202, 10, options, Protocol.V2_4)
+            sensor = SelectSensor(None, "Test", "sigen_test_trans", 0, 1, 30202, 10, options, ProtocolVersion.V2_4)
             sensor.configure_mqtt_topics("test_device")
 
             # Empty option should be treated as unknown when reading
@@ -344,7 +344,7 @@ class TestSelectSensorWriteable:
         """SelectSensor should accept numeric float-strings (e.g. '1.0') and reject case-mismatched option strings."""
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
             options = ["Off", "On", "Auto"]
-            sensor = SelectSensor(None, "Test", "sigen_test_case", 0, 1, 30203, 10, options, Protocol.V2_4)
+            sensor = SelectSensor(None, "Test", "sigen_test_case", 0, 1, 30203, 10, options, ProtocolVersion.V2_4)
             sensor.configure_mqtt_topics("test_device")
 
             mock_rr = MagicMock()
@@ -366,7 +366,7 @@ class TestSelectSensorWriteable:
     async def test_switch_accepts_boolean_values(self, mock_lock_factory, mock_modbus):
         """SwitchSensor should accept True/False and write 1/0 respectively."""
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
-            sensor = SwitchSensor(None, "Test", "sigen_switch_bool", 0, 1, 30302, 10, Protocol.V2_4)
+            sensor = SwitchSensor(None, "Test", "sigen_switch_bool", 0, 1, 30302, 10, ProtocolVersion.V2_4)
             sensor.configure_mqtt_topics("test_device")
 
             mock_rr = MagicMock()
@@ -386,7 +386,7 @@ class TestSelectSensorWriteable:
         """NumericSensor should accept decimal strings and (with precision=0) write the integer part."""
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
             sensor = NumericSensor(
-                None, "Test", "sigen_num_decimal", InputType.HOLDING, 0, 1, 30104, 1, ModbusClient.DATATYPE.UINT16, 10, "W", None, "mdi:power", 1.0, 0, Protocol.V2_4, minimum=0, maximum=1000
+                None, "Test", "sigen_num_decimal", InputType.HOLDING, 0, 1, 30104, 1, ModbusClient.DATATYPE.UINT16, 10, "W", None, "mdi:power", 1.0, 0, ProtocolVersion.V2_4, minimum=0, maximum=1000
             )
             sensor.configure_mqtt_topics("test_device")
 
@@ -404,7 +404,7 @@ class TestSwitchSensorWriteable:
     @pytest.mark.asyncio
     async def test_switch_sensor_set_value(self, mock_lock_factory, mock_modbus):
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
-            sensor = SwitchSensor(None, "Test", "sigen_test", 0, 1, 30300, 10, Protocol.V2_4)
+            sensor = SwitchSensor(None, "Test", "sigen_test", 0, 1, 30300, 10, ProtocolVersion.V2_4)
             sensor.configure_mqtt_topics("test_device")
 
             mock_rr = MagicMock()
@@ -419,7 +419,7 @@ class TestSwitchSensorWriteable:
     async def test_switch_sensor_set_value_string_and_bad(self, mock_lock_factory, mock_modbus, caplog):
         """SwitchSensor should accept numeric strings but raise on non-numeric input."""
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
-            sensor = SwitchSensor(None, "Test", "sigen_test2", 0, 1, 30301, 10, Protocol.V2_4)
+            sensor = SwitchSensor(None, "Test", "sigen_test2", 0, 1, 30301, 10, ProtocolVersion.V2_4)
             sensor.configure_mqtt_topics("test_device")
 
             mock_rr = MagicMock()

--- a/tests/unit/sensors/test_writeable_sensor_branches.py
+++ b/tests/unit/sensors/test_writeable_sensor_branches.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from sigenergy2mqtt.common import InputType, Protocol
+from sigenergy2mqtt.common import InputType, ProtocolVersion
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.modbus import ModbusClient, ModbusDataType
 from sigenergy2mqtt.sensors.base import (
@@ -95,7 +95,7 @@ class TestWriteOnlySensorIconValidation:
                 0,
                 1,
                 30001,
-                Protocol.V2_4,
+                ProtocolVersion.V2_4,
                 icon_on="bad_icon_on",  # Triggers line 56
             )
 
@@ -108,7 +108,7 @@ class TestWriteOnlySensorIconValidation:
                 0,
                 1,
                 30001,
-                Protocol.V2_4,
+                ProtocolVersion.V2_4,
                 icon_on="mdi:power-on",  # Valid
                 icon_off="bad_icon_off",  # Triggers line 58
             )
@@ -135,7 +135,7 @@ class TestWriteOnlySensorGetDiscoveryComponents:
                 0,
                 1,
                 30001,
-                Protocol.V2_4,
+                ProtocolVersion.V2_4,
                 name_on="",  # Empty name → no i18n key for this class, stays empty → skip
                 name_off="Power Off",
             )
@@ -147,7 +147,7 @@ class TestWriteOnlySensorGetDiscoveryComponents:
         """Line 131: debug log when debug_logging=True."""
         caplog.set_level(logging.DEBUG)
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
-            sensor = WriteOnlySensor("Test", "sigen_test_disc_debug", 0, 1, 30001, Protocol.V2_4)
+            sensor = WriteOnlySensor("Test", "sigen_test_disc_debug", 0, 1, 30001, ProtocolVersion.V2_4)
             sensor.debug_logging = True
             with patch("sigenergy2mqtt.sensors.base.writeable.logger") as mock_log:
                 sensor.get_discovery_components()
@@ -164,7 +164,7 @@ class TestWriteOnlySensorSetValue:
     async def test_set_value_off_payload(self, mock_lock_factory, mock_modbus):
         """Line 150: set_value translates 'off' payload to actual off value."""
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
-            sensor = WriteOnlySensor("Test", "sigen_sv_off", 0, 1, 30001, Protocol.V2_4)
+            sensor = WriteOnlySensor("Test", "sigen_sv_off", 0, 1, 30001, ProtocolVersion.V2_4)
             # Configure MQTT topics so COMMAND_TOPIC is set before calling set_value
             sensor.configure_mqtt_topics("test_device")
             # Now set the command topic explicitly so the source comparison succeeds
@@ -215,7 +215,7 @@ class TestReadWriteSensorConfigureMqttTopics:
                 "mdi:power",
                 None,
                 None,
-                Protocol.V2_4,
+                ProtocolVersion.V2_4,
                 minimum=0.0,
                 maximum=100.0,
             )
@@ -249,7 +249,7 @@ class TestNumericSensorValidateMinMaxRanges:
                 "mdi:power",
                 None,
                 None,
-                Protocol.V2_4,
+                ProtocolVersion.V2_4,
                 minimum=100.0,  # Triggers line 345
                 maximum=50.0,
             )
@@ -273,7 +273,7 @@ class TestNumericSensorValidateMinMaxRanges:
                 "mdi:power",
                 None,
                 None,
-                Protocol.V2_4,
+                ProtocolVersion.V2_4,
             )
             # Call _validate_min_max_ranges directly with non-numeric tuple values
             with pytest.raises(TypeError, match="must be numeric"):
@@ -298,7 +298,7 @@ class TestNumericSensorValidateMinMaxRanges:
                 "mdi:power",
                 None,
                 None,
-                Protocol.V2_4,
+                ProtocolVersion.V2_4,
             )
             with pytest.raises(ValueError, match="min must be < max"):
                 sensor._validate_min_max_ranges((10.0, 20.0), (5.0, 1.0))  # Triggers line 357
@@ -329,7 +329,7 @@ class TestNumericSensorGetDiscoveryComponents:
                 "mdi:power",
                 1000.0,
                 None,
-                Protocol.V2_4,
+                ProtocolVersion.V2_4,
                 minimum=(-1.0, -0.8),  # Tuple minimum
                 maximum=(0.8, 1.0),  # Tuple maximum
             )
@@ -370,7 +370,7 @@ class TestNumericSensorGetState:
                 "mdi:power",
                 None,
                 0,  # gain=None, precision=0
-                Protocol.V2_4,
+                ProtocolVersion.V2_4,
                 minimum=0.0,
                 maximum=100.0,
             )
@@ -400,7 +400,7 @@ class TestNumericSensorGetState:
                 "mdi:power",
                 None,
                 0,  # gain=None, precision=0
-                Protocol.V2_4,
+                ProtocolVersion.V2_4,
                 minimum=0.0,
                 maximum=100.0,
             )
@@ -428,7 +428,7 @@ class TestNumericSensorGetState:
                 "mdi:power",
                 None,
                 0,  # gain=None, precision=0
-                Protocol.V2_4,
+                ProtocolVersion.V2_4,
                 minimum=0.0,
                 maximum=100.0,
             )
@@ -470,6 +470,6 @@ class TestThreePhaseAdjustmentTargetValue:
                     icon="mdi:power",
                     gain=None,
                     precision=None,
-                    protocol_version=Protocol.V1_8,
+                    protocol_version=ProtocolVersion.V1_8,
                     # output_type intentionally omitted → triggers line 581
                 )

--- a/tests/unit/translations/test_i18n.py
+++ b/tests/unit/translations/test_i18n.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from sigenergy2mqtt import i18n
-from sigenergy2mqtt.common import DeviceClass, InputType, Protocol, StateClass, UnitOfPower
+from sigenergy2mqtt.common import DeviceClass, InputType, ProtocolVersion, StateClass, UnitOfPower
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.devices import Device
 from sigenergy2mqtt.modbus import ModbusDataType
@@ -35,7 +35,7 @@ class MockSensor(Sensor):
             icon="mdi:test",
             gain=1.0,
             precision=2,
-            protocol_version=Protocol.V2_4,
+            protocol_version=ProtocolVersion.V2_4,
         )
 
     async def _update_internal_state(self, **kwargs):
@@ -60,13 +60,13 @@ class MockReadOnlySensor(ReadOnlySensor):
             icon="mdi:test",
             gain=None,
             precision=None,
-            protocol_version=Protocol.V2_4,
+            protocol_version=ProtocolVersion.V2_4,
         )
 
 
 class MockAlarmSensor(AlarmSensor):
     def __init__(self):
-        super().__init__(name="Test Alarm", object_id="sigenergy_test_alarm", plant_index=0, device_address=1, address=30001, protocol_version=Protocol.V2_4, alarm_type="TEST")
+        super().__init__(name="Test Alarm", object_id="sigenergy_test_alarm", plant_index=0, device_address=1, address=30001, protocol_version=ProtocolVersion.V2_4, alarm_type="TEST")
 
     def decode_alarm_bit(self, bit_position):
         if bit_position == 0:
@@ -76,7 +76,7 @@ class MockAlarmSensor(AlarmSensor):
 
 class MockDevice(Device):
     def __init__(self):
-        super().__init__(name="Test Device", plant_index=0, unique_id="test_device_unique_id", manufacturer="Sigenergy", model="Test Model", protocol_version=Protocol.V2_4)
+        super().__init__(name="Test Device", plant_index=0, unique_id="test_device_unique_id", manufacturer="Sigenergy", model="Test Model", protocol_version=ProtocolVersion.V2_4)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/utils/modbus_sensors.py
+++ b/tests/utils/modbus_sensors.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
 from pymodbus.client.mixin import ModbusClientMixin
 from pymodbus.pdu import ExceptionResponse, ModbusPDU
 
-from sigenergy2mqtt.common import DeviceClass, FirmwareVersion, HybridInverter, Protocol, ProtocolApplies, PVInverter
+from sigenergy2mqtt.common import DeviceClass, FirmwareVersion, HybridInverter, ProtocolVersion, ProtocolApplies, PVInverter
 from sigenergy2mqtt.config import Config, _swap_active_config, active_config, initialize
 from sigenergy2mqtt.devices import PID, PSS, ACCharger, DCCharger, Device, Inverter, PowerPlant
 from sigenergy2mqtt.modbus import ModbusDataType
@@ -191,7 +191,7 @@ async def get_sensor_instances(
     dc_charger_device_address: int = 1,
     ac_charger_device_address: int = 2,
     firmware_version: str = FIRMWARE_VERSION,
-    protocol_version: Protocol | None = None,
+    protocol_version: ProtocolVersion | None = None,
     output_type: OutputType = OUTPUT_TYPE,
     concrete_sensor_check: bool = False,
 ) -> dict[str, Sensor]:
@@ -234,8 +234,8 @@ async def get_sensor_instances(
             Defaults to ``2``.
         firmware_version: The firmware version to use when creating inverters.
             Defaults to ``FIRMWARE_VERSION``.
-        protocol_version: The :class:`Protocol` version to use when creating devices.
-            Defaults to ``max(Protocol)`` (the latest known protocol version).
+        protocol_version: The :class:`ProtocolVersion` version to use when creating devices.
+            Defaults to ``max(ProtocolVersion)`` (the latest known protocol version).
         output_type: The :class:`OutputType` to use when creating devices.
             Defaults to ``OutputType.THREE_PHASE``.
         concrete_sensor_check: When ``True``, performs register gap, overlap, and
@@ -246,8 +246,8 @@ async def get_sensor_instances(
         A dictionary mapping each sensor's ``unique_id`` to its :class:`Sensor` instance.
     """
     if protocol_version is None:
-        protocol_version = max(Protocol)
-    logging.info(f"Sigenergy Modbus Protocol V{protocol_version.value} [{ProtocolApplies(protocol_version)}] ({home_assistant_enabled=})")
+        protocol_version = max(ProtocolVersion)
+    logging.info(f"Sigenergy Modbus ProtocolVersion V{protocol_version.value} [{ProtocolApplies(protocol_version)}] ({home_assistant_enabled=})")
 
     active_config.modbus[plant_index].dc_chargers.append(dc_charger_device_address)
     active_config.modbus[plant_index].ac_chargers.append(ac_charger_device_address)
@@ -270,7 +270,7 @@ async def get_sensor_instances(
     dc_charger = await DCCharger.create(plant_index, dc_charger_device_address, protocol_version)
     ac_charger = await ACCharger.create(plant_index, ac_charger_device_address, protocol_version, hi_modbus_client)
 
-    if protocol_version >= Protocol.V2_9:
+    if protocol_version >= ProtocolVersion.V2_9:
         pid = await PID.create(plant_index, 241, protocol_version, DummyPIDModbusClient("Sigen PID 1.0", "PID123A45BP678", "V100R001C00SPC113"))
         pss = await PSS.create(plant_index, 242, protocol_version, DummyPSSModbusClient("Sigen PSS 1.0", "PSS123A45BP678"))
     else:

--- a/tests/utils/modbus_test_server.py
+++ b/tests/utils/modbus_test_server.py
@@ -47,7 +47,7 @@ from pymodbus.constants import ExcCodes
 from pymodbus.server import ModbusTcpServer
 from pymodbus.simulator import DataType, SimData, SimDevice
 
-from sigenergy2mqtt.common import Constants, DeviceClass, Protocol
+from sigenergy2mqtt.common import Constants, DeviceClass, ProtocolVersion
 from sigenergy2mqtt.modbus.client import ModbusClient
 from sigenergy2mqtt.sensors.ac_charger_read_only import ACChargerInputBreaker, ACChargerRatedCurrent
 from sigenergy2mqtt.sensors.inverter_read_only import InverterFirmwareVersion, OutputType, PhaseCurrent, PhaseVoltage, PowerFactor
@@ -76,7 +76,7 @@ class TestConfig:
 
     initial_firmware: str = "V100R001C00SPC112B107G"
     upgrade_firmware: str = "V100R001C00SPC113"
-    protocol_version: Protocol | None = None
+    protocol_version: ProtocolVersion | None = None
 
     use_simplified_topics: bool = False
 
@@ -916,7 +916,7 @@ async def run_async_server(
     use_simplified_topics: bool,
     host: str = "0.0.0.0",
     port: int = 502,
-    protocol_version: Protocol = list(Protocol)[-1],
+    protocol_version: ProtocolVersion = list(ProtocolVersion)[-1],
     log_level: int = logging.INFO,
 ) -> None:
     """Build and run the async Modbus TCP test server.
@@ -1227,14 +1227,14 @@ async def async_helper() -> None:
             return default
         return logging.getLevelNamesMapping()[value.upper()]
 
-    def _env_protocol(name: str) -> Protocol | None:
+    def _env_protocol(name: str) -> ProtocolVersion | None:
         value = _env(name)
         if value is None:
             return None
         normalized = value.upper()
         if not normalized.startswith("V"):
             normalized = f"V{normalized.replace('.', '_')}"
-        return Protocol[normalized]
+        return ProtocolVersion[normalized]
 
     def _env_registers(name: str) -> list[int]:
         value = _env(name)


### PR DESCRIPTION
The common Protocol class shadowed the Protocol class in the standard typing library.

- Updated all instances of Protocol to ProtocolVersion across multiple test files and utility scripts.
- Ensured consistency in protocol version handling in tests for sensors, devices, and modbus interactions.
- Adjusted imports and constructor calls to reflect the new ProtocolVersion usage.