### PR TITLE
Discard stale inverter derived partial snapshots

### DIFF
--- a/sigenergy2mqtt/sensors/inverter_derived.py
+++ b/sigenergy2mqtt/sensors/inverter_derived.py
@@ -242,6 +242,7 @@ class InverterSelfConsumedPower(DerivedSensor, HybridInverter, PVInverter):
         self.battery_power: int | None = None
         self.pv_string_power: dict[int, int | None] = {p.string_number: None for p in pv_string_power}
         self._source_timestamps: dict[str, float | None] = {"active_power": None, "battery_power": None, **{f"pv_string_power_{p.string_number}": None for p in pv_string_power}}
+        self._source_sensors: dict[str, Sensor] = {"active_power": active_power, "battery_power": battery_power, **{f"pv_string_power_{p.string_number}": p for p in pv_string_power}}
         self._incomplete_snapshot_logged = False
 
         self.sanity_check.min_raw = 0  # Watts
@@ -275,6 +276,7 @@ class InverterSelfConsumedPower(DerivedSensor, HybridInverter, PVInverter):
     def update_from_source_sensor(self, sensor: Sensor) -> bool:
         if sensor.latest_raw_state is None:
             return False
+        self._discard_stale_snapshot()
         if isinstance(sensor, ActivePower):
             self._log_unconsumed_source_value("active_power", self.active_power, self._source_timestamps["active_power"], sensor)
             self.active_power = int(sensor.latest_raw_state)
@@ -313,3 +315,25 @@ class InverterSelfConsumedPower(DerivedSensor, HybridInverter, PVInverter):
             if self.debug_logging:
                 logger.debug(f"{self.log_identity} set_latest_state({state}) FAILED - {e}")
         return True
+
+    def _discard_stale_snapshot(self) -> None:
+        """Discard partial source values that survived beyond their source cadence."""
+        now = time.time()
+        stale_sources = []
+        for source_name, value in self._source_timestamps.items():
+            if value is None:
+                continue
+            source_sensor = self._source_sensors.get(source_name)
+            expected_interval = self._source_expected_interval(source_sensor) if source_sensor is not None else None
+            if expected_interval is not None and now - value > expected_interval:
+                stale_sources.append(source_name)
+
+        if not stale_sources:
+            return
+
+        logger.warning(f"{self.log_identity} Discarding stale incomplete source snapshot - stale={stale_sources}")
+        self.active_power = None
+        self.battery_power = None
+        self.pv_string_power = {string_number: None for string_number in self.pv_string_power}
+        self._source_timestamps = {name: None for name in self._source_timestamps}
+        self._incomplete_snapshot_logged = False

--- a/tests/unit/sensors/test_inverter_derived_values.py
+++ b/tests/unit/sensors/test_inverter_derived_values.py
@@ -185,6 +185,27 @@ class TestPVStringEnergyCoverage:
 
 
 class TestInverterSelfConsumedPowerCoverage:
+    def test_stale_partial_snapshot_is_discarded(self):
+        ap = MagicMock(spec=Sensor)
+        bp = MagicMock(spec=Sensor)
+        pv = MagicMock(spec=PVStringPower)
+        pv.string_number = 1
+        pv.protocol_version = ProtocolVersion.V2_4
+        pv.scan_interval = 2
+
+        with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
+            sensor = InverterSelfConsumedPower(0, 1, ap, bp, pv)
+            sensor.pv_string_power[1] = 1234
+            sensor._source_timestamps["pv_string_power_1"] = 100.0
+
+            with patch("sigenergy2mqtt.sensors.inverter_derived.time.time", return_value=110.0):
+                sensor._discard_stale_snapshot()
+
+            assert sensor.active_power is None
+            assert sensor.battery_power is None
+            assert sensor.pv_string_power[1] is None
+            assert all(timestamp is None for timestamp in sensor._source_timestamps.values())
+
     def test_get_attributes(self):
         from sigenergy2mqtt.sensors.inverter_derived import InverterSelfConsumedPower, PVStringPower
         from sigenergy2mqtt.sensors.inverter_read_only import ActivePower, ChargeDischargePower


### PR DESCRIPTION
Added stale partial-snapshot expiry to `InverterSelfConsumedPower`.
- A cached input older than its source cadence invalidates the entire incomplete snapshot.
- The next source update starts a fresh snapshot.
- Complete snapshots are unaffected.
- Added regression coverage for stale PV snapshot discard.