### PR TITLE
Fix stale snapshot warnings

### DIFF
--- a/sigenergy2mqtt/sensors/base/derived.py
+++ b/sigenergy2mqtt/sensors/base/derived.py
@@ -118,14 +118,15 @@ class DerivedSensor(TypedSensorMixin, Sensor):
 
     def set_latest_state(self, state: float | str | list[bool] | list[int] | list[float]) -> bool:
         """Update latest state and track pending updates for publishing."""
-        updated = super().set_latest_state(state)
+        self.mark_successful_read()
+        try:
+            updated = super().set_latest_state(state)
+        except Exception:
+            self._last_successful_read_time = self._previous_successful_read_time
+            self._update_generation -= 1
+            raise
         if updated:
             self._pending_update = True
-        else:
-            # A successful re-computation can produce the same value. The state
-            # publication is suppressed, but downstream derived sensors still
-            # need the fresh source value.
-            self._update_derived_sensors()
         return updated
 
     async def publish(self, mqtt_client, modbus_client, republish: bool = False) -> bool:

--- a/tests/unit/sensors/test_inverter_derived_edge_cases.py
+++ b/tests/unit/sensors/test_inverter_derived_edge_cases.py
@@ -472,3 +472,76 @@ class TestInverterSelfConsumedPowerEdgeCases:
                 sensor.update_from_source_sensor(ap)
                 assert mock_log.warning.call_count == 0
 
+    def test_repeated_state_publish_interval_derived_source_not_stale(self, mock_config):
+        """When repeated_state_publish_interval > 0, repeated values from a DerivedSensor source
+        (like PVStringPower) update last_successful_read_time and do NOT get discarded as stale.
+        """
+        mock_config.repeated_state_publish_interval = 60
+        with patch.dict(Sensor._used_unique_ids, clear=True), patch.dict(Sensor._used_object_ids, clear=True):
+            # Create real PVStringPower with mock voltage and current
+            v_source = MagicMock(spec=PVVoltageSensor)
+            v_source.scan_interval = 2
+            v_source.protocol_version = ProtocolVersion.V2_4
+            c_source = MagicMock(spec=PVCurrentSensor)
+            c_source.scan_interval = 2
+            c_source.protocol_version = ProtocolVersion.V2_4
+            pv_power = PVStringPower(0, 1, 1, v_source, c_source)
+
+            ap = MagicMock(spec=ActivePower)
+            ap.scan_interval = 2
+            ap.protocol_version = ProtocolVersion.V2_4
+            bp = MagicMock(spec=ChargeDischargePower)
+            bp.scan_interval = 2
+            bp.protocol_version = ProtocolVersion.V2_4
+
+            sensor = InverterSelfConsumedPower(0, 1, ap, bp, pv_power)
+
+            # Cycle 1 at t0 = 1000.0
+            t0 = 1000.0
+            with patch("time.time", return_value=t0):
+                v_source.latest_raw_state = 0
+                v_source.last_successful_read_time = t0
+                c_source.latest_raw_state = 0
+                c_source.last_successful_read_time = t0
+                pv_power.update_from_source_sensor(v_source)
+                pv_power.update_from_source_sensor(c_source)
+
+                ap.latest_raw_state = 0
+                ap.last_successful_read_time = t0
+                bp.latest_raw_state = 0
+                bp.last_successful_read_time = t0
+
+                sensor.update_from_source_sensor(ap)
+                sensor.update_from_source_sensor(bp)
+                sensor.update_from_source_sensor(pv_power)
+
+            # Cycle 2 at t1 = 1010.0 (10s later; >4s expected_interval, but <60s publish interval)
+            t1 = 1010.0
+            with patch("time.time", return_value=t1), patch("sigenergy2mqtt.sensors.inverter_derived.logger") as mock_log:
+                v_source.latest_raw_state = 0
+                v_source.last_successful_read_time = t1
+                c_source.latest_raw_state = 0
+                c_source.last_successful_read_time = t1
+                pv_power.update_from_source_sensor(v_source)
+                pv_power.update_from_source_sensor(c_source)
+
+                # pv_power's latest_time is still t0 (because 0W is repeated and <60s elapsed),
+                # but last_successful_read_time must be t1!
+                assert pv_power.latest_time == t0
+                assert pv_power.last_successful_read_time == t1
+
+                ap.latest_raw_state = 0
+                ap.last_successful_read_time = t1
+                bp.latest_raw_state = 0
+                bp.last_successful_read_time = t1
+
+                sensor.update_from_source_sensor(pv_power)
+                # Next sibling arrives - must NOT discard pv_power as stale!
+                sensor.update_from_source_sensor(ap)
+                sensor.update_from_source_sensor(bp)
+
+                # No stale discard warning should be logged
+                stale_warnings = [call for call in mock_log.warning.call_args_list if "Discarding stale incomplete source snapshot" in str(call)]
+                assert len(stale_warnings) == 0
+
+


### PR DESCRIPTION
### Root Cause Analysis

#### 1. Why `PVStringPower` became "stale" while `ActivePower` and `BatteryPower` did not
* **Readable sensors** (`ActivePower`, `ChargeDischargePower`, `PVVoltageSensor`, `PVCurrentSensor`) read from Modbus and immediately call `self.mark_successful_read()` on every 2-second poll, which updates `self._last_successful_read_time = now`.
* **Derived sensors** (`PVStringPower`), however, **never called `mark_successful_read()`**. Its `_last_successful_read_time` remained `None`.

#### 2. The Interaction with `repeated_state_publish_interval = 60s`
When `PVStringPower` calculates a value and notifies downstream `InverterSelfConsumedPower`, `InverterSelfConsumedPower` determines the source sample's timestamp via [`_source_timestamp(sensor)`](file:///root/repositories/seud0nym/sigenergy2mqtt/sigenergy2mqtt/sensors/base/derived.py#L112):
```python
@staticmethod
def _source_timestamp(sensor: Sensor) -> float | None:
    timestamp = getattr(sensor, "last_successful_read_time", None)
    if isinstance(timestamp, (int, float)):
        return timestamp
    timestamp = getattr(sensor, "latest_time", None)
    return timestamp if isinstance(timestamp, (int, float)) and timestamp > 0 else None
```
1. Because `PVStringPower.last_successful_read_time` was `None`, it fell back to `sensor.latest_time` (`self._states[-1][0]`).
2. When the state was repeated (0W overnight, or steady 106W/158W during the day), `Sensor.set_latest_state()` suppressed publishing and **did not append to `self._states`** until the 60s interval elapsed.
3. Therefore, for up to 60 seconds, `PVStringPower.latest_time` was **frozen at the old timestamp from when 0W was first published**.
4. Every time `PVStringPower` updated `InverterSelfConsumedPower`, `self._source_timestamps["pv_string_power_1"]` was populated with a timestamp that was **already 10s, 20s, up to 60s old**.
5. When `ActivePower` or `ChargeDischargePower` arrived milliseconds later, `_discard_stale_snapshot()` compared `now - timestamp` against `expected_interval` (`2 × 2s = 4s`).
6. Because `now - timestamp > 4s`, it flagged `pv_string_power_1` as **stale**, wiped out the entire snapshot, and logged:
   ```
   WARNING InverterSelfConsumedPower[plant=0,dev=1] Discarding stale incomplete source snapshot - stale={'pv_string_power_1': 0}
   ```
   This repeated every ~60–84s when the 60s window reset and lapsed again.

---

### The Fix

In [`DerivedSensor.set_latest_state`](file:///root/repositories/seud0nym/sigenergy2mqtt/sigenergy2mqtt/sensors/base/derived.py#L119-L131):
1. **Call `self.mark_successful_read()`**: When a derived sensor recomputes its state, it records a fresh acquisition at `now` and increments `self._update_generation`.
2. **Proper Timestamp Resolution**: `_source_timestamp(PVStringPower)` now reads `PVStringPower.last_successful_read_time = now` rather than falling back to the 60s-old `latest_time`.
3. **Clean Propagation**: `Sensor.set_latest_state()` natively handles downstream propagation via `if updated or self._update_generation > self._last_propagated_generation:`, removing the previous workaround.
4. **Exception Safety**: If `super().set_latest_state()` raises an exception (e.g. `SanityCheckException`), `_last_successful_read_time` and `_update_generation` are safely rolled back.

---

### Verification
* Added [`test_repeated_state_publish_interval_derived_source_not_stale`](file:///root/repositories/seud0nym/sigenergy2mqtt/tests/unit/sensors/test_inverter_derived_edge_cases.py#L475-L547) in `test_inverter_derived_edge_cases.py` reproducing this exact 60s repeat interval and 2s scan cadence.
* All **725 sensor unit tests** passed cleanly in 27s (`.venv/bin/python -m pytest tests/unit/sensors/ -n auto`).

## Removal of `self._update_derived_sensors()` from `set_latest_state`

In [`Sensor.set_latest_state()`](file:///root/repositories/seud0nym/sigenergy2mqtt/sigenergy2mqtt/sensors/base/sensor.py#L1181-L1184), the base class **already contains** the logic to propagate to downstream derived sensors:

```python
# Sensor.set_latest_state (lines 1181-1184)
if updated or self._update_generation > self._last_propagated_generation:
    self._update_derived_sensors()
    self._last_propagated_generation = self._update_generation
```

### Why was the `else: self._update_derived_sensors()` added originally?
Previously, `DerivedSensor` never called `mark_successful_read()`. 
* As a consequence, `self._update_generation` on derived sensors was always `0` and never incremented.
* When an unchanged value arrived (e.g. repeated 0W), `updated` was `False`, and `self._update_generation > self._last_propagated_generation` evaluated to `0 > 0` (`False`).
* Because `Sensor.set_latest_state` failed to trigger propagation, the `else` branch was added to `DerivedSensor.set_latest_state()` as a workaround:
  ```python
  else:
      # A successful re-computation can produce the same value. The state
      # publication is suppressed, but downstream derived sensors still
      # need the fresh source value.
      self._update_derived_sensors()
  ```

### Why it was removed
Now that `DerivedSensor.set_latest_state()` calls `self.mark_successful_read()`:
1. `self._update_generation` is incremented on every successful computation.
2. Inside `super().set_latest_state(state)`, the condition `self._update_generation > self._last_propagated_generation` evaluates to `True`.
3. `super().set_latest_state()` calls `self._update_derived_sensors()` and updates `self._last_propagated_generation = self._update_generation`.

If the `else: self._update_derived_sensors()` had been kept, whenever `updated` is `False`, downstream derived sensors would have been **called twice for every single reading** (once inside `super().set_latest_state()`, and immediately again in `DerivedSensor`'s `else` branch).