### PR TITLE
fix: update firmware version parsing and restart logic for identity changes

### DIFF
--- a/sigenergy2mqtt/common/firmware_version.py
+++ b/sigenergy2mqtt/common/firmware_version.py
@@ -14,7 +14,7 @@ class FirmwareVersion:
     PATTERN = r"V(\d+)R(\d+)C(\d+)SPC(\d+)(?:B(\d+))?([A-Z])?"
 
     def __init__(self, version_string: str):
-        match = re.search(self.PATTERN, version_string)
+        match = re.fullmatch(self.PATTERN, version_string.strip())
 
         if not match:
             raise ValueError(f"Invalid firmware format: {version_string}")

--- a/sigenergy2mqtt/sensors/inverter_read_only.py
+++ b/sigenergy2mqtt/sensors/inverter_read_only.py
@@ -127,12 +127,31 @@ class InverterFirmwareVersion(ReadOnlySensor, HybridInverter, PVInverter):
                 try:
                     previous_version = FirmwareVersion(device["hw"])
                     current_version = FirmwareVersion(cast(str, value))
-                    if previous_version.service_pack != current_version.service_pack:
+                    previous_identity = (
+                        previous_version.platform,
+                        previous_version.release,
+                        previous_version.variant,
+                        previous_version.service_pack,
+                        previous_version.build,
+                        previous_version.special_id,
+                    )
+                    current_identity = (
+                        current_version.platform,
+                        current_version.release,
+                        current_version.variant,
+                        current_version.service_pack,
+                        current_version.build,
+                        current_version.special_id,
+                    )
+                    if previous_identity != current_identity:
                         from sigenergy2mqtt.main import restart_controller
 
-                        restart_controller.request(f"firmware service pack change on inverter {device.device_address}")
+                        restart_controller.request(f"firmware version change on inverter {device.device_address}")
                 except ValueError:
-                    logger.debug(f"Unable to parse firmware versions for restart decision: old={device['hw']} new={value}")
+                    from sigenergy2mqtt.main import restart_controller
+
+                    logger.warning(f"Unable to parse firmware versions for restart decision: old={device['hw']} new={value}")
+                    restart_controller.request(f"unparseable firmware version change on inverter {device.device_address}")
                 device["hw"] = value
         return value
 

--- a/tests/unit/main/test_main.py
+++ b/tests/unit/main/test_main.py
@@ -321,7 +321,7 @@ class TestGetState:
 
     @pytest.mark.asyncio
     async def test_inverter_firmware_version_triggers_restart_on_service_pack_change(self):
-        """Test that firmware service-pack change triggers full restart."""
+        """Test that any parsed firmware identity change triggers full restart."""
         with (
             patch.dict(Sensor._used_unique_ids, clear=True),
             patch.dict(Sensor._used_object_ids, clear=True),
@@ -352,6 +352,68 @@ class TestGetState:
             assert restart_controller.requested is False
 
             mock_super.return_value = "V1R1C1SPC2"
+            await sensor.get_state()
+            assert restart_controller.requested is True
+
+    @pytest.mark.asyncio
+    async def test_inverter_firmware_version_triggers_restart_on_non_service_pack_change(self):
+        """Test that build changes trigger a full restart."""
+        with (
+            patch.dict(Sensor._used_unique_ids, clear=True),
+            patch.dict(Sensor._used_object_ids, clear=True),
+            patch("sigenergy2mqtt.sensors.base.ReadOnlySensor.get_state", new_callable=AsyncMock) as mock_super,
+        ):
+            sensor = InverterFirmwareVersion(plant_index=0, device_address=1)
+            mock_device = MagicMock()
+            hw = {"value": "V1R1C1SPC1B1"}
+
+            def _getitem(key):
+                if key == "hw":
+                    return hw["value"]
+                return None
+
+            def _setitem(key, value):
+                if key == "hw":
+                    hw["value"] = value
+
+            mock_device.__getitem__.side_effect = _getitem
+            mock_device.__setitem__.side_effect = _setitem
+            mock_device.device_address = 1
+            sensor.parent_device = mock_device
+
+            restart_controller.reset()
+            mock_super.return_value = "V1R1C1SPC1B2"
+            await sensor.get_state()
+            assert restart_controller.requested is True
+
+    @pytest.mark.asyncio
+    async def test_inverter_firmware_version_triggers_restart_on_unparseable_change(self):
+        """Test that an unparseable changed firmware value triggers recovery."""
+        with (
+            patch.dict(Sensor._used_unique_ids, clear=True),
+            patch.dict(Sensor._used_object_ids, clear=True),
+            patch("sigenergy2mqtt.sensors.base.ReadOnlySensor.get_state", new_callable=AsyncMock) as mock_super,
+        ):
+            sensor = InverterFirmwareVersion(plant_index=0, device_address=1)
+            mock_device = MagicMock()
+            hw = {"value": "V1R1C1SPC1"}
+
+            def _getitem(key):
+                if key == "hw":
+                    return hw["value"]
+                return None
+
+            def _setitem(key, value):
+                if key == "hw":
+                    hw["value"] = value
+
+            mock_device.__getitem__.side_effect = _getitem
+            mock_device.__setitem__.side_effect = _setitem
+            mock_device.device_address = 1
+            sensor.parent_device = mock_device
+
+            restart_controller.reset()
+            mock_super.return_value = "firmware-not-parseable"
             await sensor.get_state()
             assert restart_controller.requested is True
 


### PR DESCRIPTION
Implemented firmware-change mitigation.

- Restart on any firmware identity change, including platform, release, variant, service pack, build, or special ID.
- Strictly validate firmware strings with re.fullmatch.
- Trigger a restart when a changed firmware value is unparseable.
- Added regression tests for build changes and malformed firmware values.
