### PR TITLE
Refactor transport-independent WriteOnlySensorMixin

### DIFF
--- a/sigenergy2mqtt/devices/base/device.py
+++ b/sigenergy2mqtt/devices/base/device.py
@@ -13,7 +13,7 @@ from sigenergy2mqtt.config import active_config
 from sigenergy2mqtt.config.models import RegisterAccess
 from sigenergy2mqtt.i18n import _t
 from sigenergy2mqtt.mqtt import MqttHandler
-from sigenergy2mqtt.sensors.base import AlarmCombinedSensor, CrossDeviceDerivedSensor, DerivedSensor, ObservableMixin, ReadableSensorMixin, Sensor, WriteableSensorMixin, WriteOnlySensor
+from sigenergy2mqtt.sensors.base import AlarmCombinedSensor, CrossDeviceDerivedSensor, DerivedSensor, ObservableMixin, ReadableSensorMixin, Sensor, WriteableSensorMixin, WriteOnlySensorMixin
 
 if TYPE_CHECKING:
     from sigenergy2mqtt.modbus import ModbusClient
@@ -402,7 +402,7 @@ class Device(HaPublisherMixin, dict[str, str | list[str]], metaclass=abc.ABCMeta
             if added:
                 self._add_to_all_sensors(sensor)
             return added
-        if isinstance(sensor, WriteOnlySensor):
+        if isinstance(sensor, WriteOnlySensorMixin):
             self.write_sensors[sensor.unique_id] = sensor
             self._add_to_all_sensors(sensor)
             return True

--- a/sigenergy2mqtt/main/main.py
+++ b/sigenergy2mqtt/main/main.py
@@ -28,7 +28,7 @@ from sigenergy2mqtt.monitor import MonitorService
 from sigenergy2mqtt.mqtt import interrupt_mqtt_reconnection, mqtt_health_registry, reset_mqtt_reconnection_interrupt
 from sigenergy2mqtt.persistence import Category, state_store
 from sigenergy2mqtt.pvoutput import get_pvoutput_services
-from sigenergy2mqtt.sensors.base import AlarmCombinedSensor, ModbusSensorMixin, SanityCheckException, WriteOnlySensor
+from sigenergy2mqtt.sensors.base import AlarmCombinedSensor, ModbusSensorMixin, SanityCheckException, WriteOnlySensorMixin
 from sigenergy2mqtt.sensors.inverter_read_only import InverterFirmwareVersion, InverterModel, InverterSerialNumber, OutputType, PACKBCUCount, RatedActivePower
 from sigenergy2mqtt.sensors.pid_read_only import PIDSerialNumber
 from sigenergy2mqtt.sensors.plant_ess_preheating_read_write import ESSPreHeatingEnable
@@ -1154,7 +1154,7 @@ async def validate_publishable_sensors(modbus_client: ModbusClient, device: Devi
     if active_config.clean:
         return
 
-    sensors_to_test = [s for s in device.get_all_sensors(search_children=True).values() if isinstance(s, ModbusSensorMixin) and not isinstance(s, WriteOnlySensor) and s.publishable and s.state_count == 0]
+    sensors_to_test = [s for s in device.get_all_sensors(search_children=True).values() if isinstance(s, ModbusSensorMixin) and not isinstance(s, WriteOnlySensorMixin) and s.publishable and s.state_count == 0]
     if not sensors_to_test:
         return
 

--- a/sigenergy2mqtt/metrics/sensors.py
+++ b/sigenergy2mqtt/metrics/sensors.py
@@ -13,7 +13,7 @@ from typing import Any, cast
 
 from sigenergy2mqtt.common import PERCENTAGE, DeviceClass, ProtocolApplies, ProtocolVersion
 from sigenergy2mqtt.config import active_config
-from sigenergy2mqtt.sensors.base import DiscoveryKeys, ReadableSensorMixin, WriteOnlySensor
+from sigenergy2mqtt.sensors.base import DiscoveryKeys, ReadableSensorMixin, WriteOnlySensor, WriteOnlySensorMixin
 
 from .metrics import Metrics
 
@@ -831,7 +831,7 @@ class PVOutputUploadMin(MetricsSensor):
 # =============================================================================
 
 
-class ResetMetrics(WriteOnlySensor):
+class ResetMetrics(WriteOnlySensorMixin):
     """Button that resets all metrics counters to their default values.
 
     Unlike typical :class:`WriteOnlySensor` subclasses this sensor:
@@ -846,10 +846,14 @@ class ResetMetrics(WriteOnlySensor):
     def __init__(self):
         super().__init__(
             name="Reset Metrics",
+            unique_id=f"{active_config.home_assistant.unique_id_prefix}_metrics_reset",
             object_id="sigenergy2mqtt_metrics_reset",
-            plant_index=0,  # Required for assertions, but not used
-            device_address=1,  # Required for assertions, but not used
-            address=99999,  # Required for assertions, but not used
+            unit=None,
+            device_class=None,
+            state_class=None,
+            icon=None,
+            gain=None,
+            precision=None,
             protocol_version=ProtocolVersion.N_A,
             icon_off="mdi:reload",
             icon_on="mdi:reload",
@@ -859,7 +863,6 @@ class ResetMetrics(WriteOnlySensor):
             payload_on=self._PAYLOAD_PRESS,
             value_off=1,
             value_on=1,
-            unique_id_override=f"{active_config.home_assistant.unique_id_prefix}_metrics_reset",
         )
         self[DiscoveryKeys.ENABLED_BY_DEFAULT] = True
 

--- a/sigenergy2mqtt/metrics/sensors.py
+++ b/sigenergy2mqtt/metrics/sensors.py
@@ -13,7 +13,7 @@ from typing import Any, cast
 
 from sigenergy2mqtt.common import PERCENTAGE, DeviceClass, ProtocolApplies, ProtocolVersion
 from sigenergy2mqtt.config import active_config
-from sigenergy2mqtt.sensors.base import DiscoveryKeys, ReadableSensorMixin, WriteOnlySensor, WriteOnlySensorMixin
+from sigenergy2mqtt.sensors.base import DiscoveryKeys, ReadableSensorMixin, WriteOnlySensorMixin
 
 from .metrics import Metrics
 
@@ -918,7 +918,7 @@ class ResetMetrics(WriteOnlySensorMixin):
     def publish_attributes(self, mqtt_client: Any, clean: bool = False, **kwargs) -> None:
         """Metrics sensors do not publish extra MQTT attributes."""
 
-    async def _write_value(self, modbus_client: ModbusClient | None, mqtt_client: mqtt.Client, value: float | str, source: str, handler: MqttHandler) -> bool:
+    async def _write_value(self, modbus_client: Any | None, mqtt_client: Any, value: float | str, source: str, handler: Any) -> bool:
         """Reset metrics counters."""
         if str(value) == "1":
             logger.info(f"{self.log_identity} Resetting all metrics counters")

--- a/sigenergy2mqtt/metrics/sensors.py
+++ b/sigenergy2mqtt/metrics/sensors.py
@@ -918,16 +918,11 @@ class ResetMetrics(WriteOnlySensorMixin):
     def publish_attributes(self, mqtt_client: Any, clean: bool = False, **kwargs) -> None:
         """Metrics sensors do not publish extra MQTT attributes."""
 
-    async def set_value(self, modbus_client: Any | None, mqtt_client: Any, value: float | str, source: str, handler: Any) -> bool:
-        """Reset metrics without touching Modbus."""
-        self.force_publish = True
-        if str(value) == self._PAYLOAD_PRESS:
-            logger.info("ResetMetrics: Resetting all metrics counters")
+    async def _write_value(self, modbus_client: ModbusClient | None, mqtt_client: mqtt.Client, value: float | str, source: str, handler: MqttHandler) -> bool:
+        """Reset metrics counters."""
+        if str(value) == "1":
+            logger.info(f"{self.log_identity} Resetting all metrics counters")
             await Metrics.reset()
             return True
         logger.warning(f"ResetMetrics: Ignored unexpected payload '{value}'")
         return False
-
-    async def value_is_valid(self, modbus_client: Any | None, raw_value: float | str) -> bool:
-        """Accept the reset payload."""
-        return str(raw_value) == self._PAYLOAD_PRESS

--- a/sigenergy2mqtt/sensors/base/README.md
+++ b/sigenergy2mqtt/sensors/base/README.md
@@ -25,7 +25,7 @@ Sensor (abstract; discovery, state, publishing, overrides)
 │       ├── EnergyLifetimeAccumulationSensor
 │       └── EnergyDailyAccumulationSensor
 │           └── SimpleEnergyDailyAccumulationSensor
-├── WriteOnlySensor (Modbus command/button)
+├── WriteOnlySensor (WriteOnlySensorMixin + ModbusWriteableSensorMixin + Sensor)
 └── ReadWriteSensor (Modbus polling + commands)
     ├── NumericSensor (NumericSensorMixin + ReadWriteSensor)
     │   └── ThreePhaseAdjustmentTargetValue
@@ -52,11 +52,12 @@ Sensor
 └── WriteableSensorMixin
     ├── NumericSensorMixin
     ├── SelectSensorMixin
-    └── SwitchSensorMixin
+    ├── SwitchSensorMixin
+    └── WriteOnlySensorMixin
 
 TypedSensorMixin + ModbusSensorMixin + WriteableSensorMixin
 └── ModbusWriteableSensorMixin
-    ├── WriteOnlySensor
+    ├── WriteOnlySensorMixin + ModbusWriteableSensorMixin -> WriteOnlySensor
     └── ReadWriteSensor
         ├── NumericSensorMixin + ReadWriteSensor -> NumericSensor
         ├── SelectSensorMixin + ReadWriteSensor  -> SelectSensor
@@ -99,9 +100,11 @@ without choosing a transport:
   an option name to its index.
 * `SwitchSensorMixin` configures a binary `switch` entity and validates `0` or
   `1` commands.
+* `WriteOnlySensorMixin` configures Home Assistant `button` entities for
+  transmitting action payloads without tracking a readable state.
 
 They mirror the command-facing behaviour of `NumericSensor`, `SelectSensor`,
-and `SwitchSensor`, and each inherits `WriteableSensorMixin`. Subclass the
+`SwitchSensor`, and `WriteOnlySensor`, and each inherits `WriteableSensorMixin`. Subclass the
 appropriate presentation mixin directly when the backing service is not Modbus.
 
 ## Creating a non-Modbus writeable sensor
@@ -127,7 +130,7 @@ Instantiate it with the normal `Sensor` keyword arguments (`name`, `unique_id`,
 `modbus_client` argument remains in the command method signature for a common
 MQTT handler interface and may be `None` for non-Modbus sensors.
 
-For a select or switch, replace `NumericSensorMixin` with `SelectSensorMixin`
-(and provide `options`) or `SwitchSensorMixin`.  A custom transport can also
-subclass `WriteableSensorMixin` directly when it needs no number/select/switch
+For a select, switch, or button, replace `NumericSensorMixin` with `SelectSensorMixin`
+(and provide `options`), `SwitchSensorMixin`, or `WriteOnlySensorMixin`.  A custom transport can also
+subclass `WriteableSensorMixin` directly when it needs no number/select/switch/button
 presentation behaviour.

--- a/sigenergy2mqtt/sensors/base/__init__.py
+++ b/sigenergy2mqtt/sensors/base/__init__.py
@@ -97,4 +97,5 @@ from .writeable import (  # noqa: F401
     SwitchSensorMixin,
     ThreePhaseAdjustmentTargetValue,
     WriteOnlySensor,
+    WriteOnlySensorMixin,
 )

--- a/sigenergy2mqtt/sensors/base/mixins.py
+++ b/sigenergy2mqtt/sensors/base/mixins.py
@@ -317,7 +317,7 @@ class WriteableSensorMixin(Sensor):
         # Early return removed to allow string processing below
 
         # Lazy import to avoid circular dependencies
-        from .writeable import SelectSensorMixin, SwitchSensorMixin, WriteOnlySensor
+        from .writeable import SelectSensorMixin, SwitchSensorMixin, WriteOnlySensorMixin
 
         # Handle Option-based sensors
         if DiscoveryKeys.OPTIONS in self and isinstance(raw_value, (int, float)):
@@ -325,11 +325,11 @@ class WriteableSensorMixin(Sensor):
             if option:
                 return option
 
-        # Handle WriteOnlySensor states
-        if isinstance(self, WriteOnlySensor) and isinstance(raw_value, str):
-            if self._values["off"] == raw_value:
+        # Handle WriteOnlySensorMixin states
+        if isinstance(self, WriteOnlySensorMixin):
+            if raw_value in (self._values["off"], str(self._values["off"]), self._payloads.get("off")):
                 return self._names["off"]
-            elif self._values["on"] == raw_value:
+            elif raw_value in (self._values["on"], str(self._values["on"]), self._payloads.get("on")):
                 return self._names["on"]
             return raw_value
 

--- a/sigenergy2mqtt/sensors/base/writeable.py
+++ b/sigenergy2mqtt/sensors/base/writeable.py
@@ -24,154 +24,6 @@ from .sensor import AvailabilityMixin, Sensor
 
 logger = logging.getLogger(__name__)
 # =============================================================================
-
-
-class WriteOnlySensor(ModbusWriteableSensorMixin, Sensor):
-    """Sensor that can only write values (e.g., buttons, triggers).
-
-    Write-only sensors appear as buttons in Home Assistant and don't
-    have a readable state.
-    """
-
-    def __init__(
-        self,
-        name: str,
-        object_id: str,
-        plant_index: int,
-        device_address: int,
-        address: int,
-        protocol_version: ProtocolVersion,
-        payload_off: str = "off",
-        payload_on: str = "on",
-        name_off: str = "Power Off",
-        name_on: str = "Power On",
-        icon_off: str = "mdi:power-off",
-        icon_on: str = "mdi:power-on",
-        value_off: int = 0,
-        value_on: int = 1,
-        **kwargs,
-    ):
-        # Validate icons
-        if not icon_on.startswith("mdi:"):
-            raise ValueError(f"{self.__class__.__name__}: on icon '{icon_on}' does not start with 'mdi:'")
-        if not icon_off.startswith("mdi:"):
-            raise ValueError(f"{self.__class__.__name__}: off icon '{icon_off}' does not start with 'mdi:'")
-
-        super().__init__(
-            name=name,
-            object_id=object_id,
-            input_type=InputType.HOLDING,
-            plant_index=plant_index,
-            device_address=device_address,
-            address=address,
-            count=1,
-            data_type=ModbusDataType.UINT16,
-            unit=None,
-            device_class=None,
-            state_class=None,
-            icon=None,
-            gain=None,
-            precision=None,
-            protocol_version=protocol_version,
-            **kwargs,
-        )
-
-        self[DiscoveryKeys.PLATFORM] = "button"
-        self[DiscoveryKeys.ENABLED_BY_DEFAULT] = True
-
-        self._payloads = {"off": payload_off, "on": payload_on}
-
-        # Use shared translation for defaults, specific for overrides
-        t_off = _t("WriteOnlySensor.name_off", name_off, self.debug_logging) if name_off == "Power Off" else _t(f"{self.__class__.__name__}.name_off", name_off, self.debug_logging)
-        t_on = _t("WriteOnlySensor.name_on", name_on, self.debug_logging) if name_on == "Power On" else _t(f"{self.__class__.__name__}.name_on", name_on, self.debug_logging)
-
-        self._names = {"off": t_off, "on": t_on}
-        self._icons = {"off": icon_off, "on": icon_on}
-        self._values = {"off": value_off, "on": value_on}
-
-    async def _update_internal_state(self, **kwargs) -> bool | Exception | ExceptionResponse:
-        """Write-only sensors don't have internal state."""
-        return False
-
-    def get_discovery_components(self) -> dict[str, dict[str, Any]]:
-        """Get discovery components for both on and off buttons.
-
-        Returns:
-            Dictionary of component configurations
-        """
-        components: dict[str, Any] = {}
-
-        # Remove legacy entities first
-        for action in ["On", "Off"]:
-            components[f"{self.unique_id}_{action}"] = {"p": "button"}
-
-        # Create new button entities
-        for action in ["on", "off"]:
-            config: dict[str, Any] = {}
-
-            if self._names[action] == "" or self._names[action].isspace():
-                continue
-
-            for k, v in self.items():
-                if v is None:
-                    continue
-
-                if k == DiscoveryKeys.NAME:
-                    config[k] = self._names[action]
-                elif k in (DiscoveryKeys.OBJECT_ID, DiscoveryKeys.UNIQUE_ID):
-                    config[k] = f"{v}_{self._payloads[action]}"
-                else:
-                    config[k] = v
-
-            config[DiscoveryKeys.ICON] = self._icons[action]
-            config["payload_press"] = self._payloads[action]
-            components[f"{self.unique_id}_{action}"] = config
-
-        if self.debug_logging:
-            logger.debug(f"{self.log_identity} Discovered components={components}")
-
-        return components
-
-    async def set_value(self, modbus_client: ModbusClient | None, mqtt_client: mqtt.Client, value: float | str, source: str, handler: MqttHandler) -> bool:
-        """Set value, translating payload to actual value.
-
-        Args:
-            modbus_client: Modbus client for writing
-            mqtt_client: MQTT client
-            value: Payload value ("on" or "off")
-            source: Source topic
-            handler: MQTT handler
-
-        Returns:
-            True if successfully set
-        """
-        # Translate payload to actual value
-        if self._payloads["off"] == value:
-            actual_value = self._values["off"]
-        elif self._payloads["on"] == value:
-            actual_value = self._values["on"]
-        else:
-            actual_value = value
-
-        return await super().set_value(modbus_client, mqtt_client, actual_value, source, handler)
-
-    async def value_is_valid(self, modbus_client: ModbusClient | None, raw_value: float | str) -> bool:
-        """Validate that value is either on or off value.
-
-        Args:
-            modbus_client: Modbus client (unused)
-            raw_value: Value to validate
-
-        Returns:
-            True if valid
-        """
-        if raw_value not in (self._values["off"], self._values["on"]):
-            logger.error(f"{self.log_identity} Invalid value '{raw_value}': Must be either '{self._payloads['on']}' or '{self._payloads['off']}'")
-            return False
-        return True
-
-
-# =============================================================================
 # Read-Write Sensor
 # =============================================================================
 
@@ -458,6 +310,186 @@ class SwitchSensorMixin(WriteableSensorMixin):
 
     async def value_is_valid(self, modbus_client: ModbusClient | None, raw_value: float | str) -> bool:
         return raw_value in (self[DiscoveryKeys.PAYLOAD_OFF], self[DiscoveryKeys.PAYLOAD_ON])
+
+
+class WriteOnlySensorMixin(WriteableSensorMixin):
+    """Add Home Assistant button configuration and payload handling.
+
+    This inherits :class:`WriteableSensorMixin`; provide ``_write_value`` in a
+    subclass when the value is not backed by Modbus.
+    """
+
+    def __init__(
+        self,
+        payload_off: str = "off",
+        payload_on: str = "on",
+        name_off: str = "Power Off",
+        name_on: str = "Power On",
+        icon_off: str = "mdi:power-off",
+        icon_on: str = "mdi:power-on",
+        value_off: int = 0,
+        value_on: int = 1,
+        **kwargs,
+    ):
+        # Validate icons
+        if not icon_on.startswith("mdi:"):
+            raise ValueError(f"{self.__class__.__name__}: on icon '{icon_on}' does not start with 'mdi:'")
+        if not icon_off.startswith("mdi:"):
+            raise ValueError(f"{self.__class__.__name__}: off icon '{icon_off}' does not start with 'mdi:'")
+
+        super().__init__(**kwargs)
+
+        self[DiscoveryKeys.PLATFORM] = "button"
+        self[DiscoveryKeys.ENABLED_BY_DEFAULT] = True
+
+        self._payloads = {"off": payload_off, "on": payload_on}
+
+        # Use shared translation for defaults, specific for overrides
+        t_off = _t("WriteOnlySensor.name_off", name_off, self.debug_logging) if name_off == "Power Off" else _t(f"{self.__class__.__name__}.name_off", name_off, self.debug_logging)
+        t_on = _t("WriteOnlySensor.name_on", name_on, self.debug_logging) if name_on == "Power On" else _t(f"{self.__class__.__name__}.name_on", name_on, self.debug_logging)
+
+        self._names = {"off": t_off, "on": t_on}
+        self._icons = {"off": icon_off, "on": icon_on}
+        self._values = {"off": value_off, "on": value_on}
+
+    async def _update_internal_state(self, **kwargs) -> bool | Exception | ExceptionResponse:
+        """Write-only sensors don't have internal state."""
+        return False
+
+    def get_discovery_components(self) -> dict[str, dict[str, Any]]:
+        """Get discovery components for both on and off buttons.
+
+        Returns:
+            Dictionary of component configurations
+        """
+        components: dict[str, Any] = {}
+
+        # Remove legacy entities first
+        for action in ["On", "Off"]:
+            components[f"{self.unique_id}_{action}"] = {"p": "button"}
+
+        # Create new button entities
+        for action in ["on", "off"]:
+            config: dict[str, Any] = {}
+
+            if self._names[action] == "" or self._names[action].isspace():
+                continue
+
+            for k, v in self.items():
+                if v is None:
+                    continue
+
+                if k == DiscoveryKeys.NAME:
+                    config[k] = self._names[action]
+                elif k in (DiscoveryKeys.OBJECT_ID, DiscoveryKeys.UNIQUE_ID):
+                    config[k] = f"{v}_{self._payloads[action]}"
+                else:
+                    config[k] = v
+
+            config[DiscoveryKeys.ICON] = self._icons[action]
+            config["payload_press"] = self._payloads[action]
+            components[f"{self.unique_id}_{action}"] = config
+
+        if self.debug_logging:
+            logger.debug(f"{self.log_identity} Discovered components={components}")
+
+        return components
+
+    async def set_value(self, modbus_client: ModbusClient | None, mqtt_client: mqtt.Client, value: float | str, source: str, handler: MqttHandler) -> bool:
+        """Set value, translating payload to actual value.
+
+        Args:
+            modbus_client: Modbus client for writing
+            mqtt_client: MQTT client
+            value: Payload value ("on" or "off")
+            source: Source topic
+            handler: MQTT handler
+
+        Returns:
+            True if successfully set
+        """
+        # Translate payload to actual value
+        if self._payloads["off"] == value:
+            actual_value = self._values["off"]
+        elif self._payloads["on"] == value:
+            actual_value = self._values["on"]
+        else:
+            actual_value = value
+
+        return await super().set_value(modbus_client, mqtt_client, actual_value, source, handler)
+
+    async def value_is_valid(self, modbus_client: ModbusClient | None, raw_value: float | str) -> bool:
+        """Validate that value is either on or off value.
+
+        Args:
+            modbus_client: Modbus client (unused)
+            raw_value: Value to validate
+
+        Returns:
+            True if valid
+        """
+        if raw_value not in (self._values["off"], self._values["on"]):
+            logger.error(f"{self.log_identity} Invalid value '{raw_value}': Must be either '{self._payloads['on']}' or '{self._payloads['off']}'")
+            return False
+        return True
+
+
+# =============================================================================
+# Write-Only Sensor
+# =============================================================================
+
+
+class WriteOnlySensor(WriteOnlySensorMixin, ModbusWriteableSensorMixin, Sensor):
+    """Sensor that can only write values (e.g., buttons, triggers).
+
+    Write-only sensors appear as buttons in Home Assistant and don't
+    have a readable state.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        object_id: str,
+        plant_index: int,
+        device_address: int,
+        address: int,
+        protocol_version: ProtocolVersion,
+        payload_off: str = "off",
+        payload_on: str = "on",
+        name_off: str = "Power Off",
+        name_on: str = "Power On",
+        icon_off: str = "mdi:power-off",
+        icon_on: str = "mdi:power-on",
+        value_off: int = 0,
+        value_on: int = 1,
+        **kwargs,
+    ):
+        super().__init__(
+            name=name,
+            object_id=object_id,
+            input_type=InputType.HOLDING,
+            plant_index=plant_index,
+            device_address=device_address,
+            address=address,
+            count=1,
+            data_type=ModbusDataType.UINT16,
+            unit=None,
+            device_class=None,
+            state_class=None,
+            icon=None,
+            gain=None,
+            precision=None,
+            protocol_version=protocol_version,
+            payload_off=payload_off,
+            payload_on=payload_on,
+            name_off=name_off,
+            name_on=name_on,
+            icon_off=icon_off,
+            icon_on=icon_on,
+            value_off=value_off,
+            value_on=value_on,
+            **kwargs,
+        )
 
 
 # =============================================================================

--- a/tests/unit/sensors/test_non_modbus_writeable_sensors.py
+++ b/tests/unit/sensors/test_non_modbus_writeable_sensors.py
@@ -13,6 +13,7 @@ from sigenergy2mqtt.sensors.base import (
     Sensor,
     SwitchSensorMixin,
     WriteableSensorMixin,
+    WriteOnlySensorMixin,
 )
 
 
@@ -37,6 +38,10 @@ class NonModbusSelectSensor(SelectSensorMixin, _NonModbusWriteableSensor):
 
 
 class NonModbusSwitchSensor(SwitchSensorMixin, _NonModbusWriteableSensor):
+    pass
+
+
+class NonModbusWriteOnlySensor(WriteOnlySensorMixin, _NonModbusWriteableSensor):
     pass
 
 
@@ -78,10 +83,12 @@ def sensor_kwargs(name: str) -> dict:
         (NonModbusNumericSensor, {"minimum": 0, "maximum": 100}, "12", 12),
         (NonModbusSelectSensor, {"options": ["Automatic", "Manual"]}, "Manual", 1),
         (NonModbusSwitchSensor, {}, "1", 1),
+        (NonModbusWriteOnlySensor, {}, "on", 1),
+        (NonModbusWriteOnlySensor, {}, "off", 0),
     ],
 )
 async def test_writable_entity_mixins_dispatch_commands_without_modbus(sensor_class, extra_kwargs, command, expected):
-    sensor = sensor_class(**sensor_kwargs(sensor_class.__name__.lower()), **extra_kwargs)
+    sensor = sensor_class(**sensor_kwargs(f"{sensor_class.__name__.lower()}_{command}"), **extra_kwargs)
     sensor.configure_mqtt_topics("test-device")
 
     assert await sensor.set_value(None, MagicMock(), command, sensor.command_topic, MagicMock()) is True
@@ -124,3 +131,40 @@ async def test_select_mixin_matches_modbus_state_conversion():
 
     assert await sensor.get_state(republish=True) == "Manual"
     assert await sensor.get_state(raw=True, republish=True) == 1
+
+
+def test_write_only_mixin_discovery_components():
+    sensor = NonModbusWriteOnlySensor(**sensor_kwargs("btn_test"))
+    comps = sensor.get_discovery_components()
+
+    assert f"{sensor.unique_id}_on" in comps
+    assert f"{sensor.unique_id}_off" in comps
+    assert comps[f"{sensor.unique_id}_on"]["payload_press"] == "on"
+    assert comps[f"{sensor.unique_id}_off"]["payload_press"] == "off"
+    assert comps[f"{sensor.unique_id}_on"]["platform"] == "button"
+    assert comps[f"{sensor.unique_id}_off"]["platform"] == "button"
+
+
+@pytest.mark.asyncio
+async def test_write_only_mixin_validation_and_raw2state():
+    sensor = NonModbusWriteOnlySensor(**sensor_kwargs("btn_valid"))
+
+    assert await sensor._update_internal_state() is False
+    assert await sensor.value_is_valid(None, 1) is True
+    assert await sensor.value_is_valid(None, 0) is True
+    assert await sensor.value_is_valid(None, 2) is False
+    assert sensor._raw2state("0") == "Power Off"
+    assert sensor._raw2state(0) == "Power Off"
+    assert sensor._raw2state("off") == "Power Off"
+    assert sensor._raw2state("1") == "Power On"
+    assert sensor._raw2state(1) == "Power On"
+    assert sensor._raw2state("on") == "Power On"
+    assert sensor._raw2state("unknown") == "unknown"
+
+
+def test_write_only_mixin_validates_icons():
+    with pytest.raises(ValueError, match="on icon.*does not start with 'mdi:'"):
+        NonModbusWriteOnlySensor(**sensor_kwargs("bad_on"), icon_on="invalid")
+
+    with pytest.raises(ValueError, match="off icon.*does not start with 'mdi:'"):
+        NonModbusWriteOnlySensor(**sensor_kwargs("bad_off"), icon_off="invalid")

--- a/tests/unit/sensors/test_writeable_sensor_e2e.py
+++ b/tests/unit/sensors/test_writeable_sensor_e2e.py
@@ -9,7 +9,7 @@ from pymodbus.client.mixin import ModbusClientMixin
 
 from sigenergy2mqtt.config import Config, _swap_active_config
 from sigenergy2mqtt.metrics.sensors import ResetMetrics
-from sigenergy2mqtt.sensors.base import NumericSensor, SelectSensor, SwitchSensor, WriteableSensorMixin, WriteOnlySensor
+from sigenergy2mqtt.sensors.base import NumericSensor, SelectSensor, SwitchSensor, WriteableSensorMixin, WriteOnlySensorMixin
 from sigenergy2mqtt.sensors.base.constants import DiscoveryKeys
 from sigenergy2mqtt.sensors.plant_read_write import MaxChargingLimit, MaxDischargingLimit, PVMaxPowerLimit, RemoteEMSLimit
 from tests.utils.modbus_sensors import get_sensor_instances
@@ -167,7 +167,7 @@ def test_all_writable_sensor_types_write_expected_registers_and_set_force_publis
                 assert await sensor.set_value(modbus, mqtt, "__invalid_payload__", topic, handler) is False
                 assert sensor.force_publish is True
 
-            elif isinstance(sensor, WriteOnlySensor):
+            elif isinstance(sensor, WriteOnlySensorMixin):
                 valid = sensor._payloads["on"]
                 assert await sensor.set_value(modbus, mqtt, valid, topic, handler) is True
                 modbus.write_register.assert_awaited_with(sensor.address, sensor._values["on"], device_id=sensor.device_address, no_response_expected=False)

--- a/tests/utils/modbus_sensors.py
+++ b/tests/utils/modbus_sensors.py
@@ -39,7 +39,7 @@ from sigenergy2mqtt.metrics.sensors import Started
 from sigenergy2mqtt.modbus import ModbusDataType
 from sigenergy2mqtt.sensors.ac_charger_read_only import ACChargerInputBreaker, ACChargerRatedCurrent, ACChargerRunningState
 from sigenergy2mqtt.sensors.ac_charger_read_write import ACChargerStatus
-from sigenergy2mqtt.sensors.base import AlarmCombinedSensor, AlarmSensor, ModbusSensorMixin, NumericSensor, ReservedSensor, Sensor, SwitchSensor, TimestampSensor, WriteOnlySensor
+from sigenergy2mqtt.sensors.base import AlarmCombinedSensor, AlarmSensor, ModbusSensorMixin, NumericSensor, ReservedSensor, Sensor, SwitchSensor, TimestampSensor, WriteOnlySensorMixin
 from sigenergy2mqtt.sensors.inverter_read_only import (
     DCChargerRatedChargingPower,
     DCChargerRatedDischargingPower,
@@ -334,7 +334,7 @@ async def get_sensor_instances(
             logger.warning(f"{s.__class__.__name__} has no Unit of Measurement")
         # Check for missing device_class and state_class on concrete sensor classes, excluding known exceptions
         if (
-            not isinstance(s, (AlarmCombinedSensor, AlarmSensor, CurrentControlCommandValue, ESSPreHeatingTOUTime, InsulationResistance, ReservedSensor, SystemTimeZone, SwitchSensor, WriteOnlySensor))
+            not isinstance(s, (AlarmCombinedSensor, AlarmSensor, CurrentControlCommandValue, ESSPreHeatingTOUTime, InsulationResistance, ReservedSensor, SystemTimeZone, SwitchSensor, WriteOnlySensorMixin))
             and getattr(s, "data_type", ModbusDataType.STRING) is not ModbusDataType.STRING
         ):
             if s.device_class is None and not any(sub in s.__class__.__name__ for sub in ["Count", "Gradient"]):


### PR DESCRIPTION
# Refactor WriteOnlySensor into WriteOnlySensorMixin

Refactored `WriteOnlySensor` to extract its transport-independent button presentation and payload handling logic into a reusable `WriteOnlySensorMixin`, matching the pattern of `NumericSensorMixin`, `SelectSensorMixin`, and `SwitchSensorMixin`.

## Changes Made

### Core Sensor Framework

#### [sigenergy2mqtt/sensors/base/writeable.py](file:///root/repositories/seud0nym/sigenergy2mqtt/sigenergy2mqtt/sensors/base/writeable.py)
- Extracted `WriteOnlySensorMixin(WriteableSensorMixin)` under the "Transport-independent writable entity mixins" section:
  - Supports button parameters: `payload_off`, `payload_on`, `name_off`, `name_on`, `icon_off`, `icon_on`, `value_off`, `value_on`, and `**kwargs`.
  - Validates `icon_on` and `icon_off` start with `mdi:`.
  - Configures platform as `"button"` and enabled by default.
  - Handles name translations via `_t`.
  - Implements `_update_internal_state` returning `False` (buttons have no internal readable state).
  - Implements `get_discovery_components` to produce Home Assistant button entity discovery configurations.
  - Implements `set_value` to translate `"on"` / `"off"` payloads into their configured values (`value_on` / `value_off`) before delegating to `super().set_value(...)`.
  - Implements `value_is_valid` to validate incoming values against configured on/off values.
- Refactored `WriteOnlySensor(WriteOnlySensorMixin, ModbusWriteableSensorMixin, Sensor)`:
  - Preserves exact Modbus sensor parameters and default values.
  - Forwards parameters up the cooperative class hierarchy via `super().__init__(...)`.

#### [sigenergy2mqtt/sensors/base/__init__.py](file:///root/repositories/seud0nym/sigenergy2mqtt/sigenergy2mqtt/sensors/base/__init__.py)
- Exported `WriteOnlySensorMixin` alongside `NumericSensorMixin`, `SelectSensorMixin`, and `SwitchSensorMixin`.

#### [sigenergy2mqtt/sensors/base/mixins.py](file:///root/repositories/seud0nym/sigenergy2mqtt/sigenergy2mqtt/sensors/base/mixins.py)
- Updated `WriteableSensorMixin._raw2state` to check `isinstance(self, WriteOnlySensorMixin)` and match against integer values, string values, or payload strings so button entities cleanly resolve their display names.

#### [sigenergy2mqtt/sensors/base/README.md](file:///root/repositories/seud0nym/sigenergy2mqtt/sigenergy2mqtt/sensors/base/README.md)
- Updated documentation across hierarchy diagrams, mixin descriptions, and creation guide to describe `WriteOnlySensorMixin`.

### Application Implementation

#### [sigenergy2mqtt/devices/main/main.py](file:///root/repositories/seud0nym/sigenergy2mqtt/sigenergy2mqtt/devices/main/main.py)
- Use `WriteOnlySensorMixin` instead of `WriteOnlySensor` when checking base instance.

#### [sigenergy2mqtt/devices/base/device.py](file:///root/repositories/seud0nym/sigenergy2mqtt/sigenergy2mqtt/devices/base/device.py)
- Use `WriteOnlySensorMixin` instead of `WriteOnlySensor` when checking base instance.

#### [sigenergy2mqtt/devices/metrics/sensors.py](file:///root/repositories/seud0nym/sigenergy2mqtt/sigenergy2mqtt/devices/metrics/sensors.py)
- Use `WriteOnlySensorMixin` instead of `WriteOnlySensor` as parent for `ResetMetrics` button sensor and remove Modbus-specific init parameters.


### Tests

#### [tests/unit/sensors/test_writeable_sensor_e2e.py](file:///root/repositories/seud0nym/sigenergy2mqtt/tests/unit/sensors/test_writeable_sensor_e2e.py)
- Defined `NonModbusWriteOnlySensor(WriteOnlySensorMixin, _NonModbusWriteableSensor)`.
- Added test cases to `test_writable_entity_mixins_dispatch_commands_without_modbus` for `"on"` and `"off"` payload dispatch without Modbus.
- Added `test_write_only_mixin_discovery_components` to verify button discovery payload and platform configuration.
- Added `test_write_only_mixin_validation_and_raw2state` to verify state conversion, internal state update, and validity checks.
- Added `test_write_only_mixin_validates_icons` to verify `mdi:` icon prefix validation.

#### [tests/unit/sensors/test_non_modbus_writeable_sensors.py](file:///root/repositories/seud0nym/sigenergy2mqtt/tests/unit/sensors/test_non_modbus_writeable_sensors.py)
- Use `WriteOnlySensorMixin` instead of `WriteOnlySensor` when checking base instance.

#### [tests/utils/modbus_sensors.py](file:///root/repositories/seud0nym/sigenergy2mqtt/tests/utils/modbus_sensors.py)
- Use `WriteOnlySensorMixin` instead of `WriteOnlySensor` as exceptions when checking for missing device_class and state_class on concrete sensor classes.

## Verification

The tests can be verified using pytest:
```bash
.venv/bin/python -m pytest -n auto
```
