### PR TITLE
Derived Sensor Value Consumption & Stale Discard Refactoring

### DIFF
--- a/sigenergy2mqtt/sensors/inverter_derived.py
+++ b/sigenergy2mqtt/sensors/inverter_derived.py
@@ -100,15 +100,17 @@ class PVStringPower(DerivedSensor, HybridInverter, PVInverter):
         divisor: float
         value: float | None = None
         timestamp: float = 0
+        consumed: bool = True
         owner: PVStringPower | None = field(default=None, compare=False, repr=False)
 
         def apply(self, sensor: Sensor) -> None:
-            if self.owner is not None:
+            if self.owner is not None and not self.consumed:
                 self.owner._log_unconsumed_source_value(self.name, self.value, self.timestamp, sensor)
             raw = sensor.latest_raw_state
             if raw is None:
                 return
             self.value = float(raw) / self.divisor
+            self.consumed = False
             source_timestamp = self.owner._source_timestamp(sensor) if self.owner is not None else sensor.latest_time
             self.timestamp = source_timestamp if source_timestamp is not None else 0
 
@@ -172,6 +174,8 @@ class PVStringPower(DerivedSensor, HybridInverter, PVInverter):
         if self.volts.value is None or self.amperes.value is None:
             return False  # until all values populated, can't do calculation
         state = self.volts.value * self.amperes.value
+        self.volts.consumed = True
+        self.amperes.consumed = True
         if self.debug_logging:
             logger.debug(f"{self.log_identity} source values populated - setting latest state ({self.amperes.value}A * {self.volts.value}V = {state}W)")
         self.set_latest_state(state)
@@ -243,6 +247,7 @@ class InverterSelfConsumedPower(DerivedSensor, HybridInverter, PVInverter):
         self.pv_string_power: dict[int, int | None] = {p.string_number: None for p in pv_string_power}
         self._source_timestamps: dict[str, float | None] = {"active_power": None, "battery_power": None, **{f"pv_string_power_{p.string_number}": None for p in pv_string_power}}
         self._source_sensors: dict[str, Sensor] = {"active_power": active_power, "battery_power": battery_power, **{f"pv_string_power_{p.string_number}": p for p in pv_string_power}}
+        self._source_consumed: dict[str, bool] = {"active_power": True, "battery_power": True, **{f"pv_string_power_{p.string_number}": True for p in pv_string_power}}
         self._incomplete_snapshot_logged = False
 
         self.sanity_check.min_raw = 0  # Watts
@@ -270,6 +275,8 @@ class InverterSelfConsumedPower(DerivedSensor, HybridInverter, PVInverter):
             self.battery_power = None
             self.pv_string_power = {p: None for p in self.pv_string_power}
             self._source_timestamps = {name: None for name in self._source_timestamps}
+            for name in self._source_consumed:
+                self._source_consumed[name] = True
             self._incomplete_snapshot_logged = False
         return bool(published)
 
@@ -278,18 +285,24 @@ class InverterSelfConsumedPower(DerivedSensor, HybridInverter, PVInverter):
             return False
         self._discard_stale_snapshot()
         if isinstance(sensor, ActivePower):
-            self._log_unconsumed_source_value("active_power", self.active_power, self._source_timestamps["active_power"], sensor)
+            if not self._source_consumed["active_power"]:
+                self._log_unconsumed_source_value("active_power", self.active_power, self._source_timestamps["active_power"], sensor)
             self.active_power = int(sensor.latest_raw_state)
             self._source_timestamps["active_power"] = self._source_timestamp(sensor)
+            self._source_consumed["active_power"] = False
         elif isinstance(sensor, ChargeDischargePower):
-            self._log_unconsumed_source_value("battery_power", self.battery_power, self._source_timestamps["battery_power"], sensor)
+            if not self._source_consumed["battery_power"]:
+                self._log_unconsumed_source_value("battery_power", self.battery_power, self._source_timestamps["battery_power"], sensor)
             self.battery_power = int(sensor.latest_raw_state)
             self._source_timestamps["battery_power"] = self._source_timestamp(sensor)
+            self._source_consumed["battery_power"] = False
         elif isinstance(sensor, PVStringPower):
             source_name = f"pv_string_power_{sensor.string_number}"
-            self._log_unconsumed_source_value(source_name, self.pv_string_power[sensor.string_number], self._source_timestamps[source_name], sensor)
+            if not self._source_consumed[source_name]:
+                self._log_unconsumed_source_value(source_name, self.pv_string_power[sensor.string_number], self._source_timestamps[source_name], sensor)
             self.pv_string_power[sensor.string_number] = int(sensor.latest_raw_state)
             self._source_timestamps[source_name] = self._source_timestamp(sensor)
+            self._source_consumed[source_name] = False
         else:
             logger.warning(f"{self.log_identity} Attempt to call update_from_source_sensor from {sensor.log_identity}")
             return False
@@ -314,6 +327,11 @@ class InverterSelfConsumedPower(DerivedSensor, HybridInverter, PVInverter):
         except SanityCheckException as e:
             if self.debug_logging:
                 logger.debug(f"{self.log_identity} set_latest_state({state}) FAILED - {e}")
+
+        # Mark all source values as consumed by this calculation
+        for name in self._source_consumed:
+            self._source_consumed[name] = True
+
         return True
 
     def _discard_stale_snapshot(self) -> None:
@@ -321,7 +339,7 @@ class InverterSelfConsumedPower(DerivedSensor, HybridInverter, PVInverter):
         now = time.time()
         stale_sources = {}
         for source_name, value in self._source_timestamps.items():
-            if value is None:
+            if value is None or self._source_consumed.get(source_name, True):
                 continue
             source_sensor = self._source_sensors.get(source_name)
             expected_interval = self._source_expected_interval(source_sensor) if source_sensor is not None else None
@@ -337,8 +355,6 @@ class InverterSelfConsumedPower(DerivedSensor, HybridInverter, PVInverter):
                         cached_val = self.pv_string_power.get(string_number)
                     except ValueError:
                         pass
-                if cached_val == 0: # A zero value contributes nothing, so ignore stale zero values
-                    continue
                 stale_sources[source_name] = cached_val
 
         if not stale_sources:
@@ -349,4 +365,6 @@ class InverterSelfConsumedPower(DerivedSensor, HybridInverter, PVInverter):
         self.battery_power = None
         self.pv_string_power = {string_number: None for string_number in self.pv_string_power}
         self._source_timestamps = {name: None for name in self._source_timestamps}
+        for name in self._source_consumed:
+            self._source_consumed[name] = True
         self._incomplete_snapshot_logged = False

--- a/sigenergy2mqtt/sensors/inverter_derived.py
+++ b/sigenergy2mqtt/sensors/inverter_derived.py
@@ -324,13 +324,19 @@ class InverterSelfConsumedPower(DerivedSensor, HybridInverter, PVInverter):
             state = 0
         try:
             self.set_latest_state(state)
+            for name in self._source_consumed:
+                self._source_consumed[name] = True
         except SanityCheckException as e:
             if self.debug_logging:
                 logger.debug(f"{self.log_identity} set_latest_state({state}) FAILED - {e}")
-
-        # Mark all source values as consumed by this calculation
-        for name in self._source_consumed:
-            self._source_consumed[name] = True
+            # Discard bad snapshot so rejected/insane readings are not retained or reused
+            self.active_power = None
+            self.battery_power = None
+            self.pv_string_power = {string_number: None for string_number in self.pv_string_power}
+            self._source_timestamps = {name: None for name in self._source_timestamps}
+            for name in self._source_consumed:
+                self._source_consumed[name] = True
+            self._incomplete_snapshot_logged = False
 
         return True
 

--- a/sigenergy2mqtt/sensors/inverter_derived.py
+++ b/sigenergy2mqtt/sensors/inverter_derived.py
@@ -174,11 +174,19 @@ class PVStringPower(DerivedSensor, HybridInverter, PVInverter):
         if self.volts.value is None or self.amperes.value is None:
             return False  # until all values populated, can't do calculation
         state = self.volts.value * self.amperes.value
-        self.volts.consumed = True
-        self.amperes.consumed = True
         if self.debug_logging:
             logger.debug(f"{self.log_identity} source values populated - setting latest state ({self.amperes.value}A * {self.volts.value}V = {state}W)")
-        self.set_latest_state(state)
+        try:
+            self.set_latest_state(state)
+            self.volts.consumed = True
+            self.amperes.consumed = True
+        except SanityCheckException as e:
+            if self.debug_logging:
+                logger.debug(f"{self.log_identity} set_latest_state({state}) FAILED - {e}")
+            self.volts.value = None
+            self.amperes.value = None
+            self.volts.consumed = True
+            self.amperes.consumed = True
         return True
 
 

--- a/tests/unit/sensors/test_inverter_derived_edge_cases.py
+++ b/tests/unit/sensors/test_inverter_derived_edge_cases.py
@@ -240,6 +240,29 @@ class TestPVStringPowerUpdateFromSourceSensor:
                 debug_calls = [str(c) for c in mock_log.debug.call_args_list]
                 assert any("source values populated" in c for c in debug_calls)
 
+    def test_sanity_check_exception_clears_volts_and_amperes(self):
+        """SanityCheckException in PVStringPower resets volts and amperes values to None."""
+        with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
+            sensor = _make_pv_string_power()
+            v_source = MagicMock(spec=PVVoltageSensor)
+            v_source.latest_raw_state = 4000
+            v_source.latest_time = time.time()
+            sensor.update_from_source_sensor(v_source)
+
+            c_source = MagicMock(spec=PVCurrentSensor)
+            c_source.latest_raw_state = 1000
+            c_source.latest_time = time.time()
+
+            from sigenergy2mqtt.sensors.base import SanityCheckException
+
+            with patch.object(sensor, "set_latest_state", side_effect=SanityCheckException("test sanity check")):
+                result = sensor.update_from_source_sensor(c_source)
+                assert result is True
+                assert sensor.volts.value is None
+                assert sensor.amperes.value is None
+                assert sensor.volts.consumed is True
+                assert sensor.amperes.consumed is True
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # InverterSelfConsumedPower.update_from_source_sensor (lines 264, 281-288)

--- a/tests/unit/sensors/test_inverter_derived_edge_cases.py
+++ b/tests/unit/sensors/test_inverter_derived_edge_cases.py
@@ -123,6 +123,7 @@ class TestPVStringPowerValueApply:
         sensor = _make_pv_string_power()
         v = PVStringPower.Value(name="test_value", divisor=1.0, owner=sensor)
         v.value = 100.0  # Already has a value
+        v.consumed = False
         v.timestamp = time.time()
 
         mock_sensor = MagicMock(spec=Sensor)
@@ -327,3 +328,120 @@ class TestInverterSelfConsumedPowerEdgeCases:
                 assert result is True  # Returns True even when SanityCheckException is caught
                 debug_calls = [str(c) for c in mock_log.debug.call_args_list]
                 assert any("FAILED" in c for c in debug_calls)
+
+    def test_repeated_overnight_zero_reads_no_warnings(self, caplog):
+        """Repeated zero reads across multiple scan cycles log zero unconsumed or stale warnings."""
+        caplog.set_level(logging.WARNING)
+        with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
+            ap = MagicMock(spec=ActivePower)
+            ap.protocol_version = ProtocolVersion.V2_4
+            bp = MagicMock(spec=ChargeDischargePower)
+            bp.protocol_version = ProtocolVersion.V2_4
+            pv1 = MagicMock(spec=PVStringPower)
+            pv1.string_number = 1
+            pv1.protocol_version = ProtocolVersion.V2_4
+
+            sensor = InverterSelfConsumedPower(0, 1, ap, bp, pv1)
+
+            # Cycle 1: zero reads arrive from all sources
+            ap.latest_raw_state = 0
+            bp.latest_raw_state = 0
+            pv1.latest_raw_state = 0
+
+            with patch("sigenergy2mqtt.sensors.inverter_derived.logger") as mock_log:
+                sensor.update_from_source_sensor(ap)
+                sensor.update_from_source_sensor(bp)
+                sensor.update_from_source_sensor(pv1)
+
+                # Cycle 2: repeated zero reads arrive
+                sensor.update_from_source_sensor(ap)
+                sensor.update_from_source_sensor(bp)
+                sensor.update_from_source_sensor(pv1)
+
+                assert mock_log.warning.call_count == 0
+
+    def test_genuine_unconsumed_overwrite_warning(self):
+        """Updating the same source twice before calculation completes logs an unconsumed warning."""
+        with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
+            ap = MagicMock(spec=ActivePower)
+            ap.protocol_version = ProtocolVersion.V2_4
+            bp = MagicMock(spec=ChargeDischargePower)
+            bp.protocol_version = ProtocolVersion.V2_4
+            pv1 = MagicMock(spec=PVStringPower)
+            pv1.string_number = 1
+            pv1.protocol_version = ProtocolVersion.V2_4
+
+            sensor = InverterSelfConsumedPower(0, 1, ap, bp, pv1)
+
+            ap.latest_raw_state = 100
+            sensor.update_from_source_sensor(ap)
+
+            # Second update to ap before bp/pv1 arrive
+            ap.latest_raw_state = 200
+            with patch("sigenergy2mqtt.sensors.base.derived.logger") as mock_log:
+                sensor.update_from_source_sensor(ap)
+                mock_log.warning.assert_called_once()
+                assert "Overwriting unconsumed source value active_power=100" in mock_log.warning.call_args[0][0]
+
+    def test_stale_incomplete_snapshot_discard_includes_zero(self):
+        """Incomplete source snapshot past expected_interval is discarded even when value is zero."""
+        with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
+            ap = MagicMock(spec=ActivePower)
+            ap.protocol_version = ProtocolVersion.V2_4
+            ap.scan_interval = 2
+            bp = MagicMock(spec=ChargeDischargePower)
+            bp.protocol_version = ProtocolVersion.V2_4
+            pv1 = MagicMock(spec=PVStringPower)
+            pv1.string_number = 1
+            pv1.protocol_version = ProtocolVersion.V2_4
+
+            sensor = InverterSelfConsumedPower(0, 1, ap, bp, pv1)
+
+            ap.last_successful_read_time = time.time() - 10  # 10s old, expected interval ~4s
+            ap.latest_raw_state = 0
+            sensor.update_from_source_sensor(ap)
+
+            # Trigger discard via another sensor update
+            bp.latest_raw_state = 0
+            bp.last_successful_read_time = time.time()
+
+            with patch("sigenergy2mqtt.sensors.inverter_derived.logger") as mock_log:
+                sensor.update_from_source_sensor(bp)
+                mock_log.warning.assert_called_once()
+                assert "Discarding stale incomplete source snapshot" in mock_log.warning.call_args[0][0]
+
+    def test_completed_snapshot_not_discarded_as_stale(self):
+        """Completed snapshots (consumed=True) are not discarded as stale even if time passes."""
+        with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
+            ap = MagicMock(spec=ActivePower)
+            ap.protocol_version = ProtocolVersion.V2_4
+            ap.scan_interval = 2
+            bp = MagicMock(spec=ChargeDischargePower)
+            bp.protocol_version = ProtocolVersion.V2_4
+            pv1 = MagicMock(spec=PVStringPower)
+            pv1.string_number = 1
+            pv1.protocol_version = ProtocolVersion.V2_4
+
+            sensor = InverterSelfConsumedPower(0, 1, ap, bp, pv1)
+
+            now = time.time()
+            ap.last_successful_read_time = now
+            ap.latest_raw_state = 0
+            bp.last_successful_read_time = now
+            bp.latest_raw_state = 0
+            pv1.last_successful_read_time = now
+            pv1.latest_raw_state = 0
+
+            # Complete calculation
+            sensor.update_from_source_sensor(ap)
+            sensor.update_from_source_sensor(bp)
+            sensor.update_from_source_sensor(pv1)
+
+            # Advance timestamp on ap past expected_interval
+            ap.last_successful_read_time = now + 10
+            ap.latest_raw_state = 0
+
+            with patch("sigenergy2mqtt.sensors.inverter_derived.logger") as mock_log:
+                sensor.update_from_source_sensor(ap)
+                assert mock_log.warning.call_count == 0
+

--- a/tests/unit/sensors/test_inverter_derived_edge_cases.py
+++ b/tests/unit/sensors/test_inverter_derived_edge_cases.py
@@ -328,6 +328,10 @@ class TestInverterSelfConsumedPowerEdgeCases:
                 assert result is True  # Returns True even when SanityCheckException is caught
                 debug_calls = [str(c) for c in mock_log.debug.call_args_list]
                 assert any("FAILED" in c for c in debug_calls)
+                # Verify rejected snapshot is discarded
+                assert sensor.active_power is None
+                assert sensor.battery_power is None
+                assert sensor.pv_string_power[1] is None
 
     def test_repeated_overnight_zero_reads_no_warnings(self, caplog):
         """Repeated zero reads across multiple scan cycles log zero unconsumed or stale warnings."""

--- a/tests/unit/sensors/test_inverter_derived_values.py
+++ b/tests/unit/sensors/test_inverter_derived_values.py
@@ -197,6 +197,7 @@ class TestInverterSelfConsumedPowerCoverage:
             sensor = InverterSelfConsumedPower(0, 1, ap, bp, pv)
             sensor.pv_string_power[1] = 1234
             sensor._source_timestamps["pv_string_power_1"] = 100.0
+            sensor._source_consumed["pv_string_power_1"] = False
 
             with patch("sigenergy2mqtt.sensors.inverter_derived.time.time", return_value=110.0):
                 sensor._discard_stale_snapshot()
@@ -206,7 +207,8 @@ class TestInverterSelfConsumedPowerCoverage:
             assert sensor.pv_string_power[1] is None
             assert all(timestamp is None for timestamp in sensor._source_timestamps.values())
 
-    def test_stale_partial_snapshot_with_zero_is_not_discarded(self):
+    def test_stale_partial_snapshot_with_zero_is_discarded(self):
+        """Stale unconsumed snapshots with zero value are also discarded now that workaround is removed."""
         ap = MagicMock(spec=Sensor)
         bp = MagicMock(spec=Sensor)
         pv = MagicMock(spec=PVStringPower)
@@ -218,12 +220,13 @@ class TestInverterSelfConsumedPowerCoverage:
             sensor = InverterSelfConsumedPower(0, 1, ap, bp, pv)
             sensor.pv_string_power[1] = 0
             sensor._source_timestamps["pv_string_power_1"] = 100.0
+            sensor._source_consumed["pv_string_power_1"] = False
 
             with patch("sigenergy2mqtt.sensors.inverter_derived.time.time", return_value=110.0):
                 sensor._discard_stale_snapshot()
 
-            assert sensor.pv_string_power[1] == 0
-            assert sensor._source_timestamps["pv_string_power_1"] == 100.0
+            assert sensor.pv_string_power[1] is None
+            assert sensor._source_timestamps["pv_string_power_1"] is None
 
     def test_get_attributes(self):
         from sigenergy2mqtt.sensors.inverter_derived import InverterSelfConsumedPower, PVStringPower


### PR DESCRIPTION
# Derived Sensor Value Consumption & Stale Discard Refactoring

We have decoupled derived sensor source value consumption tracking from MQTT publication by implementing explicit per-source `consumed: bool` flags in `InverterSelfConsumedPower` and `PVStringPower`. We also removed the `cached_val == 0` workaround in `_discard_stale_snapshot()`.

## Changes Made

### 1. `sigenergy2mqtt/sensors/inverter_derived.py`

- **`PVStringPower.Value`**:
  - Added `consumed: bool = True` field.
  - Set `consumed = False` when a new value is applied in `apply()`.
  - Only log `_log_unconsumed_source_value` if `self.value is not None` and `not self.consumed`.
  - Set `self.volts.consumed = True` and `self.amperes.consumed = True` when state calculation succeeds in `update_from_source_sensor()`.

- **`InverterSelfConsumedPower`**:
  - Added `self._source_consumed: dict[str, bool]` to track `consumed` status per source.
  - In `update_from_source_sensor()`:
    - Only log `_log_unconsumed_source_value` if previous value is present AND `not self._source_consumed[source_name]`.
    - Mark source as `_source_consumed[source_name] = False` when receiving a new sample.
    - Set `_source_consumed[name] = True` for all sources once state calculation completes.
  - In `_discard_stale_snapshot()`:
    - Skip sources where `_source_consumed[source_name] == True`.
    - Removed `if cached_val == 0: continue` workaround. Stale incomplete snapshots are now cleanly discarded regardless of whether the cached value is 0 or non-zero.

### 2. Test Suite Updates

- Updated [`test_inverter_derived_values.py`](file:///root/repositories/seud0nym/sigenergy2mqtt/tests/unit/sensors/test_inverter_derived_values.py):
  - Updated `test_stale_partial_snapshot_with_zero_is_discarded` to confirm stale 0s are now discarded when unconsumed and past `expected_interval`.
- Updated [`test_inverter_derived_edge_cases.py`](file:///root/repositories/seud0nym/sigenergy2mqtt/tests/unit/sensors/test_inverter_derived_edge_cases.py):
  - `test_repeated_overnight_zero_reads_no_warnings`: Verifies repeated 0 reads across cycles log 0 unconsumed or stale warnings.
  - `test_genuine_unconsumed_overwrite_warning`: Verifies updating the same source twice before calculation completes logs an unconsumed warning.
  - `test_stale_incomplete_snapshot_discard_includes_zero`: Verifies an incomplete source snapshot past `expected_interval` is discarded even when value is zero.
  - `test_completed_snapshot_not_discarded_as_stale`: Verifies completed snapshots (`consumed=True`) are not discarded as stale.

## Verification Results

### Automated Tests
Ran full test suite:
```bash
.venv/bin/python -m pytest -n auto
```
```
============================ 1283 passed in 10.66s =============================
```
All 1,283 tests passed cleanly.
