### PR TITLE
Expose sensor debug_logging toggle via Diagnostics Web Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Added MQTT-configurable runtime settings sensors
 - Added configuration of runtime settings via diagnostics web UI
 - Added enhanced logging for unconsumed source values in derived sensors
-- Added ability to set sensor debug logging state via MQTT
+- Added ability to set sensor debug logging state via MQTT and the diagnostics web UI
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,9 @@
 
 ### Added
 
-- Added MQTT-configurable runtime settings sensors
-- Added configuration of runtime settings via diagnostics web UI
-- Added enhanced logging for unconsumed source values in derived sensors
+- Added configuration of runtime settings via MQTT and the diagnostics web UI
 - Added ability to set sensor debug logging state via MQTT and the diagnostics web UI
+- Added enhanced logging for unconsumed source values in derived sensors
 
 ### Fixed
 

--- a/sigenergy2mqtt/diagnostics/collectors.py
+++ b/sigenergy2mqtt/diagnostics/collectors.py
@@ -24,6 +24,7 @@ class DiagnosticsCollectors:
         if active_config.pvoutput.enabled:
             diagnostics_registry.register("pvoutput", cls._diagnostics_collect_pvoutput_metrics)
         diagnostics_registry.register("runtime_configuration", cls._diagnostics_collect_runtime_config)
+        diagnostics_registry.register("sensor_debug_logging", cls._diagnostics_collect_sensor_debug)
 
     @classmethod
     async def _diagnostics_collect_runtime_config(cls) -> dict[str, Any]:
@@ -83,6 +84,35 @@ class DiagnosticsCollectors:
                 controls[endpoint] = descriptor
 
         return {"controls": controls}
+
+    @classmethod
+    async def _diagnostics_collect_sensor_debug(cls) -> dict[str, Any]:
+        """Diagnostics provider callback: exposes all sensor debug_logging flags, grouped by device."""
+        from sigenergy2mqtt.config.sensors import SettingsSensor
+        from sigenergy2mqtt.devices.base.registry import DeviceRegistry
+
+        devices_data: dict[str, Any] = {}
+
+        for plant_index, device_list in sorted(DeviceRegistry._devices.items()):
+            if plant_index < 0:
+                continue
+            for device in device_list:
+                sensors_data: dict[str, Any] = {}
+                for sensor in device.sensors.values():
+                    if isinstance(sensor, SettingsSensor) or not sensor.publishable:
+                        continue
+                    sensors_data[sensor.unique_id] = {
+                        "label": sensor.name,
+                        "type": "switch",
+                        "value": sensor.debug_logging,
+                    }
+                if sensors_data:
+                    devices_data[device.unique_id] = {
+                        "device_name": device.name,
+                        "sensors": sensors_data,
+                    }
+
+        return devices_data
 
     @classmethod
     async def _diagnostics_collect_influxdb_metrics(cls) -> dict[str, Any]:

--- a/sigenergy2mqtt/diagnostics/registry.py
+++ b/sigenergy2mqtt/diagnostics/registry.py
@@ -62,6 +62,7 @@ class DiagnosticsRegistry:
 
     def __init__(self) -> None:
         self._providers: dict[str, _RegisteredProvider] = {}
+        self._revisions: dict[str, int] = {}
         self._lock = asyncio.Lock()
 
     def clear(self) -> None:
@@ -88,6 +89,30 @@ class DiagnosticsRegistry:
         if self._providers.pop(name, None) is not None:
             logger.debug(f"DiagnosticsRegistry Unregistered provider '{name}'")
 
+    def bump_revision(self, name: str) -> int:
+        """Atomically advance and return the revision counter for a named section.
+
+        Used by write endpoints (e.g. the debug-logging and runtime-config
+        HTTP handlers) to give clients a total order for "did a write I sent
+        actually take effect, and is it still the most recent thing that's
+        happened" — independent of HTTP response arrival order or WS
+        broadcast timing.
+
+        Deliberately synchronous and lock-free: callers must invoke this
+        immediately after ``await``-ing the value's actual commit, with no
+        further ``await`` in between. asyncio only switches tasks at await
+        points, so that gap-free sequence is what guarantees a broadcast can
+        never observe the new value with a stale revision (or vice versa).
+        Wrapping this in ``asyncio.Lock`` would require ``async with``,
+        reintroducing an await point and the exact race this exists to close.
+        """
+        self._revisions[name] = self._revisions.get(name, 0) + 1
+        return self._revisions[name]
+
+    def revision(self, name: str) -> int:
+        """Current revision counter for a named section (0 if never bumped)."""
+        return self._revisions.get(name, 0)
+
     async def snapshot(self) -> dict[str, Any]:
         """Collect every registered provider's data into one payload."""
 
@@ -107,6 +132,7 @@ class DiagnosticsRegistry:
         results = await asyncio.gather(*(_run(p) for p in providers)) if providers else []
 
         payload: dict[str, Any] = {"timestamp": int(time.time())}
+        payload["_revisions"] = dict(self._revisions)
         payload.update({name: data for name, data in results})
         return payload
 

--- a/sigenergy2mqtt/diagnostics/registry.py
+++ b/sigenergy2mqtt/diagnostics/registry.py
@@ -129,10 +129,24 @@ class DiagnosticsRegistry:
         async with self._lock:
             providers = list(self._providers.values())
 
+        # Snapshot revisions BEFORE collecting provider data, not after. A
+        # write that commits (and bumps its revision — see bump_revision)
+        # while the gather below is in flight will have already committed
+        # its value by then; that provider's collect() call will see the new
+        # value even though this "_revisions" dict, captured earlier, won't
+        # yet include the bump. That's a safe kind of staleness — a lower
+        # revision number paired with a value that's actually already
+        # current — and self-corrects via the write's own HTTP response.
+        # The reverse ordering (revisions captured after data) can instead
+        # pair a *newer* revision with a *stale* value when a write commits
+        # mid-gather, which a client's "revision > lastKnownRevision" check
+        # would wrongly trust as authoritative.
+        revisions = dict(self._revisions)
+
         results = await asyncio.gather(*(_run(p) for p in providers)) if providers else []
 
         payload: dict[str, Any] = {"timestamp": int(time.time())}
-        payload["_revisions"] = dict(self._revisions)
+        payload["_revisions"] = revisions
         payload.update({name: data for name, data in results})
         return payload
 

--- a/sigenergy2mqtt/diagnostics/server.py
+++ b/sigenergy2mqtt/diagnostics/server.py
@@ -306,8 +306,9 @@ class DiagnosticsServer:
             return web.json_response({"ok": False, "error": str(exc)}, status=500)
 
         if ok:
+            revision = diagnostics_registry.bump_revision("runtime_configuration")
             logger.info(f"DiagnosticsServer Config updated via HTTP: {endpoint!r} = {raw_value!r}")
-            return web.json_response({"ok": True})
+            return web.json_response({"ok": True, "revision": revision})
         return web.json_response({"ok": False, "error": "Update rejected by sensor validation"}, status=422)
 
     async def _handle_debug_update(self, request: web.Request) -> web.Response:
@@ -366,8 +367,9 @@ class DiagnosticsServer:
             return web.json_response({"ok": False, "error": str(exc)}, status=500)
 
         if ok:
+            revision = diagnostics_registry.bump_revision("sensor_debug_logging")
             logger.info(f"DiagnosticsServer debug_logging toggled via HTTP: {sensor_id!r} = {raw_value!r}")
-            return web.json_response({"ok": True})
+            return web.json_response({"ok": True, "revision": revision})
         return web.json_response({"ok": False, "error": "Update had no effect (value unchanged)"})
 
 

--- a/sigenergy2mqtt/diagnostics/server.py
+++ b/sigenergy2mqtt/diagnostics/server.py
@@ -70,6 +70,8 @@ class DiagnosticsServer:
         self._app.router.add_get("/diagnostics/ws", self._handle_websocket)
         self._app.router.add_get("/diagnostics/export", self._handle_export)
         self._app.router.add_post("/diagnostics/config/{endpoint}", self._handle_config_update)
+        self._app.router.add_get("/diagnostics/debug", self._handle_debug_dashboard)
+        self._app.router.add_post("/diagnostics/debug/{sensor_id}", self._handle_debug_update)
         self._app.router.add_static("/diagnostics/static/", STATIC_DIR, name="static")
 
     @staticmethod
@@ -218,6 +220,13 @@ class DiagnosticsServer:
         """
         return web.FileResponse(STATIC_DIR / "dashboard.html")
 
+    async def _handle_debug_dashboard(self, request: web.Request) -> web.FileResponse:
+        """Debug-logging dashboard — same pattern as ``_handle_solar_dashboard``:
+        served at ".../diagnostics/debug" (no trailing slash) so relative
+        "ws" and "static/..." URLs resolve against ".../diagnostics/".
+        """
+        return web.FileResponse(STATIC_DIR / "debug.html")
+
     async def _handle_export(self, request: web.Request) -> web.Response:
         """Full, freshly-collected diagnostics payload as a downloadable file."""
         logger.debug("DiagnosticsServer fetching fresh snapshot for export")
@@ -300,6 +309,66 @@ class DiagnosticsServer:
             logger.info(f"DiagnosticsServer Config updated via HTTP: {endpoint!r} = {raw_value!r}")
             return web.json_response({"ok": True})
         return web.json_response({"ok": False, "error": "Update rejected by sensor validation"}, status=422)
+
+    async def _handle_debug_update(self, request: web.Request) -> web.Response:
+        """Toggle a sensor's ``debug_logging`` flag via HTTP.
+
+        Finds the sensor whose ``unique_id`` matches the ``{sensor_id}`` path
+        parameter across all real-device plant indices (≥ 0) in
+        :class:`~sigenergy2mqtt.devices.base.registry.DeviceRegistry`, then
+        calls :meth:`~sigenergy2mqtt.sensors.base.sensor.Sensor.set_debug_logging`
+        — the same method used by the MQTT debug topic.
+
+        ``modbus_client``, ``mqtt_client``, and ``handler`` are all ``None``;
+        ``set_debug_logging`` only reads ``value`` and does not use the others.
+        """
+        from sigenergy2mqtt.config.sensors import SettingsSensor
+        from sigenergy2mqtt.devices.base.registry import DeviceRegistry
+
+        sensor_id = request.match_info["sensor_id"]
+
+        # Parse body
+        try:
+            body = await request.json()
+            raw_value = body["value"]
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError, UnicodeDecodeError) as exc:
+            return web.json_response({"ok": False, "error": f"Invalid request body: {exc}"}, status=400)
+
+        if not isinstance(raw_value, bool):
+            return web.json_response({"ok": False, "error": "Debug value must be a boolean"}, status=422)
+
+        # Find the sensor across all real-device plant indices
+        from sigenergy2mqtt.sensors.base.sensor import Sensor
+        matched_sensor: Sensor | None = None
+        for plant_index, device_list in DeviceRegistry._devices.items():
+            if plant_index < 0:
+                continue
+            for device in device_list:
+                for sensor in device.sensors.values():
+                    if isinstance(sensor, SettingsSensor):
+                        continue
+                    if sensor.unique_id == sensor_id:
+                        matched_sensor = sensor
+                        break
+                if matched_sensor is not None:
+                    break
+            if matched_sensor is not None:
+                break
+
+        if matched_sensor is None:
+            return web.json_response({"ok": False, "error": f"Unknown sensor: {sensor_id!r}"}, status=404)
+
+        coerced: float = 1.0 if raw_value else 0.0
+        try:
+            ok = await matched_sensor.set_debug_logging(None, None, coerced, "diagnostics", None)  # type: ignore[arg-type]
+        except (KeyError, RuntimeError, TypeError, ValueError) as exc:
+            logger.warning(f"DiagnosticsServer debug update for {sensor_id!r} raised: {exc}")
+            return web.json_response({"ok": False, "error": str(exc)}, status=500)
+
+        if ok:
+            logger.info(f"DiagnosticsServer debug_logging toggled via HTTP: {sensor_id!r} = {raw_value!r}")
+            return web.json_response({"ok": True})
+        return web.json_response({"ok": False, "error": "Update had no effect (value unchanged)"})
 
 
     async def _handle_websocket(self, request: web.Request) -> web.WebSocketResponse:

--- a/sigenergy2mqtt/diagnostics/static/debug.html
+++ b/sigenergy2mqtt/diagnostics/static/debug.html
@@ -588,30 +588,24 @@
 
         checkbox._currentVal = Boolean(ctrl.value);
         checkbox._pendingRequests = 0;
-        checkbox._snapshotMissed = false;
-        checkbox._lastSnapshot = Date.now();
-        checkbox._pendingValues = [];
+        checkbox._seq = 0; // bumps on every applied authoritative update (snapshot or confirmed write)
         checkbox.addEventListener('change', function () {
           const newVal = checkbox.checked;
-          const reqTime = Date.now();
+          const seqAtSend = checkbox._seq;
           checkbox._pendingRequests++;
-          checkbox._pendingValues.push(newVal);
           sendDebugUpdate(sensorId, newVal, slider, null, function () {
             checkbox.checked = checkbox._currentVal;
           }).then(function (ok) {
-            if (ok && checkbox._lastSnapshot <= reqTime) {
+            // Only apply if nothing newer (a snapshot, or another completed write)
+            // has landed since this request was sent.
+            if (ok && checkbox._seq === seqAtSend) {
               checkbox._currentVal = newVal;
+              checkbox._seq++;
             }
           }).finally(function () {
             checkbox._pendingRequests--;
-            if (checkbox._pendingRequests === 0) {
-              checkbox._pendingValues.length = 0;
-              if (checkbox._snapshotMissed) {
-                checkbox._snapshotMissed = false;
-                if (checkbox.checked !== checkbox._currentVal) {
-                  checkbox.checked = checkbox._currentVal;
-                }
-              }
+            if (checkbox._pendingRequests === 0 && checkbox.checked !== checkbox._currentVal) {
+              checkbox.checked = checkbox._currentVal;
             }
           });
         });
@@ -659,29 +653,14 @@
             const checkbox = row.querySelector('input[type="checkbox"]');
             if (checkbox) {
               const newVal = Boolean(ctrl.value);
-              const valueChanged = checkbox._currentVal !== newVal;
+              checkbox._currentVal = newVal;
+              checkbox._seq++; // every snapshot is authoritative, whether or not the value changed
 
-              if (valueChanged || checkbox._pendingRequests > 0) {
-                checkbox._currentVal = newVal;
-
-                if (checkbox._pendingValues && checkbox._pendingValues.length > 0) {
-                  const idx = checkbox._pendingValues.indexOf(newVal);
-                  if (idx !== -1) {
-                    checkbox._pendingValues.splice(0, idx + 1);
-                  } else {
-                    checkbox._pendingValues.length = 0;
-                    checkbox._lastSnapshot = Date.now();
-                  }
-                } else {
-                  checkbox._lastSnapshot = Date.now();
-                }
-
-                if (checkbox._pendingRequests === 0) {
-                  if (checkbox.checked !== newVal) checkbox.checked = newVal;
-                } else {
-                  checkbox._snapshotMissed = true;
-                }
+              if (checkbox._pendingRequests === 0 && checkbox.checked !== newVal) {
+                checkbox.checked = newVal;
               }
+              // if requests are still pending, leave checkbox.checked alone —
+              // the finally() in the change handler reconciles it once they all settle
             }
           } else {
             card.appendChild(buildRow(sensorId, ctrl));

--- a/sigenergy2mqtt/diagnostics/static/debug.html
+++ b/sigenergy2mqtt/diagnostics/static/debug.html
@@ -638,10 +638,12 @@
           const row = card.querySelector('.control-row[data-sensor-id="' + CSS.escape(sensorId) + '"]');
           if (row) {
             const checkbox = row.querySelector('input[type="checkbox"]');
-            if (checkbox && document.activeElement !== checkbox) {
+            if (checkbox) {
               const newVal = Boolean(ctrl.value);
               checkbox._currentVal = newVal;
-              if (checkbox.checked !== newVal) checkbox.checked = newVal;
+              if (document.activeElement !== checkbox && checkbox.checked !== newVal) {
+                checkbox.checked = newVal;
+              }
             }
           } else {
             card.appendChild(buildRow(sensorId, ctrl));

--- a/sigenergy2mqtt/diagnostics/static/debug.html
+++ b/sigenergy2mqtt/diagnostics/static/debug.html
@@ -587,12 +587,16 @@
         row.appendChild(switchLabel);
 
         checkbox._currentVal = Boolean(ctrl.value);
+        checkbox._lastSnapshot = Date.now();
         checkbox.addEventListener('change', function () {
           const newVal = checkbox.checked;
+          const reqTime = Date.now();
           sendDebugUpdate(sensorId, newVal, slider, null, function () {
             checkbox.checked = checkbox._currentVal;
           }).then(function (ok) {
-            if (ok) checkbox._currentVal = newVal;
+            if (ok && checkbox._lastSnapshot <= reqTime) {
+              checkbox._currentVal = newVal;
+            }
           });
         });
 
@@ -640,6 +644,7 @@
             if (checkbox) {
               const newVal = Boolean(ctrl.value);
               checkbox._currentVal = newVal;
+              checkbox._lastSnapshot = Date.now();
               if (document.activeElement !== checkbox && checkbox.checked !== newVal) {
                 checkbox.checked = newVal;
               }

--- a/sigenergy2mqtt/diagnostics/static/debug.html
+++ b/sigenergy2mqtt/diagnostics/static/debug.html
@@ -587,17 +587,16 @@
         row.appendChild(switchLabel);
 
         checkbox._currentVal = Boolean(ctrl.value);
-        checkbox._reqSeq = 0;
-        checkbox._ackSeq = 0;
+        checkbox._pendingRequests = 0;
         checkbox.addEventListener('change', function () {
           const newVal = checkbox.checked;
-          const seq = ++checkbox._reqSeq;
+          checkbox._pendingRequests++;
           sendDebugUpdate(sensorId, newVal, slider, null, function () {
             checkbox.checked = checkbox._currentVal;
-          }).then(function (ok) {
-            if (ok && seq > checkbox._ackSeq) {
-              checkbox._currentVal = newVal;
-              checkbox._ackSeq = seq;
+          }).finally(function () {
+            checkbox._pendingRequests--;
+            if (checkbox._pendingRequests === 0 && checkbox.checked !== checkbox._currentVal) {
+              checkbox.checked = checkbox._currentVal;
             }
           });
         });
@@ -645,11 +644,8 @@
             const checkbox = row.querySelector('input[type="checkbox"]');
             if (checkbox) {
               const newVal = Boolean(ctrl.value);
-              if (newVal !== checkbox._currentVal) {
-                checkbox._currentVal = newVal;
-                checkbox._ackSeq = checkbox._reqSeq;
-              }
-              if (document.activeElement !== checkbox && checkbox.checked !== newVal) {
+              checkbox._currentVal = newVal;
+              if (checkbox._pendingRequests === 0 && checkbox.checked !== newVal) {
                 checkbox.checked = newVal;
               }
             }

--- a/sigenergy2mqtt/diagnostics/static/debug.html
+++ b/sigenergy2mqtt/diagnostics/static/debug.html
@@ -1,0 +1,693 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>sigenergy2mqtt — Debug Logging</title>
+  <link rel="icon" type="image/x-icon" href="static/favicon.ico">
+  <script>
+    (function () {
+      try {
+        const saved = localStorage.getItem('s2m-theme');
+        const theme = saved || (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+        if (theme === 'light') document.documentElement.setAttribute('data-theme', 'light');
+      } catch (e) { /* localStorage unavailable — default to dark */ }
+    })();
+  </script>
+  <style>
+    :root {
+      --bg: #0b1220;
+      --bg-panel: #121b2e;
+      --bg-card: #16223a;
+      --border: #24314d;
+      --text: #e6ebf5;
+      --text-dim: #8b98b3;
+      --accent: #3ddc97;
+      --accent-dim: rgba(61, 220, 151, 0.15);
+      --warn: #f5a623;
+      --warn-dim: rgba(245, 166, 35, 0.15);
+      --bad: #ef4b5f;
+      --bad-dim: rgba(239, 75, 95, 0.15);
+      --unknown: #6b7794;
+      --mono: "SF Mono", "JetBrains Mono", Consolas, monospace;
+      --glow-1: rgba(61, 220, 151, 0.07);
+      --glow-2: rgba(58, 123, 213, 0.08);
+      --dash-border: rgba(255, 255, 255, 0.05);
+      --header-bg: rgba(18, 27, 46, 0.6);
+      --scheme: dark;
+    }
+
+    :root[data-theme="light"] {
+      --bg: #f4f6fb;
+      --bg-panel: #ffffff;
+      --bg-card: #ffffff;
+      --border: #dde3ee;
+      --text: #1a2233;
+      --text-dim: #5b6579;
+      --accent: #1f9d6f;
+      --accent-dim: rgba(31, 157, 111, 0.12);
+      --warn: #b1720a;
+      --warn-dim: rgba(177, 114, 10, 0.12);
+      --bad: #c8293e;
+      --bad-dim: rgba(200, 41, 62, 0.1);
+      --unknown: #7a8499;
+      --glow-1: rgba(31, 157, 111, 0.06);
+      --glow-2: rgba(58, 123, 213, 0.06);
+      --header-bg: rgba(255, 255, 255, 0.7);
+      --scheme: light;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html {
+      color-scheme: var(--scheme);
+    }
+
+    body {
+      margin: 0;
+      background:
+        radial-gradient(1200px 600px at 15% -10%, var(--glow-1), transparent 60%),
+        radial-gradient(900px 500px at 90% 0%, var(--glow-2), transparent 55%),
+        var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      min-height: 100vh;
+      transition: background-color 0.2s, color 0.2s;
+    }
+
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 20px 32px;
+      border-bottom: 1px solid var(--border);
+      background: var(--header-bg);
+      backdrop-filter: blur(6px);
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      gap: 20px;
+      flex-wrap: wrap;
+    }
+
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+    }
+
+    .brand img {
+      height: 50px;
+      width: auto;
+      display: block;
+    }
+
+    .brand-sub {
+      font-size: 13px;
+      color: var(--text-dim);
+      letter-spacing: 0.02em;
+    }
+
+    .header-right {
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      flex-wrap: wrap;
+    }
+
+    .conn-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 12px;
+      padding: 6px 12px;
+      border-radius: 999px;
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      color: var(--text-dim);
+    }
+
+    .conn-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--unknown);
+      transition: background 0.3s;
+    }
+
+    .conn-pill.live .conn-dot {
+      background: var(--accent);
+      box-shadow: 0 0 8px var(--accent);
+    }
+
+    .conn-pill.down .conn-dot {
+      background: var(--bad);
+      box-shadow: 0 0 8px var(--bad);
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 13px;
+      padding: 8px 16px;
+      border-radius: 8px;
+      border: 1px solid var(--border);
+      background: var(--bg-card);
+      color: var(--text);
+      cursor: pointer;
+      text-decoration: none;
+      transition: border-color 0.15s, transform 0.1s;
+    }
+
+    .btn:hover {
+      border-color: var(--accent);
+      transform: translateY(-1px);
+    }
+
+    .theme-toggle {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 34px;
+      height: 34px;
+      padding: 0;
+      border-radius: 8px;
+      border: 1px solid var(--border);
+      background: var(--bg-card);
+      color: var(--text-dim);
+      cursor: pointer;
+      transition: border-color 0.15s, color 0.15s;
+    }
+
+    .theme-toggle:hover {
+      border-color: var(--accent);
+      color: var(--text);
+    }
+
+    .theme-toggle svg {
+      width: 16px;
+      height: 16px;
+      display: block;
+    }
+
+    .theme-toggle .icon-moon {
+      display: none;
+    }
+
+    :root[data-theme="light"] .theme-toggle .icon-sun {
+      display: none;
+    }
+
+    :root[data-theme="light"] .theme-toggle .icon-moon {
+      display: block;
+    }
+
+    main {
+      padding: 28px 32px 60px;
+      max-width: 1280px;
+      margin: 0 auto;
+    }
+
+    /* Filter bar */
+    .filter-bar {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 24px;
+    }
+
+    .filter-input {
+      flex: 1;
+      background: var(--bg-panel);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      color: var(--text);
+      font-family: inherit;
+      font-size: 13px;
+      padding: 10px 16px;
+      outline: none;
+      transition: border-color 0.15s;
+    }
+
+    .filter-input:focus {
+      border-color: var(--accent);
+    }
+
+    .filter-input::placeholder {
+      color: var(--text-dim);
+    }
+
+    .filter-count {
+      font-size: 12px;
+      color: var(--text-dim);
+      white-space: nowrap;
+    }
+
+    /* Transient notice */
+    .transient-notice {
+      display: flex;
+      align-items: flex-start;
+      gap: 8px;
+      background: var(--warn-dim);
+      color: var(--warn);
+      border-radius: 8px;
+      padding: 8px 10px;
+      font-size: 10px;
+      line-height: 1.4;
+      margin-bottom: 20px;
+    }
+
+    .transient-notice svg {
+      width: 14px;
+      height: 14px;
+      flex-shrink: 0;
+      margin-top: 1px;
+    }
+
+    /* Card grid */
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+      gap: 18px;
+    }
+
+    .card {
+      background: var(--bg-panel);
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      padding: 20px;
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+      gap: 12px;
+    }
+
+    .card-title {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      font-size: 13px;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: var(--text-dim);
+    }
+
+    /* Control rows */
+    .control-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      font-size: 13px;
+      color: var(--text-dim);
+      padding: 5px 0;
+      border-bottom: 1px dashed var(--dash-border);
+    }
+
+    .control-row:last-child {
+      border-bottom: none;
+    }
+
+    .control-row.hidden-by-filter {
+      display: none;
+    }
+
+    .ctrl-label {
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    /* Toggle switch */
+    .ctrl-switch {
+      position: relative;
+      display: inline-block;
+      width: 36px;
+      height: 20px;
+      flex-shrink: 0;
+    }
+
+    .ctrl-switch input {
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+
+    .ctrl-slider {
+      position: absolute;
+      inset: 0;
+      background: var(--border);
+      border-radius: 999px;
+      cursor: pointer;
+      transition: background 0.2s;
+    }
+
+    .ctrl-slider::before {
+      content: '';
+      position: absolute;
+      width: 14px;
+      height: 14px;
+      left: 3px;
+      top: 3px;
+      background: var(--text);
+      border-radius: 50%;
+      transition: transform 0.2s;
+    }
+
+    .ctrl-switch input:checked+.ctrl-slider {
+      background: var(--accent);
+    }
+
+    .ctrl-switch input:checked+.ctrl-slider::before {
+      transform: translateX(16px);
+    }
+
+    /* Flash feedback */
+    @keyframes flashOk {
+
+      0%,
+      100% {
+        box-shadow: none;
+      }
+
+      40% {
+        box-shadow: 0 0 8px var(--accent);
+      }
+    }
+
+    @keyframes flashErr {
+
+      0%,
+      100% {
+        box-shadow: none;
+      }
+
+      40% {
+        box-shadow: 0 0 8px var(--bad);
+      }
+    }
+
+    .flash-ok {
+      animation: flashOk 0.7s ease;
+    }
+
+    .flash-err {
+      animation: flashErr 0.7s ease;
+    }
+
+    /* Empty / loading */
+    .empty-state {
+      grid-column: 1 / -1;
+      text-align: center;
+      padding: 60px 20px;
+      color: var(--text-dim);
+      font-size: 14px;
+    }
+
+    @keyframes pulse {
+
+      0%,
+      100% {
+        opacity: 1;
+      }
+
+      50% {
+        opacity: 0.4;
+      }
+    }
+
+    .pulsing {
+      animation: pulse 1.6s ease-in-out infinite;
+    }
+
+    .footer-note {
+      text-align: center;
+      color: var(--text-dim);
+      font-size: 12px;
+      margin-top: 40px;
+    }
+  </style>
+</head>
+
+<body>
+
+  <header>
+    <div class="brand">
+      <img src="static/logo.png" alt="sigenergy2mqtt">
+      <span class="brand-sub">Debug Logging</span>
+    </div>
+    <div class="header-right">
+      <span class="conn-pill" id="connPill"><span class="conn-dot"></span><span id="connLabel">Connecting…</span></span>
+      <a class="btn" href="./">← Diagnostics</a>
+      <button class="theme-toggle" id="themeToggle" type="button" aria-label="Toggle light/dark theme"
+        title="Toggle theme">
+        <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+          stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="4"></circle>
+          <path
+            d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41">
+          </path>
+        </svg>
+        <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+          stroke-linecap="round" stroke-linejoin="round">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+        </svg>
+      </button>
+    </div>
+  </header>
+
+  <main>
+    <div class="transient-notice">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+        stroke-linejoin="round">
+        <path d="M12 9v4"></path>
+        <path d="M12 17h.01"></path>
+        <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"></path>
+      </svg>
+      <span>Changes apply immediately but are <strong>not saved</strong> and will revert to configured values on
+        restart. <i>Application Log Level</i> must be set to <strong>DEBUG</strong> for the effects of changes to be
+        seen in the logs.</span>
+    </div>
+
+    <div class="filter-bar">
+      <input class="filter-input" id="filterInput" type="search" placeholder="Filter sensors by name…"
+        autocomplete="off">
+      <span class="filter-count" id="filterCount"></span>
+    </div>
+
+    <div class="grid" id="cardGrid">
+      <div class="empty-state pulsing">Waiting for the first diagnostics snapshot…</div>
+    </div>
+  </main>
+
+  <script>
+    (function () {
+      const cardGrid = document.getElementById('cardGrid');
+      const connPill = document.getElementById('connPill');
+      const connLabel = document.getElementById('connLabel');
+      const themeToggle = document.getElementById('themeToggle');
+      const filterInput = document.getElementById('filterInput');
+      const filterCount = document.getElementById('filterCount');
+
+      // Theme toggle
+      themeToggle.addEventListener('click', () => {
+        const isLight = document.documentElement.getAttribute('data-theme') === 'light';
+        const next = isLight ? 'dark' : 'light';
+        if (next === 'light') {
+          document.documentElement.setAttribute('data-theme', 'light');
+        } else {
+          document.documentElement.removeAttribute('data-theme');
+        }
+        try { localStorage.setItem('s2m-theme', next); } catch (e) { /* ignore */ }
+      });
+
+      // Filter — show/hide rows and update per-card active counts
+      function applyFilter() {
+        const q = filterInput.value.trim().toLowerCase();
+        let visible = 0, total = 0;
+        cardGrid.querySelectorAll('.control-row').forEach(row => {
+          const label = (row.dataset.label || '').toLowerCase();
+          const show = !q || label.includes(q);
+          row.classList.toggle('hidden-by-filter', !show);
+          if (show) visible++;
+          total++;
+        });
+        cardGrid.querySelectorAll('.card').forEach(card => {
+          const visibleRows = card.querySelectorAll('.control-row:not(.hidden-by-filter)');
+          card.style.display = visibleRows.length === 0 ? 'none' : '';
+        });
+        filterCount.textContent = q ? (visible + ' of ' + total + ' sensors') : (total > 0 ? total + ' sensors' : '');
+      }
+
+      filterInput.addEventListener('input', applyFilter);
+
+      // POST a debug toggle to the server
+      async function sendDebugUpdate(sensorId, value, slider, prevValue, revertCb) {
+        try {
+          // This page is at .../diagnostics/debug (no trailing slash).
+          // Resolving "debug/<id>" against location.href correctly yields
+          // .../diagnostics/debug/<id>
+          const url = new URL('debug/' + encodeURIComponent(sensorId), location.href);
+          const res = await fetch(url.href, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ value }),
+          });
+          const result = await res.json();
+          if (res.ok && result.ok) {
+            slider.classList.remove('flash-ok', 'flash-err');
+            void slider.offsetWidth;
+            slider.classList.add('flash-ok');
+            return true;
+          } else {
+            throw new Error(result.error || 'Update failed');
+          }
+        } catch (err) {
+          console.error('Debug toggle failed for ' + sensorId + ':', err);
+          slider.classList.remove('flash-ok', 'flash-err');
+          void slider.offsetWidth;
+          slider.classList.add('flash-err');
+          if (revertCb) revertCb(prevValue);
+          return false;
+        }
+      }
+
+      // Build a device card with one switch row per sensor
+      function buildCard(deviceId, deviceData) {
+        const sensors = deviceData.sensors || {};
+
+        const card = document.createElement('div');
+        card.className = 'card';
+        card.dataset.device = deviceId;
+
+        const title = document.createElement('div');
+        title.className = 'card-title';
+
+        const nameSpan = document.createElement('span');
+        nameSpan.textContent = deviceData.device_name || deviceId;
+        title.appendChild(nameSpan);
+
+        card.appendChild(title);
+
+        Object.entries(sensors).forEach(function ([sensorId, ctrl]) {
+          const row = document.createElement('div');
+          row.className = 'control-row';
+          row.dataset.sensorId = sensorId;
+          row.dataset.label = ctrl.label || sensorId;
+
+          const labelEl = document.createElement('span');
+          labelEl.className = 'ctrl-label';
+          labelEl.textContent = ctrl.label || sensorId;
+          labelEl.title = sensorId;  // full unique_id as tooltip
+          row.appendChild(labelEl);
+
+          const switchLabel = document.createElement('label');
+          switchLabel.className = 'ctrl-switch';
+
+          const checkbox = document.createElement('input');
+          checkbox.type = 'checkbox';
+          checkbox.checked = Boolean(ctrl.value);
+          checkbox.dataset.sensorId = sensorId;
+
+          const slider = document.createElement('span');
+          slider.className = 'ctrl-slider';
+
+          switchLabel.appendChild(checkbox);
+          switchLabel.appendChild(slider);
+          row.appendChild(switchLabel);
+          card.appendChild(row);
+
+          let currentVal = Boolean(ctrl.value);
+          checkbox.addEventListener('change', function () {
+            const newVal = checkbox.checked;
+            sendDebugUpdate(sensorId, newVal, slider, currentVal, function (prev) {
+              checkbox.checked = prev;
+            }).then(function (ok) {
+              if (ok) currentVal = newVal;
+            });
+          });
+        });
+
+        return card;
+      }
+
+      // Update an existing card in-place without rebuilding DOM
+      function updateCard(card, deviceData) {
+        const sensors = deviceData.sensors || {};
+        Object.entries(sensors).forEach(function ([sensorId, ctrl]) {
+          const checkbox = card.querySelector('[data-sensor-id="' + sensorId + '"]');
+          if (!checkbox) return;
+          if (document.activeElement === checkbox) return;
+          const newVal = Boolean(ctrl.value);
+          if (checkbox.checked !== newVal) checkbox.checked = newVal;
+        });
+      }
+
+      // Render/update the grid from a snapshot
+      function render(snapshot) {
+        const data = snapshot.sensor_debug_logging;
+        if (!data || typeof data !== 'object') return;
+
+        const emptyState = cardGrid.querySelector('.empty-state');
+        if (emptyState) cardGrid.innerHTML = '';
+
+        const deviceIds = Object.keys(data);
+
+        deviceIds.forEach(function (deviceId) {
+          const existingCard = cardGrid.querySelector('[data-device="' + deviceId + '"]');
+          if (existingCard) {
+            updateCard(existingCard, data[deviceId]);
+          } else {
+            cardGrid.appendChild(buildCard(deviceId, data[deviceId]));
+          }
+        });
+
+        // Remove stale cards
+        cardGrid.querySelectorAll('[data-device]').forEach(function (c) {
+          if (!deviceIds.includes(c.dataset.device)) c.remove();
+        });
+
+        applyFilter();
+      }
+
+      // WebSocket connection
+      function setConn(state) {
+        connPill.className = 'conn-pill ' + state;
+        connLabel.textContent = state === 'live' ? 'Live' : state === 'down' ? 'Disconnected' : 'Connecting…';
+      }
+
+      let retryDelay = 1000;
+
+      function connect() {
+        // This page is at .../diagnostics/debug
+        // Relative "ws" resolves to .../diagnostics/ws — the shared WebSocket feed.
+        const wsUrl = new URL('ws', location.href);
+        wsUrl.protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+        const socket = new WebSocket(wsUrl.href);
+
+        socket.onopen = function () { setConn('live'); retryDelay = 1000; };
+        socket.onmessage = function (evt) {
+          try { render(JSON.parse(evt.data)); } catch (e) { console.error('Bad diagnostics payload', e); }
+        };
+        socket.onclose = function () {
+          setConn('down');
+          setTimeout(connect, retryDelay);
+          retryDelay = Math.min(retryDelay * 1.5, 15000);
+        };
+        socket.onerror = function () { socket.close(); };
+      }
+
+      connect();
+    })();
+  </script>
+
+</body>
+
+</html>

--- a/sigenergy2mqtt/diagnostics/static/debug.html
+++ b/sigenergy2mqtt/diagnostics/static/debug.html
@@ -634,7 +634,7 @@
 
         // Add new rows and update existing ones
         Object.entries(sensors).forEach(function ([sensorId, ctrl]) {
-          const row = card.querySelector('.control-row[data-sensor-id="' + sensorId + '"]');
+          const row = card.querySelector('.control-row[data-sensor-id="' + CSS.escape(sensorId) + '"]');
           if (row) {
             const checkbox = row.querySelector('input[type="checkbox"]');
             if (checkbox && document.activeElement !== checkbox) {
@@ -658,7 +658,7 @@
         const deviceIds = Object.keys(data);
 
         deviceIds.forEach(function (deviceId) {
-          const existingCard = cardGrid.querySelector('[data-device="' + deviceId + '"]');
+          const existingCard = cardGrid.querySelector('[data-device="' + CSS.escape(deviceId) + '"]');
           if (existingCard) {
             updateCard(existingCard, data[deviceId]);
           } else {

--- a/sigenergy2mqtt/diagnostics/static/debug.html
+++ b/sigenergy2mqtt/diagnostics/static/debug.html
@@ -559,6 +559,46 @@
         }
       }
 
+      function buildRow(sensorId, ctrl) {
+        const row = document.createElement('div');
+        row.className = 'control-row';
+        row.dataset.sensorId = sensorId;
+        row.dataset.label = ctrl.label || sensorId;
+
+        const labelEl = document.createElement('span');
+        labelEl.className = 'ctrl-label';
+        labelEl.textContent = ctrl.label || sensorId;
+        labelEl.title = sensorId;  // full unique_id as tooltip
+        row.appendChild(labelEl);
+
+        const switchLabel = document.createElement('label');
+        switchLabel.className = 'ctrl-switch';
+
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.checked = Boolean(ctrl.value);
+        checkbox.dataset.sensorId = sensorId;
+
+        const slider = document.createElement('span');
+        slider.className = 'ctrl-slider';
+
+        switchLabel.appendChild(checkbox);
+        switchLabel.appendChild(slider);
+        row.appendChild(switchLabel);
+
+        let currentVal = Boolean(ctrl.value);
+        checkbox.addEventListener('change', function () {
+          const newVal = checkbox.checked;
+          sendDebugUpdate(sensorId, newVal, slider, currentVal, function (prev) {
+            checkbox.checked = prev;
+          }).then(function (ok) {
+            if (ok) currentVal = newVal;
+          });
+        });
+
+        return row;
+      }
+
       // Build a device card with one switch row per sensor
       function buildCard(deviceId, deviceData) {
         const sensors = deviceData.sensors || {};
@@ -577,56 +617,33 @@
         card.appendChild(title);
 
         Object.entries(sensors).forEach(function ([sensorId, ctrl]) {
-          const row = document.createElement('div');
-          row.className = 'control-row';
-          row.dataset.sensorId = sensorId;
-          row.dataset.label = ctrl.label || sensorId;
-
-          const labelEl = document.createElement('span');
-          labelEl.className = 'ctrl-label';
-          labelEl.textContent = ctrl.label || sensorId;
-          labelEl.title = sensorId;  // full unique_id as tooltip
-          row.appendChild(labelEl);
-
-          const switchLabel = document.createElement('label');
-          switchLabel.className = 'ctrl-switch';
-
-          const checkbox = document.createElement('input');
-          checkbox.type = 'checkbox';
-          checkbox.checked = Boolean(ctrl.value);
-          checkbox.dataset.sensorId = sensorId;
-
-          const slider = document.createElement('span');
-          slider.className = 'ctrl-slider';
-
-          switchLabel.appendChild(checkbox);
-          switchLabel.appendChild(slider);
-          row.appendChild(switchLabel);
-          card.appendChild(row);
-
-          let currentVal = Boolean(ctrl.value);
-          checkbox.addEventListener('change', function () {
-            const newVal = checkbox.checked;
-            sendDebugUpdate(sensorId, newVal, slider, currentVal, function (prev) {
-              checkbox.checked = prev;
-            }).then(function (ok) {
-              if (ok) currentVal = newVal;
-            });
-          });
+          card.appendChild(buildRow(sensorId, ctrl));
         });
 
         return card;
       }
 
-      // Update an existing card in-place without rebuilding DOM
+      // Update an existing card in-place
       function updateCard(card, deviceData) {
         const sensors = deviceData.sensors || {};
+        
+        // Remove stale rows
+        card.querySelectorAll('.control-row').forEach(function (row) {
+          if (!sensors[row.dataset.sensorId]) row.remove();
+        });
+
+        // Add new rows and update existing ones
         Object.entries(sensors).forEach(function ([sensorId, ctrl]) {
-          const checkbox = card.querySelector('[data-sensor-id="' + sensorId + '"]');
-          if (!checkbox) return;
-          if (document.activeElement === checkbox) return;
-          const newVal = Boolean(ctrl.value);
-          if (checkbox.checked !== newVal) checkbox.checked = newVal;
+          const row = card.querySelector('.control-row[data-sensor-id="' + sensorId + '"]');
+          if (row) {
+            const checkbox = row.querySelector('input[type="checkbox"]');
+            if (checkbox && document.activeElement !== checkbox) {
+              const newVal = Boolean(ctrl.value);
+              if (checkbox.checked !== newVal) checkbox.checked = newVal;
+            }
+          } else {
+            card.appendChild(buildRow(sensorId, ctrl));
+          }
         });
       }
 

--- a/sigenergy2mqtt/diagnostics/static/debug.html
+++ b/sigenergy2mqtt/diagnostics/static/debug.html
@@ -587,15 +587,17 @@
         row.appendChild(switchLabel);
 
         checkbox._currentVal = Boolean(ctrl.value);
-        checkbox._lastSnapshot = Date.now();
+        checkbox._reqSeq = 0;
+        checkbox._ackSeq = 0;
         checkbox.addEventListener('change', function () {
           const newVal = checkbox.checked;
-          const reqTime = Date.now();
+          const seq = ++checkbox._reqSeq;
           sendDebugUpdate(sensorId, newVal, slider, null, function () {
             checkbox.checked = checkbox._currentVal;
           }).then(function (ok) {
-            if (ok && checkbox._lastSnapshot <= reqTime) {
+            if (ok && seq > checkbox._ackSeq) {
               checkbox._currentVal = newVal;
+              checkbox._ackSeq = seq;
             }
           });
         });
@@ -643,8 +645,10 @@
             const checkbox = row.querySelector('input[type="checkbox"]');
             if (checkbox) {
               const newVal = Boolean(ctrl.value);
-              checkbox._currentVal = newVal;
-              checkbox._lastSnapshot = Date.now();
+              if (newVal !== checkbox._currentVal) {
+                checkbox._currentVal = newVal;
+                checkbox._ackSeq = checkbox._reqSeq;
+              }
               if (document.activeElement !== checkbox && checkbox.checked !== newVal) {
                 checkbox.checked = newVal;
               }

--- a/sigenergy2mqtt/diagnostics/static/debug.html
+++ b/sigenergy2mqtt/diagnostics/static/debug.html
@@ -496,16 +496,6 @@
       const filterInput = document.getElementById('filterInput');
       const filterCount = document.getElementById('filterCount');
 
-      // Server-authoritative ordering for sensor_debug_logging writes vs.
-      // snapshots. Bumped by the server on every successful debug POST;
-      // echoed in that POST's response and in every WS snapshot's
-      // "_revisions.sensor_debug_logging". A write's own value is only kept
-      // if its revision is strictly newer than the last one we've seen —
-      // this settles both completion-order races (two toggles in flight)
-      // and snapshot-vs-write races, using the server's own ordering
-      // instead of guessing from client-side timing.
-      let lastKnownRevision = 0;
-
       // Theme toggle
       themeToggle.addEventListener('click', () => {
         const isLight = document.documentElement.getAttribute('data-theme') === 'light';
@@ -569,7 +559,7 @@
         }
       }
 
-      function buildRow(sensorId, ctrl) {
+      function buildRow(sensorId, ctrl, revision) {
         const row = document.createElement('div');
         row.className = 'control-row';
         row.dataset.sensorId = sensorId;
@@ -597,6 +587,13 @@
         row.appendChild(switchLabel);
 
         checkbox._currentVal = Boolean(ctrl.value);
+        // Per-checkbox, NOT shared across sensors: the revision counter is
+        // provider-wide, so gating on a page-level "last known revision"
+        // would let one sensor's write completion fence out a different,
+        // unrelated sensor's own legitimate completion. Each checkbox only
+        // cares whether ITS OWN last-applied information (from a snapshot,
+        // or from its own prior write) is older than a write it just sent.
+        checkbox._lastKnownRevision = revision || 0;
         checkbox._pendingRequests = 0;
         checkbox.addEventListener('change', function () {
           const newVal = checkbox.checked;
@@ -605,12 +602,12 @@
             checkbox.checked = checkbox._currentVal;
           }).then(function (result) {
             // Apply only if the server says this write is newer than the last
-            // thing we've seen (another completion or a snapshot). If a
-            // snapshot already caught up to (or past) this write, trust that
-            // instead — it's already authoritative and already rendered.
-            if (result.ok && result.revision > lastKnownRevision) {
+            // thing we've seen for THIS checkbox (another completion of its
+            // own, or a snapshot). If a snapshot already caught up to (or
+            // past) this write, trust that instead.
+            if (result.ok && result.revision > checkbox._lastKnownRevision) {
               checkbox._currentVal = newVal;
-              lastKnownRevision = result.revision;
+              checkbox._lastKnownRevision = result.revision;
             }
           }).finally(function () {
             checkbox._pendingRequests--;
@@ -624,7 +621,7 @@
       }
 
       // Build a device card with one switch row per sensor
-      function buildCard(deviceId, deviceData) {
+      function buildCard(deviceId, deviceData, revision) {
         const sensors = deviceData.sensors || {};
 
         const card = document.createElement('div');
@@ -641,14 +638,14 @@
         card.appendChild(title);
 
         Object.entries(sensors).forEach(function ([sensorId, ctrl]) {
-          card.appendChild(buildRow(sensorId, ctrl));
+          card.appendChild(buildRow(sensorId, ctrl, revision));
         });
 
         return card;
       }
 
       // Update an existing card in-place
-      function updateCard(card, deviceData) {
+      function updateCard(card, deviceData, revision) {
         const sensors = deviceData.sensors || {};
 
         // Remove stale rows
@@ -664,6 +661,12 @@
             if (checkbox) {
               const newVal = Boolean(ctrl.value);
               checkbox._currentVal = newVal;
+              // This snapshot's revision genuinely confirms this sensor's
+              // value too (a snapshot is a full picture of every sensor at
+              // that revision) — safe to advance the per-checkbox baseline.
+              if (typeof revision === 'number') {
+                checkbox._lastKnownRevision = Math.max(checkbox._lastKnownRevision, revision);
+              }
 
               if (checkbox._pendingRequests === 0 && checkbox.checked !== newVal) {
                 checkbox.checked = newVal;
@@ -672,7 +675,7 @@
               // the finally() in the change handler reconciles it once they all settle
             }
           } else {
-            card.appendChild(buildRow(sensorId, ctrl));
+            card.appendChild(buildRow(sensorId, ctrl, revision));
           }
         });
       }
@@ -680,9 +683,7 @@
       // Render/update the grid from a snapshot
       function render(snapshot) {
         const revisions = snapshot._revisions || {};
-        if (typeof revisions.sensor_debug_logging === 'number') {
-          lastKnownRevision = Math.max(lastKnownRevision, revisions.sensor_debug_logging);
-        }
+        const revision = typeof revisions.sensor_debug_logging === 'number' ? revisions.sensor_debug_logging : 0;
 
         const data = snapshot.sensor_debug_logging;
         if (!data || typeof data !== 'object') return;
@@ -695,9 +696,9 @@
         deviceIds.forEach(function (deviceId) {
           const existingCard = cardGrid.querySelector('[data-device="' + CSS.escape(deviceId) + '"]');
           if (existingCard) {
-            updateCard(existingCard, data[deviceId]);
+            updateCard(existingCard, data[deviceId], revision);
           } else {
-            cardGrid.appendChild(buildCard(deviceId, data[deviceId]));
+            cardGrid.appendChild(buildCard(deviceId, data[deviceId], revision));
           }
         });
 

--- a/sigenergy2mqtt/diagnostics/static/debug.html
+++ b/sigenergy2mqtt/diagnostics/static/debug.html
@@ -589,11 +589,17 @@
         checkbox._currentVal = Boolean(ctrl.value);
         checkbox._pendingRequests = 0;
         checkbox._snapshotMissed = false;
+        checkbox._lastSnapshot = Date.now();
         checkbox.addEventListener('change', function () {
           const newVal = checkbox.checked;
+          const reqTime = Date.now();
           checkbox._pendingRequests++;
           sendDebugUpdate(sensorId, newVal, slider, null, function () {
             checkbox.checked = checkbox._currentVal;
+          }).then(function (ok) {
+            if (ok && checkbox._lastSnapshot <= reqTime) {
+              checkbox._currentVal = newVal;
+            }
           }).finally(function () {
             checkbox._pendingRequests--;
             if (checkbox._pendingRequests === 0 && checkbox._snapshotMissed) {
@@ -650,6 +656,7 @@
               const newVal = Boolean(ctrl.value);
               if (checkbox._currentVal !== newVal) {
                 checkbox._currentVal = newVal;
+                checkbox._lastSnapshot = Date.now();
                 if (checkbox._pendingRequests === 0) {
                   if (checkbox.checked !== newVal) checkbox.checked = newVal;
                 } else {

--- a/sigenergy2mqtt/diagnostics/static/debug.html
+++ b/sigenergy2mqtt/diagnostics/static/debug.html
@@ -496,6 +496,16 @@
       const filterInput = document.getElementById('filterInput');
       const filterCount = document.getElementById('filterCount');
 
+      // Server-authoritative ordering for sensor_debug_logging writes vs.
+      // snapshots. Bumped by the server on every successful debug POST;
+      // echoed in that POST's response and in every WS snapshot's
+      // "_revisions.sensor_debug_logging". A write's own value is only kept
+      // if its revision is strictly newer than the last one we've seen —
+      // this settles both completion-order races (two toggles in flight)
+      // and snapshot-vs-write races, using the server's own ordering
+      // instead of guessing from client-side timing.
+      let lastKnownRevision = 0;
+
       // Theme toggle
       themeToggle.addEventListener('click', () => {
         const isLight = document.documentElement.getAttribute('data-theme') === 'light';
@@ -545,7 +555,7 @@
             slider.classList.remove('flash-ok', 'flash-err');
             void slider.offsetWidth;
             slider.classList.add('flash-ok');
-            return true;
+            return { ok: true, revision: result.revision };
           } else {
             throw new Error(result.error || 'Update failed');
           }
@@ -555,7 +565,7 @@
           void slider.offsetWidth;
           slider.classList.add('flash-err');
           if (revertCb) revertCb(prevValue);
-          return false;
+          return { ok: false };
         }
       }
 
@@ -588,21 +598,19 @@
 
         checkbox._currentVal = Boolean(ctrl.value);
         checkbox._pendingRequests = 0;
-        checkbox._sendSeq = 0;    // counts requests sent; each request's id is its post-increment value
-        checkbox._appliedSeq = 0; // send-id boundary of the most recent authoritative update
         checkbox.addEventListener('change', function () {
           const newVal = checkbox.checked;
-          const sendId = ++checkbox._sendSeq;
           checkbox._pendingRequests++;
           sendDebugUpdate(sensorId, newVal, slider, null, function () {
             checkbox.checked = checkbox._currentVal;
-          }).then(function (ok) {
-            // Apply only if this request is newer (by send order) than whatever
-            // last set _currentVal — a later-sent write always wins over an
-            // earlier one, regardless of which completes first.
-            if (ok && sendId > checkbox._appliedSeq) {
+          }).then(function (result) {
+            // Apply only if the server says this write is newer than the last
+            // thing we've seen (another completion or a snapshot). If a
+            // snapshot already caught up to (or past) this write, trust that
+            // instead — it's already authoritative and already rendered.
+            if (result.ok && result.revision > lastKnownRevision) {
               checkbox._currentVal = newVal;
-              checkbox._appliedSeq = sendId;
+              lastKnownRevision = result.revision;
             }
           }).finally(function () {
             checkbox._pendingRequests--;
@@ -656,11 +664,6 @@
             if (checkbox) {
               const newVal = Boolean(ctrl.value);
               checkbox._currentVal = newVal;
-              // Invalidate any request sent up to now (it can no longer override this
-              // snapshot), but leave requests sent after this point still eligible.
-              if (checkbox._sendSeq > checkbox._appliedSeq) {
-                checkbox._appliedSeq = checkbox._sendSeq;
-              }
 
               if (checkbox._pendingRequests === 0 && checkbox.checked !== newVal) {
                 checkbox.checked = newVal;
@@ -676,6 +679,11 @@
 
       // Render/update the grid from a snapshot
       function render(snapshot) {
+        const revisions = snapshot._revisions || {};
+        if (typeof revisions.sensor_debug_logging === 'number') {
+          lastKnownRevision = Math.max(lastKnownRevision, revisions.sensor_debug_logging);
+        }
+
         const data = snapshot.sensor_debug_logging;
         if (!data || typeof data !== 'object') return;
 

--- a/sigenergy2mqtt/diagnostics/static/debug.html
+++ b/sigenergy2mqtt/diagnostics/static/debug.html
@@ -588,6 +588,7 @@
 
         checkbox._currentVal = Boolean(ctrl.value);
         checkbox._pendingRequests = 0;
+        checkbox._snapshotMissed = false;
         checkbox.addEventListener('change', function () {
           const newVal = checkbox.checked;
           checkbox._pendingRequests++;
@@ -595,8 +596,11 @@
             checkbox.checked = checkbox._currentVal;
           }).finally(function () {
             checkbox._pendingRequests--;
-            if (checkbox._pendingRequests === 0 && checkbox.checked !== checkbox._currentVal) {
-              checkbox.checked = checkbox._currentVal;
+            if (checkbox._pendingRequests === 0 && checkbox._snapshotMissed) {
+              checkbox._snapshotMissed = false;
+              if (checkbox.checked !== checkbox._currentVal) {
+                checkbox.checked = checkbox._currentVal;
+              }
             }
           });
         });
@@ -645,8 +649,10 @@
             if (checkbox) {
               const newVal = Boolean(ctrl.value);
               checkbox._currentVal = newVal;
-              if (checkbox._pendingRequests === 0 && checkbox.checked !== newVal) {
-                checkbox.checked = newVal;
+              if (checkbox._pendingRequests === 0) {
+                if (checkbox.checked !== newVal) checkbox.checked = newVal;
+              } else {
+                checkbox._snapshotMissed = true;
               }
             }
           } else {

--- a/sigenergy2mqtt/diagnostics/static/debug.html
+++ b/sigenergy2mqtt/diagnostics/static/debug.html
@@ -589,9 +589,8 @@
         checkbox._currentVal = Boolean(ctrl.value);
         checkbox.addEventListener('change', function () {
           const newVal = checkbox.checked;
-          const currentVal = checkbox._currentVal;
-          sendDebugUpdate(sensorId, newVal, slider, currentVal, function (prev) {
-            checkbox.checked = prev;
+          sendDebugUpdate(sensorId, newVal, slider, null, function () {
+            checkbox.checked = checkbox._currentVal;
           }).then(function (ok) {
             if (ok) checkbox._currentVal = newVal;
           });
@@ -638,10 +637,12 @@
           const row = card.querySelector('.control-row[data-sensor-id="' + CSS.escape(sensorId) + '"]');
           if (row) {
             const checkbox = row.querySelector('input[type="checkbox"]');
-            if (checkbox && document.activeElement !== checkbox) {
+            if (checkbox) {
               const newVal = Boolean(ctrl.value);
               checkbox._currentVal = newVal;
-              if (checkbox.checked !== newVal) checkbox.checked = newVal;
+              if (document.activeElement !== checkbox) {
+                if (checkbox.checked !== newVal) checkbox.checked = newVal;
+              }
             }
           } else {
             card.appendChild(buildRow(sensorId, ctrl));

--- a/sigenergy2mqtt/diagnostics/static/debug.html
+++ b/sigenergy2mqtt/diagnostics/static/debug.html
@@ -586,13 +586,14 @@
         switchLabel.appendChild(slider);
         row.appendChild(switchLabel);
 
-        let currentVal = Boolean(ctrl.value);
+        checkbox._currentVal = Boolean(ctrl.value);
         checkbox.addEventListener('change', function () {
           const newVal = checkbox.checked;
+          const currentVal = checkbox._currentVal;
           sendDebugUpdate(sensorId, newVal, slider, currentVal, function (prev) {
             checkbox.checked = prev;
           }).then(function (ok) {
-            if (ok) currentVal = newVal;
+            if (ok) checkbox._currentVal = newVal;
           });
         });
 
@@ -639,6 +640,7 @@
             const checkbox = row.querySelector('input[type="checkbox"]');
             if (checkbox && document.activeElement !== checkbox) {
               const newVal = Boolean(ctrl.value);
+              checkbox._currentVal = newVal;
               if (checkbox.checked !== newVal) checkbox.checked = newVal;
             }
           } else {

--- a/sigenergy2mqtt/diagnostics/static/debug.html
+++ b/sigenergy2mqtt/diagnostics/static/debug.html
@@ -659,9 +659,11 @@
             const checkbox = row.querySelector('input[type="checkbox"]');
             if (checkbox) {
               const newVal = Boolean(ctrl.value);
-              if (checkbox._currentVal !== newVal) {
+              const valueChanged = checkbox._currentVal !== newVal;
+
+              if (valueChanged || checkbox._pendingRequests > 0) {
                 checkbox._currentVal = newVal;
-                
+
                 if (checkbox._pendingValues && checkbox._pendingValues.length > 0) {
                   const idx = checkbox._pendingValues.indexOf(newVal);
                   if (idx !== -1) {

--- a/sigenergy2mqtt/diagnostics/static/debug.html
+++ b/sigenergy2mqtt/diagnostics/static/debug.html
@@ -588,19 +588,21 @@
 
         checkbox._currentVal = Boolean(ctrl.value);
         checkbox._pendingRequests = 0;
-        checkbox._seq = 0; // bumps on every applied authoritative update (snapshot or confirmed write)
+        checkbox._sendSeq = 0;    // counts requests sent; each request's id is its post-increment value
+        checkbox._appliedSeq = 0; // send-id boundary of the most recent authoritative update
         checkbox.addEventListener('change', function () {
           const newVal = checkbox.checked;
-          const seqAtSend = checkbox._seq;
+          const sendId = ++checkbox._sendSeq;
           checkbox._pendingRequests++;
           sendDebugUpdate(sensorId, newVal, slider, null, function () {
             checkbox.checked = checkbox._currentVal;
           }).then(function (ok) {
-            // Only apply if nothing newer (a snapshot, or another completed write)
-            // has landed since this request was sent.
-            if (ok && checkbox._seq === seqAtSend) {
+            // Apply only if this request is newer (by send order) than whatever
+            // last set _currentVal — a later-sent write always wins over an
+            // earlier one, regardless of which completes first.
+            if (ok && sendId > checkbox._appliedSeq) {
               checkbox._currentVal = newVal;
-              checkbox._seq++;
+              checkbox._appliedSeq = sendId;
             }
           }).finally(function () {
             checkbox._pendingRequests--;
@@ -654,7 +656,11 @@
             if (checkbox) {
               const newVal = Boolean(ctrl.value);
               checkbox._currentVal = newVal;
-              checkbox._seq++; // every snapshot is authoritative, whether or not the value changed
+              // Invalidate any request sent up to now (it can no longer override this
+              // snapshot), but leave requests sent after this point still eligible.
+              if (checkbox._sendSeq > checkbox._appliedSeq) {
+                checkbox._appliedSeq = checkbox._sendSeq;
+              }
 
               if (checkbox._pendingRequests === 0 && checkbox.checked !== newVal) {
                 checkbox.checked = newVal;

--- a/sigenergy2mqtt/diagnostics/static/debug.html
+++ b/sigenergy2mqtt/diagnostics/static/debug.html
@@ -590,10 +590,12 @@
         checkbox._pendingRequests = 0;
         checkbox._snapshotMissed = false;
         checkbox._lastSnapshot = Date.now();
+        checkbox._pendingValues = [];
         checkbox.addEventListener('change', function () {
           const newVal = checkbox.checked;
           const reqTime = Date.now();
           checkbox._pendingRequests++;
+          checkbox._pendingValues.push(newVal);
           sendDebugUpdate(sensorId, newVal, slider, null, function () {
             checkbox.checked = checkbox._currentVal;
           }).then(function (ok) {
@@ -602,10 +604,13 @@
             }
           }).finally(function () {
             checkbox._pendingRequests--;
-            if (checkbox._pendingRequests === 0 && checkbox._snapshotMissed) {
-              checkbox._snapshotMissed = false;
-              if (checkbox.checked !== checkbox._currentVal) {
-                checkbox.checked = checkbox._currentVal;
+            if (checkbox._pendingRequests === 0) {
+              checkbox._pendingValues.length = 0;
+              if (checkbox._snapshotMissed) {
+                checkbox._snapshotMissed = false;
+                if (checkbox.checked !== checkbox._currentVal) {
+                  checkbox.checked = checkbox._currentVal;
+                }
               }
             }
           });
@@ -656,7 +661,19 @@
               const newVal = Boolean(ctrl.value);
               if (checkbox._currentVal !== newVal) {
                 checkbox._currentVal = newVal;
-                checkbox._lastSnapshot = Date.now();
+                
+                if (checkbox._pendingValues && checkbox._pendingValues.length > 0) {
+                  const idx = checkbox._pendingValues.indexOf(newVal);
+                  if (idx !== -1) {
+                    checkbox._pendingValues.splice(0, idx + 1);
+                  } else {
+                    checkbox._pendingValues.length = 0;
+                    checkbox._lastSnapshot = Date.now();
+                  }
+                } else {
+                  checkbox._lastSnapshot = Date.now();
+                }
+
                 if (checkbox._pendingRequests === 0) {
                   if (checkbox.checked !== newVal) checkbox.checked = newVal;
                 } else {

--- a/sigenergy2mqtt/diagnostics/static/debug.html
+++ b/sigenergy2mqtt/diagnostics/static/debug.html
@@ -648,11 +648,13 @@
             const checkbox = row.querySelector('input[type="checkbox"]');
             if (checkbox) {
               const newVal = Boolean(ctrl.value);
-              checkbox._currentVal = newVal;
-              if (checkbox._pendingRequests === 0) {
-                if (checkbox.checked !== newVal) checkbox.checked = newVal;
-              } else {
-                checkbox._snapshotMissed = true;
+              if (checkbox._currentVal !== newVal) {
+                checkbox._currentVal = newVal;
+                if (checkbox._pendingRequests === 0) {
+                  if (checkbox.checked !== newVal) checkbox.checked = newVal;
+                } else {
+                  checkbox._snapshotMissed = true;
+                }
               }
             }
           } else {

--- a/sigenergy2mqtt/diagnostics/static/diagnostics.html
+++ b/sigenergy2mqtt/diagnostics/static/diagnostics.html
@@ -684,13 +684,6 @@
       const connLabel = document.getElementById('connLabel');
       const themeToggle = document.getElementById('themeToggle');
 
-      // Server-authoritative ordering for runtime_configuration writes vs.
-      // snapshots — same purpose and mechanism as the equivalent counter on
-      // the debug-logging page. Bumped by the server on every successful
-      // config POST; echoed in that POST's response and in every WS
-      // snapshot's "_revisions.runtime_configuration".
-      let lastKnownConfigRevision = 0;
-
       themeToggle.addEventListener('click', () => {
         const isLight = document.documentElement.getAttribute('data-theme') === 'light';
         const next = isLight ? 'dark' : 'light';
@@ -810,7 +803,7 @@
       // Renders one provider's dict as a card. Nested dicts (e.g. per-client
       // connection maps) get flattened one level with a "group.key" label so
       // any future provider "just works" without UI changes.
-      function buildCard(name, data) {
+      function buildCard(name, data, revision) {
         const card = document.createElement('div');
         card.className = 'card';
 
@@ -889,7 +882,7 @@
           card.appendChild(notice);
 
           const controlsContainer = document.createElement('div');
-          buildControls(data.controls, controlsContainer);
+          buildControls(data.controls, controlsContainer, revision);
           card.appendChild(controlsContainer);
         }
 
@@ -947,7 +940,7 @@
         }
       }
 
-      function buildControls(controls, container) {
+      function buildControls(controls, container, revision) {
         Object.entries(controls).forEach(([endpoint, ctrl]) => {
           const row = document.createElement('div');
           row.className = 'control-row';
@@ -968,6 +961,12 @@
             select.className = 'ctrl-select';
             select.dataset.endpoint = endpoint;
             select._currentVal = ctrl.value;
+            // Per-widget, NOT shared across controls: the revision counter is
+            // provider-wide (covers every runtime_configuration endpoint), so
+            // gating on a page-level "last known revision" would let one
+            // control's write completion fence out a different, unrelated
+            // control's own legitimate completion.
+            select._lastKnownRevision = revision || 0;
 
             (ctrl.options || []).forEach(opt => {
               const optionEl = document.createElement('option');
@@ -983,9 +982,9 @@
               sendConfigUpdate(endpoint, newVal, select, prevVal, (prev) => {
                 select.value = prev;
               }).then(result => {
-                if (result.ok && result.revision > lastKnownConfigRevision) {
+                if (result.ok && result.revision > select._lastKnownRevision) {
                   select._currentVal = newVal;
-                  lastKnownConfigRevision = result.revision;
+                  select._lastKnownRevision = result.revision;
                 }
               });
             });
@@ -1001,6 +1000,7 @@
             if (ctrl.max !== undefined && ctrl.max !== null) input.max = ctrl.max;
 
             input._currentVal = ctrl.value;
+            input._lastKnownRevision = revision || 0;
             const trySend = (val) => {
               const num = parseFloat(val);
               if (!isNaN(num) && num !== input._currentVal) {
@@ -1008,9 +1008,9 @@
                 sendConfigUpdate(endpoint, num, input, prevVal, (prev) => {
                   input.value = prev;
                 }).then(result => {
-                  if (result.ok && result.revision > lastKnownConfigRevision) {
+                  if (result.ok && result.revision > input._lastKnownRevision) {
                     input._currentVal = num;
-                    lastKnownConfigRevision = result.revision;
+                    input._lastKnownRevision = result.revision;
                   }
                 });
               }
@@ -1044,15 +1044,16 @@
             labelEl.appendChild(slider);
 
             checkbox._currentVal = Boolean(ctrl.value);
+            checkbox._lastKnownRevision = revision || 0;
             checkbox.addEventListener('change', () => {
               const newVal = checkbox.checked;
               const prevVal = checkbox._currentVal;
               sendConfigUpdate(endpoint, newVal, slider, prevVal, (prev) => {
                 checkbox.checked = prev;
               }).then(result => {
-                if (result.ok && result.revision > lastKnownConfigRevision) {
+                if (result.ok && result.revision > checkbox._lastKnownRevision) {
                   checkbox._currentVal = newVal;
-                  lastKnownConfigRevision = result.revision;
+                  checkbox._lastKnownRevision = result.revision;
                 }
               });
             });
@@ -1070,18 +1071,24 @@
         });
       }
 
-      function updateControlsCard(card, controls) {
+      function updateControlsCard(card, controls, revision) {
         Object.entries(controls).forEach(([endpoint, ctrl]) => {
           const widget = card.querySelector(`[data-endpoint="${endpoint}"]`);
           if (!widget) return;
 
           // Keep the tracked "confirmed" value current regardless of focus —
           // it's what a future revert or write-completion compares against,
-          // not what's currently displayed.
+          // not what's currently displayed. Same for the revision baseline:
+          // this snapshot's revision genuinely confirms this control's value
+          // too (a snapshot is a full picture of every control at that
+          // revision), so it's safe to advance.
           if (ctrl.type === 'switch') {
             widget._currentVal = Boolean(ctrl.value);
           } else {
             widget._currentVal = ctrl.value;
+          }
+          if (typeof revision === 'number') {
+            widget._lastKnownRevision = Math.max(widget._lastKnownRevision || 0, revision);
           }
 
           if (document.activeElement === widget || widget.contains(document.activeElement)) return;
@@ -1119,9 +1126,7 @@
 
       function render(snapshot) {
         const revisions = snapshot._revisions || {};
-        if (typeof revisions.runtime_configuration === 'number') {
-          lastKnownConfigRevision = Math.max(lastKnownConfigRevision, revisions.runtime_configuration);
-        }
+        const configRevision = typeof revisions.runtime_configuration === 'number' ? revisions.runtime_configuration : 0;
 
         const monitor = snapshot.monitor || {};
         const status = monitor.status || 'unknown';
@@ -1143,13 +1148,13 @@
           const existingCard = cardGrid.querySelector(`[data-provider="${key}"]`);
           const data = snapshot[key];
           if (key === 'runtime_configuration' && existingCard && data && data.controls) {
-            updateControlsCard(existingCard, data.controls);
+            updateControlsCard(existingCard, data.controls, configRevision);
           } else if (existingCard) {
-            const newCard = buildCard(key, data);
+            const newCard = buildCard(key, data, configRevision);
             newCard.dataset.provider = key;
             cardGrid.replaceChild(newCard, existingCard);
           } else {
-            const newCard = buildCard(key, data);
+            const newCard = buildCard(key, data, configRevision);
             newCard.dataset.provider = key;
             cardGrid.appendChild(newCard);
           }

--- a/sigenergy2mqtt/diagnostics/static/diagnostics.html
+++ b/sigenergy2mqtt/diagnostics/static/diagnostics.html
@@ -644,6 +644,7 @@
       <span class="conn-pill" id="connPill"><span class="conn-dot"></span><span id="connLabel">Connecting…</span></span>
       <a class="btn" href="export" download>⬇ Export JSON</a>
       <a class="btn" href="solar">☀ Solar &amp; Battery</a>
+      <a class="btn" href="debug">🐛 Debug Logging</a>
       <button class="theme-toggle" id="themeToggle" type="button" aria-label="Toggle light/dark theme"
         title="Toggle theme">
         <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
@@ -1093,7 +1094,7 @@
       // Both dashboards still read from the same /diagnostics/ws feed and
       // the provider's data still appears in /diagnostics/export — this only
       // hides it from this page's auto-generated grid.
-      const DEDICATED_PAGE_PROVIDERS = new Set(['solar']);
+      const DEDICATED_PAGE_PROVIDERS = new Set(['solar', 'sensor_debug_logging']);
 
       function render(snapshot) {
         const monitor = snapshot.monitor || {};

--- a/sigenergy2mqtt/diagnostics/static/diagnostics.html
+++ b/sigenergy2mqtt/diagnostics/static/diagnostics.html
@@ -684,6 +684,13 @@
       const connLabel = document.getElementById('connLabel');
       const themeToggle = document.getElementById('themeToggle');
 
+      // Server-authoritative ordering for runtime_configuration writes vs.
+      // snapshots — same purpose and mechanism as the equivalent counter on
+      // the debug-logging page. Bumped by the server on every successful
+      // config POST; echoed in that POST's response and in every WS
+      // snapshot's "_revisions.runtime_configuration".
+      let lastKnownConfigRevision = 0;
+
       themeToggle.addEventListener('click', () => {
         const isLight = document.documentElement.getAttribute('data-theme') === 'light';
         const next = isLight ? 'dark' : 'light';
@@ -926,7 +933,7 @@
             flashEl.classList.remove('flash-ok', 'flash-err');
             void flashEl.offsetWidth;
             flashEl.classList.add('flash-ok');
-            return true;
+            return { ok: true, revision: result.revision };
           } else {
             throw new Error(result.error || 'Update failed');
           }
@@ -936,7 +943,7 @@
           void flashEl.offsetWidth;
           flashEl.classList.add('flash-err');
           if (revertCb) revertCb(prevValue);
-          return false;
+          return { ok: false };
         }
       }
 
@@ -960,22 +967,26 @@
             const select = document.createElement('select');
             select.className = 'ctrl-select';
             select.dataset.endpoint = endpoint;
-            let currentVal = ctrl.value;
+            select._currentVal = ctrl.value;
 
             (ctrl.options || []).forEach(opt => {
               const optionEl = document.createElement('option');
               optionEl.value = opt;
               optionEl.textContent = opt;
-              if (opt === currentVal) optionEl.selected = true;
+              if (opt === select._currentVal) optionEl.selected = true;
               select.appendChild(optionEl);
             });
 
             select.addEventListener('change', () => {
               const newVal = select.value;
-              sendConfigUpdate(endpoint, newVal, select, currentVal, (prev) => {
+              const prevVal = select._currentVal;
+              sendConfigUpdate(endpoint, newVal, select, prevVal, (prev) => {
                 select.value = prev;
-              }).then(ok => {
-                if (ok) currentVal = newVal;
+              }).then(result => {
+                if (result.ok && result.revision > lastKnownConfigRevision) {
+                  select._currentVal = newVal;
+                  lastKnownConfigRevision = result.revision;
+                }
               });
             });
 
@@ -989,29 +1000,25 @@
             if (ctrl.min !== undefined && ctrl.min !== null) input.min = ctrl.min;
             if (ctrl.max !== undefined && ctrl.max !== null) input.max = ctrl.max;
 
-            let currentVal = ctrl.value;
-            const debouncedSend = debounce((val) => {
+            input._currentVal = ctrl.value;
+            const trySend = (val) => {
               const num = parseFloat(val);
-              if (!isNaN(num) && num !== currentVal) {
-                sendConfigUpdate(endpoint, num, input, currentVal, (prev) => {
+              if (!isNaN(num) && num !== input._currentVal) {
+                const prevVal = input._currentVal;
+                sendConfigUpdate(endpoint, num, input, prevVal, (prev) => {
                   input.value = prev;
-                }).then(ok => {
-                  if (ok) currentVal = num;
+                }).then(result => {
+                  if (result.ok && result.revision > lastKnownConfigRevision) {
+                    input._currentVal = num;
+                    lastKnownConfigRevision = result.revision;
+                  }
                 });
               }
-            }, 500);
+            };
+            const debouncedSend = debounce(trySend, 500);
 
             input.addEventListener('input', (e) => debouncedSend(e.target.value));
-            input.addEventListener('change', (e) => {
-              const num = parseFloat(e.target.value);
-              if (!isNaN(num) && num !== currentVal) {
-                sendConfigUpdate(endpoint, num, input, currentVal, (prev) => {
-                  input.value = prev;
-                }).then(ok => {
-                  if (ok) currentVal = num;
-                });
-              }
-            });
+            input.addEventListener('change', (e) => trySend(e.target.value));
 
             widgetWrap.appendChild(input);
 
@@ -1036,13 +1043,17 @@
             labelEl.appendChild(checkbox);
             labelEl.appendChild(slider);
 
-            let currentVal = Boolean(ctrl.value);
+            checkbox._currentVal = Boolean(ctrl.value);
             checkbox.addEventListener('change', () => {
               const newVal = checkbox.checked;
-              sendConfigUpdate(endpoint, newVal, slider, currentVal, (prev) => {
+              const prevVal = checkbox._currentVal;
+              sendConfigUpdate(endpoint, newVal, slider, prevVal, (prev) => {
                 checkbox.checked = prev;
-              }).then(ok => {
-                if (ok) currentVal = newVal;
+              }).then(result => {
+                if (result.ok && result.revision > lastKnownConfigRevision) {
+                  checkbox._currentVal = newVal;
+                  lastKnownConfigRevision = result.revision;
+                }
               });
             });
 
@@ -1063,6 +1074,16 @@
         Object.entries(controls).forEach(([endpoint, ctrl]) => {
           const widget = card.querySelector(`[data-endpoint="${endpoint}"]`);
           if (!widget) return;
+
+          // Keep the tracked "confirmed" value current regardless of focus —
+          // it's what a future revert or write-completion compares against,
+          // not what's currently displayed.
+          if (ctrl.type === 'switch') {
+            widget._currentVal = Boolean(ctrl.value);
+          } else {
+            widget._currentVal = ctrl.value;
+          }
+
           if (document.activeElement === widget || widget.contains(document.activeElement)) return;
 
           if (ctrl.type === 'select') {
@@ -1097,6 +1118,11 @@
       const DEDICATED_PAGE_PROVIDERS = new Set(['solar', 'sensor_debug_logging']);
 
       function render(snapshot) {
+        const revisions = snapshot._revisions || {};
+        if (typeof revisions.runtime_configuration === 'number') {
+          lastKnownConfigRevision = Math.max(lastKnownConfigRevision, revisions.runtime_configuration);
+        }
+
         const monitor = snapshot.monitor || {};
         const status = monitor.status || 'unknown';
         statusBanner.className = 'status-banner ' + (status === 'healthy' ? 'healthy' : status === 'degraded' ? 'degraded' : 'unknown');
@@ -1104,7 +1130,7 @@
         const ts = snapshot.timestamp ? new Date(snapshot.timestamp * 1000).toLocaleString() : '—';
         statusMeta.textContent = `last updated ${ts}`;
 
-        const keys = Object.keys(snapshot).filter(k => k !== 'timestamp' && !DEDICATED_PAGE_PROVIDERS.has(k));
+        const keys = Object.keys(snapshot).filter(k => k !== 'timestamp' && k !== '_revisions' && !DEDICATED_PAGE_PROVIDERS.has(k));
         if (keys.length === 0) {
           cardGrid.innerHTML = '<div class="empty-state">No diagnostics providers registered.</div>';
           return;


### PR DESCRIPTION
# Expose `debug_logging` Toggle via Diagnostics Web Server

Sensors already support toggling debug_logging at runtime via an MQTT topic (`<base_topic>/debug`), handled by 
`sensor.set_debug_logging()` and subscribed in `device.subscribe()`.

The diagnostics web server already has a precedent for dedicated sub-pages: 
`/diagnostics/solar`  is a standalone HTML file served at a separate route but reads from the same `/diagnostics/ws` WebSocket feed and `/diagnostics/static/` assets as the main page.

This PR follows that same pattern: a new `/diagnostics/debug` page, served from a new `debug.html` static file, with one card per device, where each card contains a switch row per sensor. A new `POST /diagnostics/debug/{sensor_unique_id}` endpoint delegates to `sensor.set_debug_logging()`, and the WebSocket feed is extended with a `sensor_debug_logging` provider so the page reflects changes made via MQTT as well.

## Changes Made

- **`diagnostics/collectors.py`**: Added a new `_diagnostics_collect_sensor_debug` classmethod to `DiagnosticsCollectors` and registered it under `"sensor_debug_logging"`. This provider iterates all active devices and emits switch control descriptors for each sensor's `debug_logging` property, grouped by device.
- **`diagnostics/server.py`**: Added two new routes to `DiagnosticsServer`:
  - `GET /diagnostics/debug`: Serves the new debug logging dashboard.
  - `POST /diagnostics/debug/{sensor_id}`: Handles updates. This parses a boolean value from the request body, searches for the matching sensor, and calls its `set_debug_logging()` method.
- **`diagnostics/static/debug.html`**: Created a new standalone HTML page styled consistently with the main dashboard. It subscribes to the shared `/diagnostics/ws` WebSocket feed, renders one card per device, and creates a switch row for each sensor to reflect and control its `debug_logging` state. Includes a live text filter and transient-notice warning.
- **`diagnostics/static/diagnostics.html`**: Excluded the `"sensor_debug_logging"` provider from the main auto-generated grid by adding it to `DEDICATED_PAGE_PROVIDERS`, and added a new "🐛 Debug Logging" navigation link to the header.

## Verification

- Running the full pytest test suite using `-n auto` passed successfully without regressions.
- The new frontend correctly handles grouping, toggle updating, and URL routing using the same relative-URL strategy used for the `solar` dashboard.
