### PR TITLE
Runtime Configuration Card on Diagnostics Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 
 - Added MQTT-configurable runtime settings sensors
+- Added configuration of runtime settings via diagnostics web UI
 
 ### Fixed
 

--- a/sigenergy2mqtt/diagnostics/collectors.py
+++ b/sigenergy2mqtt/diagnostics/collectors.py
@@ -1,10 +1,15 @@
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 from sigenergy2mqtt.config import ConsumptionSource, active_config
 from sigenergy2mqtt.i18n import _t
 from sigenergy2mqtt.metrics.metrics import Metrics
+from sigenergy2mqtt.sensors.base.constants import DiscoveryKeys
+from sigenergy2mqtt.sensors.base.writeable import NumericSensorMixin, SelectSensorMixin, SwitchSensorMixin
 
 from .registry import diagnostics_registry
+
+if TYPE_CHECKING:
+    from sigenergy2mqtt.config.sensors import SettingsSensor
 
 
 class DiagnosticsCollectors:
@@ -18,6 +23,66 @@ class DiagnosticsCollectors:
             diagnostics_registry.register("influxdb", cls._diagnostics_collect_influxdb_metrics)
         if active_config.pvoutput.enabled:
             diagnostics_registry.register("pvoutput", cls._diagnostics_collect_pvoutput_metrics)
+        diagnostics_registry.register("runtime_config", cls._diagnostics_collect_runtime_config)
+
+    @classmethod
+    async def _diagnostics_collect_runtime_config(cls) -> dict[str, Any]:
+        """Diagnostics provider callback: exposes live SettingsService sensor values as editable controls."""
+        from sigenergy2mqtt.config.sensors import SettingsSensor
+        from sigenergy2mqtt.devices.base.registry import DeviceRegistry
+
+        controls: dict[str, Any] = {}
+
+        # Find the SettingsService device (registered at plant_index=-1)
+        for device in DeviceRegistry.get(-1):
+            for sensor in device.sensors.values():
+                if not isinstance(sensor, SettingsSensor):
+                    continue
+                settings_sensor = cast("SettingsSensor", sensor)
+
+                # Derive a URL-safe endpoint key from the unique_id
+                # e.g. "sigenergy2mqtt_config_log_level" -> "log_level"
+                endpoint = settings_sensor.unique_id.removeprefix("sigenergy2mqtt_config_")
+
+                # Read the current display value via get_state()
+                state = await settings_sensor.get_state()
+
+                # Build the descriptor based on the sensor's mixin type
+                descriptor: dict[str, Any] = {
+                    "label": settings_sensor.name,
+                    "comment": settings_sensor.get_attributes().get("comment", ""),
+                    "endpoint": endpoint,
+                }
+
+                if isinstance(settings_sensor, SelectSensorMixin):
+                    options = cast(list[str], settings_sensor[DiscoveryKeys.OPTIONS])
+                    # Filter out empty placeholder slots (log-level list has empty strings)
+                    visible_options = [o for o in options if o]
+                    descriptor.update({
+                        "type": "select",
+                        "value": str(state) if state is not None else "",
+                        "options": visible_options,
+                    })
+                elif isinstance(settings_sensor, NumericSensorMixin):
+                    descriptor.update({
+                        "type": "number",
+                        "value": state,
+                        "min": settings_sensor.get(DiscoveryKeys.MIN),
+                        "max": settings_sensor.get(DiscoveryKeys.MAX),
+                        "unit": settings_sensor.unit or "",
+                    })
+                elif isinstance(settings_sensor, SwitchSensorMixin):
+                    descriptor.update({
+                        "type": "switch",
+                        "value": bool(state),
+                    })
+                else:
+                    # Fallback: surface as a read-only string
+                    descriptor.update({"type": "readonly", "value": str(state)})
+
+                controls[endpoint] = descriptor
+
+        return {"controls": controls}
 
     @classmethod
     async def _diagnostics_collect_influxdb_metrics(cls) -> dict[str, Any]:

--- a/sigenergy2mqtt/diagnostics/server.py
+++ b/sigenergy2mqtt/diagnostics/server.py
@@ -277,6 +277,8 @@ class DiagnosticsServer:
         # Coerce value to the type expected by the sensor kind
         try:
             if isinstance(matched_sensor, SwitchSensorMixin):
+                if not isinstance(raw_value, bool):
+                    return web.json_response({"ok": False, "error": "Switch value must be a boolean"}, status=422)
                 coerced: float | str = 1 if raw_value else 0
             elif isinstance(matched_sensor, NumericSensorMixin):
                 coerced = float(raw_value)

--- a/sigenergy2mqtt/diagnostics/server.py
+++ b/sigenergy2mqtt/diagnostics/server.py
@@ -69,6 +69,7 @@ class DiagnosticsServer:
         self._app.router.add_get("/diagnostics/solar", self._handle_solar_dashboard)
         self._app.router.add_get("/diagnostics/ws", self._handle_websocket)
         self._app.router.add_get("/diagnostics/export", self._handle_export)
+        self._app.router.add_post("/diagnostics/config/{endpoint}", self._handle_config_update)
         self._app.router.add_static("/diagnostics/static/", STATIC_DIR, name="static")
 
     @staticmethod
@@ -227,6 +228,77 @@ class DiagnosticsServer:
             content_type="application/json",
             headers={"Content-Disposition": 'attachment; filename="sigenergy2mqtt-diagnostics.json"'},
         )
+
+    async def _handle_config_update(self, request: web.Request) -> web.Response:
+        """Apply a runtime configuration change posted from the diagnostics UI.
+
+        Finds the matching :class:`~sigenergy2mqtt.config.sensors.SettingsSensor`
+        in the :class:`~sigenergy2mqtt.config.service.SettingsService` via
+        ``DeviceRegistry.get(-1)``, then calls its ``set_value`` method so that
+        the normal ``WriteableSensorMixin`` validation path is exercised — the
+        same path used when a change arrives over MQTT.
+
+        ``sensor.command_topic`` is passed as *source* to satisfy the guard in
+        :meth:`~sigenergy2mqtt.sensors.base.mixins.WriteableSensorMixin.set_value`
+        that rejects writes whose source does not match the command topic.
+        ``modbus_client``, ``mqtt_client``, and ``handler`` are all ``None``;
+        ``SettingsSensor._write_value`` only calls ``setattr`` (and
+        ``logging.getLogger().setLevel()`` for log-level sensors), so these
+        are safe to omit.
+        """
+        from sigenergy2mqtt.config.sensors import SettingsSensor
+        from sigenergy2mqtt.devices.base.registry import DeviceRegistry
+        from sigenergy2mqtt.sensors.base.writeable import NumericSensorMixin, SelectSensorMixin, SwitchSensorMixin
+
+        endpoint = request.match_info["endpoint"]
+
+        # Parse body
+        try:
+            body = await request.json()
+            raw_value = body["value"]
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError, UnicodeDecodeError) as exc:
+            return web.json_response({"ok": False, "error": f"Invalid request body: {exc}"}, status=400)
+
+        # Find the sensor matching this endpoint in SettingsService (plant_index=-1)
+        matched_sensor: SettingsSensor | None = None
+        for device in DeviceRegistry.get(-1):
+            for sensor in device.sensors.values():
+                if not isinstance(sensor, SettingsSensor):
+                    continue
+                if sensor.unique_id.removeprefix("sigenergy2mqtt_config_") == endpoint:
+                    matched_sensor = sensor
+                    break
+            if matched_sensor is not None:
+                break
+
+        if matched_sensor is None:
+            return web.json_response({"ok": False, "error": f"Unknown config endpoint: {endpoint!r}"}, status=404)
+
+        # Coerce value to the type expected by the sensor kind
+        try:
+            if isinstance(matched_sensor, SwitchSensorMixin):
+                coerced: float | str = 1 if raw_value else 0
+            elif isinstance(matched_sensor, NumericSensorMixin):
+                coerced = float(raw_value)
+            elif isinstance(matched_sensor, SelectSensorMixin):
+                coerced = str(raw_value)
+            else:
+                coerced = raw_value
+        except (TypeError, ValueError) as exc:
+            return web.json_response({"ok": False, "error": f"Invalid value: {exc}"}, status=422)
+
+        # Delegate to set_value — this runs validation and _write_value
+        try:
+            ok = await matched_sensor.set_value(None, None, coerced, matched_sensor.command_topic, None)  # type: ignore[arg-type]
+        except (KeyError, RuntimeError, TypeError, ValueError) as exc:
+            logger.warning(f"DiagnosticsServer config update for {endpoint!r} raised: {exc}")
+            return web.json_response({"ok": False, "error": str(exc)}, status=500)
+
+        if ok:
+            logger.info(f"DiagnosticsServer Config updated via HTTP: {endpoint!r} = {raw_value!r}")
+            return web.json_response({"ok": True})
+        return web.json_response({"ok": False, "error": "Update rejected by sensor validation"}, status=422)
+
 
     async def _handle_websocket(self, request: web.Request) -> web.WebSocketResponse:
         ws = web.WebSocketResponse(heartbeat=30)

--- a/sigenergy2mqtt/diagnostics/static/diagnostics.html
+++ b/sigenergy2mqtt/diagnostics/static/diagnostics.html
@@ -453,6 +453,148 @@
     .pulsing {
       animation: pulse 1.6s ease-in-out infinite;
     }
+
+    /* ── Runtime config controls card ─────────────────────────────────────── */
+
+    .control-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      font-size: 13px;
+      color: var(--text-dim);
+      padding: 6px 0;
+      border-bottom: 1px dashed var(--dash-border);
+    }
+
+    .control-row:last-child {
+      border-bottom: none;
+    }
+
+    .control-row > .ctrl-label {
+      flex-shrink: 0;
+      max-width: 55%;
+    }
+
+    .control-row > .ctrl-widget {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      min-width: 0;
+    }
+
+    .ctrl-select,
+    .ctrl-number {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text);
+      font-family: var(--mono);
+      font-size: 12px;
+      padding: 4px 8px;
+      transition: border-color 0.15s;
+      outline: none;
+      min-width: 0;
+    }
+
+    .ctrl-select:focus,
+    .ctrl-number:focus {
+      border-color: var(--accent);
+    }
+
+    .ctrl-number {
+      width: 7ch;
+    }
+
+    .ctrl-unit {
+      font-size: 11px;
+      color: var(--text-dim);
+      white-space: nowrap;
+    }
+
+    /* Toggle switch */
+    .ctrl-switch {
+      position: relative;
+      display: inline-block;
+      width: 36px;
+      height: 20px;
+      flex-shrink: 0;
+    }
+
+    .ctrl-switch input {
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+
+    .ctrl-slider {
+      position: absolute;
+      inset: 0;
+      background: var(--border);
+      border-radius: 999px;
+      cursor: pointer;
+      transition: background 0.2s;
+    }
+
+    .ctrl-slider::before {
+      content: '';
+      position: absolute;
+      width: 14px;
+      height: 14px;
+      left: 3px;
+      top: 3px;
+      background: var(--text);
+      border-radius: 50%;
+      transition: transform 0.2s;
+    }
+
+    .ctrl-switch input:checked + .ctrl-slider {
+      background: var(--accent);
+    }
+
+    .ctrl-switch input:checked + .ctrl-slider::before {
+      transform: translateX(16px);
+    }
+
+    /* Flash feedback */
+    @keyframes flashOk {
+      0%, 100% { border-color: var(--border); }
+      40% { border-color: var(--accent); box-shadow: 0 0 6px var(--accent); }
+    }
+
+    @keyframes flashErr {
+      0%, 100% { border-color: var(--border); }
+      40% { border-color: var(--bad); box-shadow: 0 0 6px var(--bad); }
+    }
+
+    .flash-ok {
+      animation: flashOk 0.7s ease;
+    }
+
+    .flash-err {
+      animation: flashErr 0.7s ease;
+    }
+
+    .card-controls-divider {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-top: 4px;
+      padding-top: 12px;
+      border-top: 1px solid var(--border);
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--text-dim);
+    }
+
+    .card-controls-divider svg {
+      width: 13px;
+      height: 13px;
+      opacity: 0.75;
+      flex-shrink: 0;
+    }
   </style>
 </head>
 
@@ -645,6 +787,18 @@
           pill.className = 'pill bad';
           pill.textContent = 'error';
           title.appendChild(pill);
+        } else if (name === 'runtime_config') {
+          // Gear icon instead of a status pill for the editable config card
+          const gear = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+          gear.setAttribute('viewBox', '0 0 24 24');
+          gear.setAttribute('fill', 'none');
+          gear.setAttribute('stroke', 'currentColor');
+          gear.setAttribute('stroke-width', '2');
+          gear.setAttribute('stroke-linecap', 'round');
+          gear.setAttribute('stroke-linejoin', 'round');
+          gear.style.cssText = 'width:15px;height:15px;opacity:0.6;';
+          gear.innerHTML = '<circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>';
+          title.appendChild(gear);
         }
         card.appendChild(title);
 
@@ -654,7 +808,7 @@
         // them being mixed into the regular metric flattening.
         function buildRows(obj, prefix, container) {
           Object.entries(obj).forEach(([k, v]) => {
-            if (k === 'status' || k === 'config') return;
+            if (k === 'status' || k === 'config' || k === 'controls') return;
             if (v && typeof v === 'object' && !Array.isArray(v)) {
               buildRows(v, prefix ? `${prefix}.${k}` : k, container);
               return;
@@ -684,6 +838,13 @@
         if (data && typeof data === 'object') buildRows(data, '', rows);
         card.appendChild(rows);
 
+        // Reserved "controls" key: interactive controls for runtime configuration
+        if (data && typeof data === 'object' && data.controls && typeof data.controls === 'object' && !Array.isArray(data.controls) && Object.keys(data.controls).length > 0) {
+          const controlsContainer = document.createElement('div');
+          buildControls(data.controls, controlsContainer);
+          card.appendChild(controlsContainer);
+        }
+
         // Reserved "config" key: any provider can attach a "config": {...}
         // sub-object with whatever static settings it wants, no schema
         // required. Rendered in the same card, under a small divider, with
@@ -702,6 +863,182 @@
         }
 
         return card;
+      }
+
+      function debounce(fn, delay) {
+        let timer;
+        return function (...args) {
+          clearTimeout(timer);
+          timer = setTimeout(() => fn.apply(this, args), delay);
+        };
+      }
+
+      async function sendConfigUpdate(endpoint, value, flashEl, prevValue, revertCb) {
+        try {
+          const res = await fetch(`config/${encodeURIComponent(endpoint)}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ value })
+          });
+          const result = await res.json();
+          if (res.ok && result.ok) {
+            flashEl.classList.remove('flash-ok', 'flash-err');
+            void flashEl.offsetWidth;
+            flashEl.classList.add('flash-ok');
+            return true;
+          } else {
+            throw new Error(result.error || 'Update failed');
+          }
+        } catch (err) {
+          console.error(`Config update failed for ${endpoint}:`, err);
+          flashEl.classList.remove('flash-ok', 'flash-err');
+          void flashEl.offsetWidth;
+          flashEl.classList.add('flash-err');
+          if (revertCb) revertCb(prevValue);
+          return false;
+        }
+      }
+
+      function buildControls(controls, container) {
+        Object.entries(controls).forEach(([endpoint, ctrl]) => {
+          const row = document.createElement('div');
+          row.className = 'control-row';
+          if (ctrl.comment) {
+            row.title = ctrl.comment;
+          }
+
+          const label = document.createElement('span');
+          label.className = 'ctrl-label';
+          label.textContent = ctrl.label || humanKey(endpoint);
+          row.appendChild(label);
+
+          const widgetWrap = document.createElement('div');
+          widgetWrap.className = 'ctrl-widget';
+
+          if (ctrl.type === 'select') {
+            const select = document.createElement('select');
+            select.className = 'ctrl-select';
+            select.dataset.endpoint = endpoint;
+            let currentVal = ctrl.value;
+
+            (ctrl.options || []).forEach(opt => {
+              const optionEl = document.createElement('option');
+              optionEl.value = opt;
+              optionEl.textContent = opt;
+              if (opt === currentVal) optionEl.selected = true;
+              select.appendChild(optionEl);
+            });
+
+            select.addEventListener('change', () => {
+              const newVal = select.value;
+              sendConfigUpdate(endpoint, newVal, select, currentVal, (prev) => {
+                select.value = prev;
+              }).then(ok => {
+                if (ok) currentVal = newVal;
+              });
+            });
+
+            widgetWrap.appendChild(select);
+          } else if (ctrl.type === 'number') {
+            const input = document.createElement('input');
+            input.type = 'number';
+            input.className = 'ctrl-number';
+            input.dataset.endpoint = endpoint;
+            input.value = ctrl.value;
+            if (ctrl.min !== undefined && ctrl.min !== null) input.min = ctrl.min;
+            if (ctrl.max !== undefined && ctrl.max !== null) input.max = ctrl.max;
+
+            let currentVal = ctrl.value;
+            const debouncedSend = debounce((val) => {
+              const num = parseFloat(val);
+              if (!isNaN(num) && num !== currentVal) {
+                sendConfigUpdate(endpoint, num, input, currentVal, (prev) => {
+                  input.value = prev;
+                }).then(ok => {
+                  if (ok) currentVal = num;
+                });
+              }
+            }, 500);
+
+            input.addEventListener('input', (e) => debouncedSend(e.target.value));
+            input.addEventListener('change', (e) => {
+              const num = parseFloat(e.target.value);
+              if (!isNaN(num) && num !== currentVal) {
+                sendConfigUpdate(endpoint, num, input, currentVal, (prev) => {
+                  input.value = prev;
+                }).then(ok => {
+                  if (ok) currentVal = num;
+                });
+              }
+            });
+
+            widgetWrap.appendChild(input);
+
+            if (ctrl.unit) {
+              const unit = document.createElement('span');
+              unit.className = 'ctrl-unit';
+              unit.textContent = ctrl.unit;
+              widgetWrap.appendChild(unit);
+            }
+          } else if (ctrl.type === 'switch') {
+            const labelEl = document.createElement('label');
+            labelEl.className = 'ctrl-switch';
+
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.dataset.endpoint = endpoint;
+            checkbox.checked = Boolean(ctrl.value);
+
+            const slider = document.createElement('span');
+            slider.className = 'ctrl-slider';
+
+            labelEl.appendChild(checkbox);
+            labelEl.appendChild(slider);
+
+            let currentVal = Boolean(ctrl.value);
+            checkbox.addEventListener('change', () => {
+              const newVal = checkbox.checked;
+              sendConfigUpdate(endpoint, newVal, slider, currentVal, (prev) => {
+                checkbox.checked = prev;
+              }).then(ok => {
+                if (ok) currentVal = newVal;
+              });
+            });
+
+            widgetWrap.appendChild(labelEl);
+          } else {
+            const val = document.createElement('span');
+            val.className = 'v';
+            val.textContent = fmtVal(ctrl.value);
+            widgetWrap.appendChild(val);
+          }
+
+          row.appendChild(widgetWrap);
+          container.appendChild(row);
+        });
+      }
+
+      function updateControlsCard(card, controls) {
+        Object.entries(controls).forEach(([endpoint, ctrl]) => {
+          const widget = card.querySelector(`[data-endpoint="${endpoint}"]`);
+          if (!widget) return;
+          if (document.activeElement === widget || widget.contains(document.activeElement)) return;
+
+          if (ctrl.type === 'select') {
+            if (widget.value !== ctrl.value) {
+              widget.value = ctrl.value;
+            }
+          } else if (ctrl.type === 'switch') {
+            const checked = Boolean(ctrl.value);
+            if (widget.checked !== checked) {
+              widget.checked = checked;
+            }
+          } else if (ctrl.type === 'number') {
+            if (String(widget.value) !== String(ctrl.value)) {
+              widget.value = ctrl.value;
+            }
+          }
+        });
       }
 
       // Providers listed here have their own dedicated page (e.g. "solar" ->
@@ -726,13 +1063,36 @@
         const ts = snapshot.timestamp ? new Date(snapshot.timestamp * 1000).toLocaleString() : '—';
         statusMeta.textContent = `last updated ${ts}`;
 
-        cardGrid.innerHTML = '';
         const keys = Object.keys(snapshot).filter(k => k !== 'timestamp' && !DEDICATED_PAGE_PROVIDERS.has(k));
         if (keys.length === 0) {
           cardGrid.innerHTML = '<div class="empty-state">No diagnostics providers registered.</div>';
           return;
         }
-        keys.forEach(key => cardGrid.appendChild(buildCard(key, snapshot[key])));
+
+        const emptyState = cardGrid.querySelector('.empty-state');
+        if (emptyState) cardGrid.innerHTML = '';
+
+        keys.forEach(key => {
+          const existingCard = cardGrid.querySelector(`[data-provider="${key}"]`);
+          const data = snapshot[key];
+          if (key === 'runtime_config' && existingCard && data && data.controls) {
+            updateControlsCard(existingCard, data.controls);
+          } else if (existingCard) {
+            const newCard = buildCard(key, data);
+            newCard.dataset.provider = key;
+            cardGrid.replaceChild(newCard, existingCard);
+          } else {
+            const newCard = buildCard(key, data);
+            newCard.dataset.provider = key;
+            cardGrid.appendChild(newCard);
+          }
+        });
+
+        cardGrid.querySelectorAll('[data-provider]').forEach(c => {
+          if (!keys.includes(c.dataset.provider)) {
+            c.remove();
+          }
+        });
       }
 
       function setConn(state) {

--- a/tests/unit/diagnostics/test_collectors.py
+++ b/tests/unit/diagnostics/test_collectors.py
@@ -59,3 +59,24 @@ async def test_collect_pvoutput_metrics(monkeypatch):
     assert "PVOutput Upload Errors" in metrics
     assert "config" in metrics
     assert metrics["config"]["end_of_day"] == "@ status interval"
+
+
+@pytest.mark.asyncio
+async def test_collect_runtime_config():
+    from sigenergy2mqtt.config.service import SettingsService
+    from sigenergy2mqtt.devices.base.registry import DeviceRegistry
+
+    DeviceRegistry.clear()
+    try:
+        _ = SettingsService()
+        payload = await DiagnosticsCollectors._diagnostics_collect_runtime_config()
+        assert "controls" in payload
+        controls = payload["controls"]
+        assert "log_level" in controls
+        assert controls["log_level"]["type"] == "select"
+        assert "repeated_state_publish_interval" in controls
+        assert controls["repeated_state_publish_interval"]["type"] == "number"
+        assert "persistence_debug" in controls
+        assert controls["persistence_debug"]["type"] == "switch"
+    finally:
+        DeviceRegistry.clear()

--- a/tests/unit/diagnostics/test_server.py
+++ b/tests/unit/diagnostics/test_server.py
@@ -334,3 +334,64 @@ async def test_ip_filter_middleware_health_not_exempt_outside_docker(server: Dia
             await server._ip_filter_middleware(request, handler)
             
     handler.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_config_update_success(server: DiagnosticsServer) -> None:
+    from sigenergy2mqtt.config.service import SettingsService
+    from sigenergy2mqtt.devices.base.registry import DeviceRegistry
+    DeviceRegistry.clear()
+    try:
+        _ = SettingsService()
+        request = make_mocked_request("POST", "/diagnostics/config/log_level", match_info={"endpoint": "log_level"})
+        request.json = AsyncMock(return_value={"value": "DEBUG"})
+
+        response = await server._handle_config_update(request)
+        assert response.status == 200
+        body = json.loads(response.text)
+        assert body["ok"] is True
+    finally:
+        DeviceRegistry.clear()
+
+
+@pytest.mark.asyncio
+async def test_handle_config_update_unknown_endpoint(server: DiagnosticsServer) -> None:
+    from sigenergy2mqtt.devices.base.registry import DeviceRegistry
+    DeviceRegistry.clear()
+
+    request = make_mocked_request("POST", "/diagnostics/config/non_existent", match_info={"endpoint": "non_existent"})
+    request.json = AsyncMock(return_value={"value": "foo"})
+
+    response = await server._handle_config_update(request)
+    assert response.status == 404
+    body = json.loads(response.text)
+    assert body["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_handle_config_update_invalid_json(server: DiagnosticsServer) -> None:
+    request = make_mocked_request("POST", "/diagnostics/config/log_level", match_info={"endpoint": "log_level"})
+    request.json = AsyncMock(side_effect=json.JSONDecodeError("msg", "doc", 0))
+
+    response = await server._handle_config_update(request)
+    assert response.status == 400
+    body = json.loads(response.text)
+    assert body["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_handle_config_update_validation_rejected(server: DiagnosticsServer) -> None:
+    from sigenergy2mqtt.config.service import SettingsService
+    from sigenergy2mqtt.devices.base.registry import DeviceRegistry
+    DeviceRegistry.clear()
+    try:
+        _ = SettingsService()
+        request = make_mocked_request("POST", "/diagnostics/config/log_level", match_info={"endpoint": "log_level"})
+        request.json = AsyncMock(return_value={"value": "INVALID_LEVEL"})
+
+        response = await server._handle_config_update(request)
+        assert response.status == 422
+        body = json.loads(response.text)
+        assert body["ok"] is False
+    finally:
+        DeviceRegistry.clear()


### PR DESCRIPTION
# Runtime Configuration Card on Diagnostics Page

Add an interactive "Runtime Configuration" card to the diagnostics page that surfaces the same settings exposed by `SettingsService` (via MQTT), and allows those settings to be modified directly from the browser.

---

## Background

- **`config/sensors.py`** — defines `SettingsSensor` subclasses (log levels, switches, numerics). Each has a `_base_mqtt_topic`, a `command_topic` (`<base>/set`), and a `_write_value` coroutine that modifies `active_config` in-place.
- **`config/service.py`** — `SettingsService` (a `Device` registered at `plant_index=-1`) wires up all sensor entities; the exact set depends on which optional modules (diagnostics, influxdb, pvoutput) are enabled.
- **`devices/base/registry.py`** — `DeviceRegistry.get(plant_index)` returns all devices for a given index. `SettingsService` uses `plant_index=-1`, making it easily discoverable at runtime.
- **`devices/base/device.py`** — `Device.sensors` property returns `dict[str, Sensor]` keyed by `unique_id`.
- **`diagnostics/registry.py`** — extensible pull-based registry; any component calls `diagnostics_registry.register(name, fn)` to add a named section to the diagnostics payload.
- **`diagnostics/server.py`** — `DiagnosticsServer` owns HTTP routes. Currently read-only.
- **`diagnostics/static/diagnostics.html`** — renders one card per registry provider.
- **`sensors/base/mixins.py`** — `WriteableSensorMixin.set_value(modbus_client, mqtt_client, value, source, handler)` performs validation then calls `_write_value`. The `source` argument must equal `sensor.command_topic` or the write is rejected.

---

## Design Decisions

| Question | Decision |
|---|---|
| How to reach sensors from the HTTP POST handler? | Discover `SettingsService` from `DeviceRegistry.get(-1)`, iterate its `.sensors` dict at request time. No pre-registration step needed. |
| Which method to call for writes? | `set_value` (not `_write_value` directly), passing `sensor.command_topic` as `source` and `None` for `modbus_client`, `mqtt_client`, and `handler` — config sensors don't use those. |
| Which sensors to surface? | Derive entirely from `SettingsService.sensors` — exactly what is registered at runtime reflects the enabled modules. |
| Write access control | Existing `_ip_filter_middleware` is sufficient, given that these settings are accessible via MQTT. |

