### PR TITLE
Enhanced logging for unconsumed source values in derived sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 <!-- git log [since tag]..HEAD --oneline -->
 # Changelog 
 
-## [2026.8.26a3] - 2026-08-26
+## [Unreleased]
 
 ### Added
 
 - Added MQTT-configurable runtime settings sensors
 - Added configuration of runtime settings via diagnostics web UI
+- Added enhanced logging for unconsumed source values in derived sensors
 
 ### Fixed
 

--- a/sigenergy2mqtt/sensors/base/accumulation.py
+++ b/sigenergy2mqtt/sensors/base/accumulation.py
@@ -75,6 +75,7 @@ class AccumulationSensor(DerivedSensor):
         self._source = source
         self._current_total_lock = asyncio.Lock()
         self._current_total: float = 0.0
+        self._last_source_generation: int | None = None
 
         # Inherit discriminator fields from source early so init-time persistence
         # logs use the real identity rather than plant/dev=n/a.
@@ -143,14 +144,23 @@ class AccumulationSensor(DerivedSensor):
         if sensor.latest_raw_state is None or sensor.state_count < 2:
             return False  # Need at least two points
 
+        source_generation = getattr(sensor, "update_generation", None)
+        if isinstance(source_generation, int) and source_generation > 0:
+            if source_generation == self._last_source_generation:
+                return False
+            self._last_source_generation = source_generation
+
         # Calculate time difference in hours
-        interval_hours = sensor.latest_interval / 3600 if sensor.latest_interval else 0
+        source_interval = getattr(sensor, "successful_read_interval", None)
+        if not isinstance(source_interval, (int, float)):
+            source_interval = sensor.latest_interval
+        interval_hours = source_interval / 3600 if source_interval else 0
 
         if interval_hours < 0:
-            logger.warning(f"{self.log_identity} negative interval IGNORED (interval={sensor.latest_interval})")
+            logger.warning(f"{self.log_identity} negative interval IGNORED (interval={source_interval})")
             return False
         if interval_hours >= 2:
-            logger.warning(f"{self.log_identity} 2+ hour interval IGNORED (interval={sensor.latest_interval})")
+            logger.warning(f"{self.log_identity} 2+ hour interval IGNORED (interval={source_interval})")
             return False
 
         # Convert negative power to zero
@@ -163,9 +173,7 @@ class AccumulationSensor(DerivedSensor):
 
         # Check for decreasing total
         if new_total < self._current_total and self.state_class == StateClass.TOTAL_INCREASING:
-            logger.debug(
-                f"{self.log_identity} negative increase IGNORED (current={self._current_total} prev={previous} curr={current} increase={increase} new={new_total} interval={sensor.latest_interval:.2f}s)"
-            )
+            logger.debug(f"{self.log_identity} negative increase IGNORED (current={self._current_total} prev={previous} curr={current} increase={increase} new={new_total} interval={source_interval:.2f}s)")
             return False
 
         # Update total

--- a/sigenergy2mqtt/sensors/base/derived.py
+++ b/sigenergy2mqtt/sensors/base/derived.py
@@ -76,6 +76,33 @@ class DerivedSensor(TypedSensorMixin, Sensor):
             # Re-apply sensor overrides so that an explicit debug-logging=False override will be respected
             self.apply_sensor_overrides()
 
+    def _log_unconsumed_source_value(self, source_name: str, value: Any, timestamp: float | None, sensor: Sensor) -> None:
+        """Log when a cached source value is replaced before being consumed."""
+        if value is None:
+            return
+
+        source_timestamp = getattr(sensor, "last_successful_read_time", None)
+        if not isinstance(source_timestamp, (int, float)):
+            source_timestamp = getattr(sensor, "latest_time", None)
+        age = max(0.0, source_timestamp - timestamp) if isinstance(source_timestamp, (int, float)) and isinstance(timestamp, (int, float)) else None
+        scan_interval = getattr(sensor, "scan_interval", None)
+        expected_interval = max(1, 2 * scan_interval) if isinstance(scan_interval, int) else None
+        message = f"{self.log_identity} Overwriting unconsumed source value {source_name}={value}"
+        if age is not None and expected_interval is not None:
+            message += f" (age={age:.2f}s expected_interval={expected_interval}s)"
+        if age is None or expected_interval is None or age > expected_interval:
+            logger.warning(message)
+        else:
+            logger.debug(message)
+
+    @staticmethod
+    def _source_timestamp(sensor: Sensor) -> float | None:
+        timestamp = getattr(sensor, "last_successful_read_time", None)
+        if isinstance(timestamp, (int, float)):
+            return timestamp
+        timestamp = getattr(sensor, "latest_time", None)
+        return timestamp if isinstance(timestamp, (int, float)) and timestamp > 0 else None
+
     def set_latest_state(self, state: float | str | list[bool] | list[int] | list[float]) -> bool:
         """Update latest state and track pending updates for publishing."""
         updated = super().set_latest_state(state)

--- a/sigenergy2mqtt/sensors/inverter_derived.py
+++ b/sigenergy2mqtt/sensors/inverter_derived.py
@@ -99,15 +99,17 @@ class PVStringPower(DerivedSensor, HybridInverter, PVInverter):
         divisor: float
         value: float | None = None
         timestamp: float = 0
+        owner: PVStringPower | None = field(default=None, compare=False, repr=False)
 
         def apply(self, sensor: Sensor) -> None:
-            if self.value is not None:
-                logger.warning(f"{self.name} Overwriting unconsumed value {self.value} (age={(sensor.latest_time - self.timestamp):.2f}s)")
+            if self.owner is not None:
+                self.owner._log_unconsumed_source_value(self.name, self.value, self.timestamp, sensor)
             raw = sensor.latest_raw_state
             if raw is None:
                 return
             self.value = float(raw) / self.divisor
-            self.timestamp = sensor.latest_time
+            source_timestamp = self.owner._source_timestamp(sensor) if self.owner is not None else sensor.latest_time
+            self.timestamp = source_timestamp if source_timestamp is not None else 0
 
     def __init__(self, plant_index: int, device_address: int, string_number: int, voltage: PVVoltageSensor, current: PVCurrentSensor):
         # Set properties before super().__init__ so that log_identity is correctly generated
@@ -127,8 +129,8 @@ class PVStringPower(DerivedSensor, HybridInverter, PVInverter):
             precision=0,  # Intentional rounding to nearest watt
             source_sensors=(voltage, current),
         )
-        self.amperes: PVStringPower.Value = PVStringPower.Value(f"{self.log_identity[:-1]},value=amperes]", PVCurrentSensor.raw2amps)
-        self.volts: PVStringPower.Value = PVStringPower.Value(f"{self.log_identity[:-1]},value=volts]", PVVoltageSensor.raw2volts)
+        self.amperes: PVStringPower.Value = PVStringPower.Value(f"{self.log_identity[:-1]},value=amperes]", PVCurrentSensor.raw2amps, owner=self)
+        self.volts: PVStringPower.Value = PVStringPower.Value(f"{self.log_identity[:-1]},value=volts]", PVVoltageSensor.raw2volts, owner=self)
         self.protocol_version = max(voltage.protocol_version, current.protocol_version)
 
     def get_attributes(self) -> dict[str, float | int | str]:
@@ -141,13 +143,14 @@ class PVStringPower(DerivedSensor, HybridInverter, PVInverter):
             if self.debug_logging:
                 logger.debug(f"{self.log_identity} Publishing SKIPPED - current={self.amperes.value} voltage={self.volts.value}")
             return False  # until all values populated, can't do calculation
+        pending_update = self._pending_update
         gap = abs(self.volts.timestamp - self.amperes.timestamp)
         if self.debug_logging:
             logger.debug(f"{self.log_identity} Publishing READY   - current={self.amperes.value} voltage={self.volts.value} gap={gap:.2f}s")
             if gap > _MAX_PV_STRING_POWER_GAP_WARNING_SECONDS:
                 logger.debug(f"{self.log_identity} Publishing WARNING - gap between acquiring current and voltage was {gap:.2f}s")
         published = await super().publish(mqtt_client, modbus_client, republish=republish)  # Publish even if gap exceeds warning threshold
-        if published is False:
+        if published is False and pending_update:
             return False
         if not republish:
             # reset internal values to missing for next calculation
@@ -237,6 +240,7 @@ class InverterSelfConsumedPower(DerivedSensor, HybridInverter, PVInverter):
         self.active_power: int | None = None
         self.battery_power: int | None = None
         self.pv_string_power: dict[int, int | None] = {p.string_number: None for p in pv_string_power}
+        self._source_timestamps: dict[str, float | None] = {"active_power": None, "battery_power": None, **{f"pv_string_power_{p.string_number}": None for p in pv_string_power}}
 
         self.sanity_check.min_raw = 0  # Watts
         self.sanity_check.max_raw = 3000  # Watts
@@ -267,11 +271,18 @@ class InverterSelfConsumedPower(DerivedSensor, HybridInverter, PVInverter):
         if sensor.latest_raw_state is None:
             return False
         if isinstance(sensor, ActivePower):
+            self._log_unconsumed_source_value("active_power", self.active_power, self._source_timestamps["active_power"], sensor)
             self.active_power = int(sensor.latest_raw_state)
+            self._source_timestamps["active_power"] = self._source_timestamp(sensor)
         elif isinstance(sensor, ChargeDischargePower):
+            self._log_unconsumed_source_value("battery_power", self.battery_power, self._source_timestamps["battery_power"], sensor)
             self.battery_power = int(sensor.latest_raw_state)
+            self._source_timestamps["battery_power"] = self._source_timestamp(sensor)
         elif isinstance(sensor, PVStringPower):
+            source_name = f"pv_string_power_{sensor.string_number}"
+            self._log_unconsumed_source_value(source_name, self.pv_string_power[sensor.string_number], self._source_timestamps[source_name], sensor)
             self.pv_string_power[sensor.string_number] = int(sensor.latest_raw_state)
+            self._source_timestamps[source_name] = self._source_timestamp(sensor)
         else:
             logger.warning(f"{self.log_identity} Attempt to call update_from_source_sensor from {sensor.log_identity}")
             return False

--- a/sigenergy2mqtt/sensors/inverter_derived.py
+++ b/sigenergy2mqtt/sensors/inverter_derived.py
@@ -255,10 +255,11 @@ class InverterSelfConsumedPower(DerivedSensor, HybridInverter, PVInverter):
             if self.debug_logging:
                 logger.debug(f"{self.log_identity} Publishing SKIPPED - active_power={self.active_power} battery_power={self.battery_power} pv_string_power={[p for p in self.pv_string_power.values()]}")
             return False
+        pending_update = self._pending_update
         if self.debug_logging:
             logger.debug(f"{self.log_identity} Publishing READY   - active_power={self.active_power} battery_power={self.battery_power} pv_string_power={[p for p in self.pv_string_power.values()]}")
         published = await super().publish(mqtt_client, modbus_client, republish=republish)  # Publish even if gap exceeds warning threshold
-        if published is False:
+        if published is False and pending_update:
             return False
         if not republish:
             # reset internal values to missing for next calculation

--- a/sigenergy2mqtt/sensors/plant_derived.py
+++ b/sigenergy2mqtt/sensors/plant_derived.py
@@ -375,8 +375,9 @@ class TotalPVPower(DerivedSensor, HybridInverter, PVInverter):
                 return False  # until all values populated, can't do calculation
             if self.debug_logging:
                 logger.debug(f"{self.log_identity} Publishing READY   - {self._sources=}")
+        pending_update = self._pending_update
         published = await super().publish(mqtt_client, modbus_client, republish=republish)
-        if published is False:
+        if published is False and pending_update:
             return False
         if not republish:
             # reset internal values to missing for next calculation
@@ -395,8 +396,9 @@ class TotalPVPower(DerivedSensor, HybridInverter, PVInverter):
         raw_state = getattr(sensor, "latest_raw_state", None)
         if raw_state is None:
             return False
+        self._log_unconsumed_source_value(source, self._sources[source].state, self._sources[source].last_update, sensor)
         self._sources[source].state = float(raw_state)
-        self._sources[source].last_update = time.time()
+        self._sources[source].last_update = self._source_timestamp(sensor)
         if self.debug_logging:
             logger.debug(f"{self.log_identity} Updated from source '{source}' - {self._sources=}")
         if any(value.state is None for value in self._sources.values()):
@@ -496,9 +498,11 @@ class PlantConsumedPower(CrossDeviceDerivedSensor, HybridInverter, PVInverter):
         self.set_latest_state(consumed_power)
         return True
 
-    def _update_source(self, source: str, value: float) -> None:
+    def _update_source(self, source: str, value: float, sensor: Sensor | None = None) -> None:
+        if sensor is not None:
+            self._log_unconsumed_source_value(source, self._sources[source].state, self._sources[source].last_update, sensor)
         self._sources[source].state = (-value if self._sources[source].negate else value) * self._sources[source].gain
-        self._sources[source].last_update = time.time()
+        self._sources[source].last_update = self._source_timestamp(sensor) if sensor is not None else time.time()
 
     def get_attributes(self) -> dict[str, float | int | str]:
         attributes = super().get_attributes()
@@ -518,8 +522,9 @@ class PlantConsumedPower(CrossDeviceDerivedSensor, HybridInverter, PVInverter):
                     logger.debug(f"{self.log_identity} Publishing SKIPPED - {self._sources}")
                 return False  # until all values populated, can't do calculation
             republish = True  # if we got here, we have a valid value to publish
+        pending_update = self._pending_update
         published = await super().publish(mqtt_client, modbus_client, republish=republish)
-        if published is False:
+        if published is False and pending_update:
             return False
         # reset internal values to missing for next calculation
         for value in self._sources.values():
@@ -531,15 +536,15 @@ class PlantConsumedPower(CrossDeviceDerivedSensor, HybridInverter, PVInverter):
             return False
         raw = float(sensor.latest_raw_state)
         if isinstance(sensor, TotalLoadPower):
-            self._update_source(ConsumptionMethod.TOTAL.value, raw)
+            self._update_source(ConsumptionMethod.TOTAL.value, raw, sensor)
         elif isinstance(sensor, GeneralLoadPower):
-            self._update_source(ConsumptionMethod.GENERAL.value, raw)
+            self._update_source(ConsumptionMethod.GENERAL.value, raw, sensor)
         elif isinstance(sensor, BatteryPower):
-            self._update_source("battery", raw)
+            self._update_source("battery", raw, sensor)
         elif isinstance(sensor, GridSensorActivePower):
-            self._update_source("grid", raw)
+            self._update_source("grid", raw, sensor)
         elif isinstance(sensor, (PlantPVPower, TotalPVPower)):
-            self._update_source("pv", raw)
+            self._update_source("pv", raw, sensor)
         elif isinstance(sensor, GridStatus):
             if self.method == ConsumptionMethod.CALCULATED:
                 grid = int(sensor.latest_raw_state)
@@ -551,7 +556,7 @@ class PlantConsumedPower(CrossDeviceDerivedSensor, HybridInverter, PVInverter):
                             logger.warning(f"{self.log_identity} Off Grid detected - ignoring AC/DC charger power in consumption calculations")
                     self._grid_status = grid
         elif isinstance(sensor, (ACChargerChargingPower, DCChargerOutputPower)):
-            self._update_source(sensor.unique_id, raw)
+            self._update_source(sensor.unique_id, raw, sensor)
         else:
             logger.warning(f"{self.log_identity} Attempt to call update_from_source_sensor from {sensor.log_identity}")
             return False
@@ -615,6 +620,7 @@ class TotalLifetimePVEnergy(UnpublishResetSensorMixin, DerivedSensor, HybridInve
         self.protocol_version = ProtocolVersion.V2_7
         self.plant_lifetime_pv_energy: float | None = None
         self.plant_3rd_party_lifetime_pv_energy: float | None = None
+        self._source_timestamps: dict[str, float | None] = {"plant_lifetime_pv_energy": None, "plant_3rd_party_lifetime_pv_energy": None}
 
     def get_attributes(self) -> dict[str, float | int | str]:
         attributes = super().get_attributes()
@@ -628,8 +634,9 @@ class TotalLifetimePVEnergy(UnpublishResetSensorMixin, DerivedSensor, HybridInve
             return False  # until all values populated, can't do calculation
         if self.debug_logging:
             logger.debug(f"{self.log_identity} Publishing READY   - plant_lifetime_pv_energy={self.plant_lifetime_pv_energy} plant_3rd_party_lifetime_pv_energy={self.plant_3rd_party_lifetime_pv_energy}")
+        pending_update = self._pending_update
         published = await super().publish(mqtt_client, modbus_client, republish=republish)
-        if published is False:
+        if published is False and pending_update:
             return False
         # reset internal values to missing for next calculation
         self.plant_lifetime_pv_energy = None
@@ -640,9 +647,13 @@ class TotalLifetimePVEnergy(UnpublishResetSensorMixin, DerivedSensor, HybridInve
         if sensor.latest_raw_state is None:
             return False
         if isinstance(sensor, PlantPVTotalGeneration):
+            self._log_unconsumed_source_value("plant_lifetime_pv_energy", self.plant_lifetime_pv_energy, self._source_timestamps["plant_lifetime_pv_energy"], sensor)
             self.plant_lifetime_pv_energy = float(sensor.latest_raw_state)
+            self._source_timestamps["plant_lifetime_pv_energy"] = self._source_timestamp(sensor)
         elif isinstance(sensor, ThirdPartyLifetimePVEnergy):
+            self._log_unconsumed_source_value("plant_3rd_party_lifetime_pv_energy", self.plant_3rd_party_lifetime_pv_energy, self._source_timestamps["plant_3rd_party_lifetime_pv_energy"], sensor)
             self.plant_3rd_party_lifetime_pv_energy = float(sensor.latest_raw_state)
+            self._source_timestamps["plant_3rd_party_lifetime_pv_energy"] = self._source_timestamp(sensor)
         else:
             logger.warning(f"{self.log_identity} Attempt to call update_from_source_sensor from {sensor.log_identity}")
             return False
@@ -744,6 +755,7 @@ class PlantSelfConsumedPower(CrossDeviceDerivedSensor, HybridInverter):
         )
         # _values is populated in finalise_binding() once inverter sensors are known
         self._values: dict[str, int | None] = {}
+        self._value_timestamps: dict[str, float | None] = {}
 
     def finalise_binding(self, plant_index: int, *_sources: Sensor) -> bool:
         """Discover all publishable InverterSelfConsumedPower sensors across inverters
@@ -767,6 +779,7 @@ class PlantSelfConsumedPower(CrossDeviceDerivedSensor, HybridInverter):
             return False
 
         self._values = {s.object_id: None for s in sources}
+        self._value_timestamps = {s.object_id: None for s in sources}
         return super().finalise_binding(plant_index, *sources)
 
     def get_attributes(self) -> dict[str, float | int | str]:
@@ -781,8 +794,9 @@ class PlantSelfConsumedPower(CrossDeviceDerivedSensor, HybridInverter):
             return False  # until all values populated, can't do calculation
         if self.debug_logging:
             logger.debug(f"{self.log_identity} Publishing READY   - values={self._values}")
+        pending_update = self._pending_update
         published = await super().publish(mqtt_client, modbus_client, republish=republish)
-        if published is False:
+        if published is False and pending_update:
             return False
         # reset internal values to missing for next calculation
         for k in self._values:
@@ -793,7 +807,11 @@ class PlantSelfConsumedPower(CrossDeviceDerivedSensor, HybridInverter):
         if sensor.latest_raw_state is None:
             return False
         if isinstance(sensor, InverterSelfConsumedPower):
+            source_key = sensor.object_id
+            self._value_timestamps.setdefault(source_key, None)
+            self._log_unconsumed_source_value(source_key, self._values[source_key], self._value_timestamps[source_key], sensor)
             self._values[sensor.object_id] = int(sensor.latest_raw_state)
+            self._value_timestamps[source_key] = self._source_timestamp(sensor)
         else:
             logger.warning(f"{self.log_identity} Attempt to call update_from_source_sensor from {sensor.log_identity}")
             return False

--- a/tests/unit/sensors/test_accumulation_sensors.py
+++ b/tests/unit/sensors/test_accumulation_sensors.py
@@ -16,6 +16,44 @@ def mock_state_store():
 
 class TestAccumulationLogic:
     @pytest.mark.asyncio
+    async def test_repeated_successful_read_is_integrated_once_per_generation(self):
+        source = MagicMock(spec=Sensor)
+        source.unique_id = "source_uid"
+        source.log_identity = "source"
+        source.latest_raw_state = 20.0
+        source.previous_raw_state = 10.0
+        source.state_count = 2
+        source.update_generation = 1
+        source.successful_read_interval = 3600.0
+        source.latest_interval = 3600.0
+
+        with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
+            sensor = ResettableAccumulationSensor(
+                name="Accumulator",
+                unique_id="sigen_accumulator_generation",
+                object_id="sigen_accumulator_generation",
+                source=source,
+                data_type=ModbusDataType.UINT32,
+                unit="kWh",
+                device_class=DeviceClass.ENERGY,
+                state_class=StateClass.TOTAL_INCREASING,
+                icon="mdi:battery",
+                gain=1.0,
+                precision=2,
+            )
+
+            with patch.object(sensor, "run_persistence_coroutine", side_effect=lambda coro: coro.close()):
+                assert sensor.update_from_source_sensor(source) is True
+                assert sensor._current_total == 15.0
+                assert sensor.update_from_source_sensor(source) is False
+                assert sensor._current_total == 15.0
+
+                source.update_generation = 2
+                source.successful_read_interval = 1800.0
+                assert sensor.update_from_source_sensor(source) is True
+                assert sensor._current_total == 22.5
+
+    @pytest.mark.asyncio
     async def test_riemann_sum_accumulation(self):
         """Test the basic Riemann sum (trapezoidal) accumulation logic."""
         source = MagicMock(spec=Sensor)

--- a/tests/unit/sensors/test_inverter_derived_edge_cases.py
+++ b/tests/unit/sensors/test_inverter_derived_edge_cases.py
@@ -118,19 +118,20 @@ class TestInverterBatteryDischargingPowerNoneState:
 
 class TestPVStringPowerValueApply:
     def test_overwriting_unconsumed_value_logs_warning(self, caplog):
-        """Line 105: warning when overwriting an unconsumed value."""
+        """Overwriting an unconsumed value uses shared derived diagnostics."""
         caplog.set_level(logging.WARNING)
-        v = PVStringPower.Value(name="test_value", divisor=1.0)
+        sensor = _make_pv_string_power()
+        v = PVStringPower.Value(name="test_value", divisor=1.0, owner=sensor)
         v.value = 100.0  # Already has a value
         v.timestamp = time.time()
 
         mock_sensor = MagicMock(spec=Sensor)
         mock_sensor.latest_time = time.time()
 
-        with patch("sigenergy2mqtt.sensors.inverter_derived.logger") as mock_log:
+        with patch("sigenergy2mqtt.sensors.base.derived.logger") as mock_log:
             v.apply(mock_sensor)  # Overwrites → triggers line 105
             mock_log.warning.assert_called_once()
-            assert "Overwriting unconsumed value" in mock_log.warning.call_args[0][0]
+            assert "Overwriting unconsumed source value" in mock_log.warning.call_args[0][0]
 
     def test_none_raw_state_returns_early(self):
         """Line 108: early-return when sensor.latest_raw_state is None."""
@@ -165,13 +166,40 @@ class TestPVStringPowerPublishGapWarning:
             sensor.amperes.value = 10.0
             sensor.amperes.timestamp = now
 
-            with patch("sigenergy2mqtt.sensors.base.DerivedSensor.publish", new_callable=AsyncMock):
-                with patch("sigenergy2mqtt.sensors.inverter_derived.logger") as mock_log:
-                    result = await sensor.publish(MagicMock(), None)
-                    assert result is True
-                    # Should have logged the gap warning (line 148)
-                    debug_calls = [str(c) for c in mock_log.debug.call_args_list]
-                    assert any("WARNING" in c for c in debug_calls)
+            with patch("sigenergy2mqtt.sensors.base.DerivedSensor.publish", new_callable=AsyncMock), patch("sigenergy2mqtt.sensors.inverter_derived.logger") as mock_log:
+                result = await sensor.publish(MagicMock(), None)
+                assert result is True
+                # Should have logged the gap warning (line 148)
+                debug_calls = [str(c) for c in mock_log.debug.call_args_list]
+                assert any("WARNING" in c for c in debug_calls)
+
+    @pytest.mark.asyncio
+    async def test_completed_pair_is_cleared_when_unchanged_publish_is_skipped(self):
+        with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
+            sensor = _make_pv_string_power()
+            sensor.volts.value = 400.0
+            sensor.amperes.value = 10.0
+            sensor._states.append((time.time(), 4000.0))
+
+            with patch("sigenergy2mqtt.sensors.base.DerivedSensor.publish", new_callable=AsyncMock, return_value=False):
+                assert await sensor.publish(MagicMock(), None) is False
+
+            assert sensor.volts.value is None
+            assert sensor.amperes.value is None
+
+    @pytest.mark.asyncio
+    async def test_completed_pair_is_retained_when_pending_publish_fails(self):
+        with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
+            sensor = _make_pv_string_power()
+            sensor.volts.value = 400.0
+            sensor.amperes.value = 10.0
+            sensor._pending_update = True
+
+            with patch("sigenergy2mqtt.sensors.base.DerivedSensor.publish", new_callable=AsyncMock, return_value=False):
+                assert await sensor.publish(MagicMock(), None) is False
+
+            assert sensor.volts.value == 400.0
+            assert sensor.amperes.value == 10.0
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -290,12 +318,12 @@ class TestInverterSelfConsumedPowerEdgeCases:
             sensor.update_from_source_sensor(bp)
 
             from sigenergy2mqtt.sensors.base import SanityCheckException
+
             pv1.latest_raw_state = 100
 
             # Patch set_latest_state to raise SanityCheckException
-            with patch.object(sensor, "set_latest_state", side_effect=SanityCheckException("test sanity check")):
-                with patch("sigenergy2mqtt.sensors.inverter_derived.logger") as mock_log:
-                    result = sensor.update_from_source_sensor(pv1)
-                    assert result is True  # Returns True even when SanityCheckException is caught
-                    debug_calls = [str(c) for c in mock_log.debug.call_args_list]
-                    assert any("FAILED" in c for c in debug_calls)
+            with patch.object(sensor, "set_latest_state", side_effect=SanityCheckException("test sanity check")), patch("sigenergy2mqtt.sensors.inverter_derived.logger") as mock_log:
+                result = sensor.update_from_source_sensor(pv1)
+                assert result is True  # Returns True even when SanityCheckException is caught
+                debug_calls = [str(c) for c in mock_log.debug.call_args_list]
+                assert any("FAILED" in c for c in debug_calls)

--- a/tests/unit/sensors/test_inverter_derived_values.py
+++ b/tests/unit/sensors/test_inverter_derived_values.py
@@ -9,6 +9,7 @@ from sigenergy2mqtt.sensors.base import Sensor
 from sigenergy2mqtt.sensors.inverter_derived import (
     InverterBatteryChargingPower,
     InverterBatteryDischargingPower,
+    InverterSelfConsumedPower,
     PVStringDailyEnergy,
     PVStringLifetimeEnergy,
     PVStringPower,
@@ -37,6 +38,32 @@ def mock_config():
 
 
 class TestBatteryDerivedPowerCoverage:
+    @pytest.mark.asyncio
+    async def test_repeated_state_suppression_clears_consumed_inputs(self):
+        ap = MagicMock(spec=Sensor)
+        ap.protocol_version = ProtocolVersion.V2_4
+        bp = MagicMock(spec=Sensor)
+        bp.protocol_version = ProtocolVersion.V2_4
+        pv = MagicMock(spec=PVStringPower)
+        pv.string_number = 1
+        pv.protocol_version = ProtocolVersion.V2_4
+
+        with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
+            sensor = InverterSelfConsumedPower(0, 1, ap, bp, pv)
+            sensor.active_power = 100
+            sensor.battery_power = -50
+            sensor.pv_string_power[1] = 500
+            sensor._states.append((0.0, 450.0))
+
+            cfg = Config()
+            cfg.repeated_state_publish_interval = 60
+            with _swap_active_config(cfg), patch("sigenergy2mqtt.sensors.base.DerivedSensor.publish", new_callable=AsyncMock, return_value=False):
+                assert await sensor.publish(MagicMock(), None) is False
+
+            assert sensor.active_power is None
+            assert sensor.battery_power is None
+            assert sensor.pv_string_power[1] is None
+
     def test_get_attributes_charging(self):
         with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
             cdp = MagicMock(spec=ChargeDischargePower)


### PR DESCRIPTION
* Fixed regression introduced in previous PR for retry-safe cache change that retained `PVStringPower` inputs whenever `super().publish()` returned `False`, but `False` also means “no MQTT publish was needed” when the calculated derived value is unchanged. That left the completed voltage/current pair cached, so the next read logged "Overwriting unconsumed value".

* Added shared overwrite diagnostics mitigation for other `DerivedSensor`s that previously had no "overwriting unconsumed value" checks

  * Added _log_unconsumed_source_value() and _source_timestamp() to derived.py.
  * Added diagnostics to `InverterSelfConsumedPower`, `TotalPVPower`, `PlantConsumedPower`, `TotalLifetimePVEnergy`, and `PlantSelfConsumedPower`
  * Expected overwrites within 2 × `scan_interval` are logged at `DEBUG`.
  * Older overwrites are logged at `WARNING`.
  * Diagnostics use `last_successful_read_time`, falling back safely to `latest_time`.
  * Dynamic cross-device sources and lightweight test doubles are supported.
  * Updated `PVStringPower` to use the shared overwrite diagnostics:
    * Added an owner reference to `PVStringPower.Value`.
    * Replaced its custom warning with `DerivedSensor._log_unconsumed_source_value()`.
    * Uses `last_successful_read_time` through the shared timestamp helper.
    * Preserves a safe timestamp fallback when metadata is unavailable.
    * Updated the regression test to validate the shared diagnostic path.

* Resolved separate risk in Accumulation sensors have a separate risk: when a source read succeeds with the same value, latest_interval does not advance because no new state-history entry is recorded, while propagation still occurs for the new successful-read generation. The accumulator can therefore integrate the old interval repeatedly.
  * Each successful source-read generation is integrated at most once.
  * Duplicate callbacks for the same generation are ignored.
  * Repeated unchanged reads use `successful_read_interval`, not stale `latest_interval`.
  * Manual or legacy sources without generation metadata continue using `latest_interval` as a fallback.