### PR TITLE
Add Button to Call Metrics.reset() via Diagnostics Web Service

### DIFF
--- a/sigenergy2mqtt/diagnostics/collectors.py
+++ b/sigenergy2mqtt/diagnostics/collectors.py
@@ -4,7 +4,7 @@ from sigenergy2mqtt.config import ConsumptionSource, active_config
 from sigenergy2mqtt.i18n import _t
 from sigenergy2mqtt.metrics.metrics import Metrics
 from sigenergy2mqtt.sensors.base.constants import DiscoveryKeys
-from sigenergy2mqtt.sensors.base.writeable import NumericSensorMixin, SelectSensorMixin, SwitchSensorMixin
+from sigenergy2mqtt.sensors.base.writeable import NumericSensorMixin, SelectSensorMixin, SwitchSensorMixin, WriteOnlySensorMixin
 
 from .registry import diagnostics_registry
 
@@ -34,54 +34,65 @@ class DiagnosticsCollectors:
 
         controls: dict[str, Any] = {}
 
-        # Find the SettingsService device (registered at plant_index=-1)
+        # Find virtual service devices (registered at plant_index=-1)
         for device in DeviceRegistry.get(-1):
             for sensor in device.sensors.values():
-                if not isinstance(sensor, SettingsSensor):
-                    continue
-                settings_sensor = cast("SettingsSensor", sensor)
+                if isinstance(sensor, SettingsSensor):
+                    settings_sensor = cast("SettingsSensor", sensor)
 
-                # Derive a URL-safe endpoint key from the unique_id
-                # e.g. "sigenergy2mqtt_config_log_level" -> "log_level"
-                endpoint = settings_sensor.unique_id.removeprefix("sigenergy2mqtt_config_")
+                    # Derive a URL-safe endpoint key from the unique_id
+                    # e.g. "sigenergy2mqtt_config_log_level" -> "log_level"
+                    endpoint = settings_sensor.unique_id.removeprefix("sigenergy2mqtt_config_")
 
-                # Read the current display value via get_value()
-                value = settings_sensor.get_value()
+                    # Read the current display value via get_value()
+                    value = settings_sensor.get_value()
 
-                # Build the descriptor based on the sensor's mixin type
-                descriptor: dict[str, Any] = {
-                    "label": settings_sensor.name,
-                    "comment": settings_sensor.get_attributes().get("comment", ""),
-                    "endpoint": endpoint,
-                }
+                    # Build the descriptor based on the sensor's mixin type
+                    descriptor: dict[str, Any] = {
+                        "label": settings_sensor.name,
+                        "comment": settings_sensor.get_attributes().get("comment", ""),
+                        "endpoint": endpoint,
+                    }
 
-                if isinstance(settings_sensor, SelectSensorMixin):
-                    options = cast(list[str], settings_sensor[DiscoveryKeys.OPTIONS])
-                    # Filter out empty placeholder slots (log-level list has empty strings)
-                    visible_options = [o for o in options if o]
-                    descriptor.update({
-                        "type": "select",
-                        "value": str(value) if value is not None else "",
-                        "options": visible_options,
-                    })
-                elif isinstance(settings_sensor, NumericSensorMixin):
-                    descriptor.update({
-                        "type": "number",
-                        "value": value,
-                        "min": settings_sensor.get(DiscoveryKeys.MIN),
-                        "max": settings_sensor.get(DiscoveryKeys.MAX),
-                        "unit": settings_sensor.unit or "",
-                    })
-                elif isinstance(settings_sensor, SwitchSensorMixin):
-                    descriptor.update({
-                        "type": "switch",
-                        "value": bool(value),
-                    })
-                else:
-                    # Fallback: surface as a read-only string
-                    descriptor.update({"type": "readonly", "value": str(value)})
+                    if isinstance(settings_sensor, SelectSensorMixin):
+                        options = cast(list[str], settings_sensor[DiscoveryKeys.OPTIONS])
+                        # Filter out empty placeholder slots (log-level list has empty strings)
+                        visible_options = [o for o in options if o]
+                        descriptor.update({
+                            "type": "select",
+                            "value": str(value) if value is not None else "",
+                            "options": visible_options,
+                        })
+                    elif isinstance(settings_sensor, NumericSensorMixin):
+                        descriptor.update({
+                            "type": "number",
+                            "value": value,
+                            "min": settings_sensor.get(DiscoveryKeys.MIN),
+                            "max": settings_sensor.get(DiscoveryKeys.MAX),
+                            "unit": settings_sensor.unit or "",
+                        })
+                    elif isinstance(settings_sensor, SwitchSensorMixin):
+                        descriptor.update({
+                            "type": "switch",
+                            "value": bool(value),
+                        })
+                    else:
+                        # Fallback: surface as a read-only string
+                        descriptor.update({"type": "readonly", "value": str(value)})
 
-                controls[endpoint] = descriptor
+                    controls[endpoint] = descriptor
+
+                elif isinstance(sensor, WriteOnlySensorMixin):
+                    prefix = f"{active_config.home_assistant.unique_id_prefix}_"
+                    endpoint = sensor.unique_id.removeprefix(prefix).removeprefix("sigenergy2mqtt_")
+                    descriptor = {
+                        "label": sensor.name,
+                        "comment": sensor.get_attributes().get("comment", "") if hasattr(sensor, "get_attributes") else "",
+                        "endpoint": endpoint,
+                        "type": "button",
+                        "value": "Reset",
+                    }
+                    controls[endpoint] = descriptor
 
         return {"controls": controls}
 

--- a/sigenergy2mqtt/diagnostics/server.py
+++ b/sigenergy2mqtt/diagnostics/server.py
@@ -242,45 +242,64 @@ class DiagnosticsServer:
         """Apply a runtime configuration change posted from the diagnostics UI.
 
         Finds the matching :class:`~sigenergy2mqtt.config.sensors.SettingsSensor`
-        in the :class:`~sigenergy2mqtt.config.service.SettingsService` via
-        ``DeviceRegistry.get(-1)``, then calls its ``set_value`` method so that
-        the normal ``WriteableSensorMixin`` validation path is exercised — the
-        same path used when a change arrives over MQTT.
+        or :class:`~sigenergy2mqtt.sensors.base.writeable.WriteOnlySensorMixin`
+        in virtual services via ``DeviceRegistry.get(-1)``, then calls its
+        ``set_value`` method so that the normal ``WriteableSensorMixin`` validation
+        path is exercised — the same path used when a change arrives over MQTT.
 
         ``sensor.command_topic`` is passed as *source* to satisfy the guard in
         :meth:`~sigenergy2mqtt.sensors.base.mixins.WriteableSensorMixin.set_value`
         that rejects writes whose source does not match the command topic.
         ``modbus_client``, ``mqtt_client``, and ``handler`` are all ``None``;
-        ``SettingsSensor._write_value`` only calls ``setattr`` (and
-        ``logging.getLogger().setLevel()`` for log-level sensors), so these
-        are safe to omit.
+        ``SettingsSensor._write_value`` and ``ResetMetrics._write_value`` do
+        not use these transports, so these are safe to omit.
         """
         from sigenergy2mqtt.config.sensors import SettingsSensor
         from sigenergy2mqtt.devices.base.registry import DeviceRegistry
-        from sigenergy2mqtt.sensors.base.writeable import NumericSensorMixin, SelectSensorMixin, SwitchSensorMixin
+        from sigenergy2mqtt.sensors.base.constants import DiscoveryKeys
+        from sigenergy2mqtt.sensors.base.writeable import NumericSensorMixin, SelectSensorMixin, SwitchSensorMixin, WriteOnlySensorMixin
 
         endpoint = request.match_info["endpoint"]
 
         # Parse body
         try:
             body = await request.json()
-            raw_value = body["value"]
+            if not isinstance(body, dict):
+                return web.json_response({"ok": False, "error": "Invalid request body: expected JSON object"}, status=400)
+            if "value" not in body and endpoint not in ("metrics_reset", "reset_metrics"):
+                return web.json_response({"ok": False, "error": "Invalid request body: missing 'value'"}, status=400)
+            raw_value = body.get("value", 1)
         except (json.JSONDecodeError, KeyError, TypeError, ValueError, UnicodeDecodeError) as exc:
-            return web.json_response({"ok": False, "error": f"Invalid request body: {exc}"}, status=400)
+            if endpoint in ("metrics_reset", "reset_metrics") and isinstance(exc, (json.JSONDecodeError, KeyError)):
+                raw_value = 1
+            else:
+                return web.json_response({"ok": False, "error": f"Invalid request body: {exc}"}, status=400)
 
-        # Find the sensor matching this endpoint in SettingsService (plant_index=-1)
-        matched_sensor: SettingsSensor | None = None
+        # Find the sensor matching this endpoint in virtual services (plant_index=-1)
+        matched_sensor: SettingsSensor | WriteOnlySensorMixin | None = None
         for device in DeviceRegistry.get(-1):
             for sensor in device.sensors.values():
-                if not isinstance(sensor, SettingsSensor):
-                    continue
-                if sensor.unique_id.removeprefix("sigenergy2mqtt_config_") == endpoint:
-                    matched_sensor = sensor
-                    break
+                if isinstance(sensor, SettingsSensor):
+                    if sensor.unique_id.removeprefix("sigenergy2mqtt_config_") == endpoint:
+                        matched_sensor = sensor
+                        break
+                elif isinstance(sensor, WriteOnlySensorMixin):
+                    prefix = f"{active_config.home_assistant.unique_id_prefix}_"
+                    ep = sensor.unique_id.removeprefix(prefix).removeprefix("sigenergy2mqtt_")
+                    if ep == endpoint or (endpoint in ("metrics_reset", "reset_metrics") and ep in ("metrics_reset", "reset_metrics")):
+                        matched_sensor = sensor
+                        break
             if matched_sensor is not None:
                 break
 
         if matched_sensor is None:
+            if endpoint in ("metrics_reset", "reset_metrics"):
+                from sigenergy2mqtt.metrics.metrics import Metrics
+
+                await Metrics.reset()
+                revision = diagnostics_registry.bump_revision("runtime_configuration")
+                logger.info(f"DiagnosticsServer Reset all metrics via HTTP: {endpoint!r}")
+                return web.json_response({"ok": True, "revision": revision})
             return web.json_response({"ok": False, "error": f"Unknown config endpoint: {endpoint!r}"}, status=404)
 
         # Coerce value to the type expected by the sensor kind
@@ -293,6 +312,8 @@ class DiagnosticsServer:
                 coerced = float(raw_value)
             elif isinstance(matched_sensor, SelectSensorMixin):
                 coerced = str(raw_value)
+            elif isinstance(matched_sensor, WriteOnlySensorMixin):
+                coerced = 1
             else:
                 coerced = raw_value
         except (TypeError, ValueError) as exc:
@@ -300,7 +321,13 @@ class DiagnosticsServer:
 
         # Delegate to set_value — this runs validation and _write_value
         try:
-            ok = await matched_sensor.set_value(None, None, coerced, matched_sensor.command_topic, None)  # type: ignore[arg-type]
+            cmd_topic = matched_sensor.command_topic
+        except RuntimeError:
+            cmd_topic = f"sigenergy2mqtt/metrics/{endpoint}/set"
+            matched_sensor[DiscoveryKeys.COMMAND_TOPIC] = cmd_topic
+
+        try:
+            ok = await matched_sensor.set_value(None, None, coerced, cmd_topic, None)  # type: ignore[arg-type]
         except (KeyError, RuntimeError, TypeError, ValueError) as exc:
             logger.warning(f"DiagnosticsServer config update for {endpoint!r} raised: {exc}")
             return web.json_response({"ok": False, "error": str(exc)}, status=500)

--- a/sigenergy2mqtt/diagnostics/static/diagnostics.html
+++ b/sigenergy2mqtt/diagnostics/static/diagnostics.html
@@ -325,6 +325,33 @@
       white-space: nowrap;
     }
 
+    .ctrl-btn {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text);
+      font-family: var(--mono);
+      font-size: 12px;
+      padding: 4px 12px;
+      cursor: pointer;
+      transition: border-color 0.15s, transform 0.1s;
+      outline: none;
+    }
+
+    .ctrl-btn:hover:not(:disabled) {
+      border-color: var(--accent);
+      transform: translateY(-1px);
+    }
+
+    .ctrl-btn:active:not(:disabled) {
+      transform: translateY(0);
+    }
+
+    .ctrl-btn:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
     /* Toggle switch */
     .ctrl-switch {
       position: relative;
@@ -827,6 +854,19 @@
             });
 
             widgetWrap.appendChild(labelEl);
+          } else if (ctrl.type === 'button') {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'ctrl-btn';
+            btn.dataset.endpoint = endpoint;
+            btn.textContent = ctrl.value || 'Reset';
+            btn.addEventListener('click', () => {
+              btn.disabled = true;
+              sendConfigUpdate(endpoint, 1, btn).finally(() => {
+                btn.disabled = false;
+              });
+            });
+            widgetWrap.appendChild(btn);
           } else {
             const val = document.createElement('span');
             val.className = 'v';
@@ -841,6 +881,7 @@
 
       function updateControlsCard(card, controls, revision) {
         Object.entries(controls).forEach(([endpoint, ctrl]) => {
+          if (ctrl.type === 'button') return;
           const widget = card.querySelector(`[data-endpoint="${endpoint}"]`);
           if (!widget) return;
 

--- a/tests/unit/diagnostics/test_collectors.py
+++ b/tests/unit/diagnostics/test_collectors.py
@@ -83,3 +83,28 @@ async def test_collect_runtime_config():
         assert controls["persistence_debug"]["type"] == "switch"
     finally:
         DeviceRegistry.clear()
+
+
+@pytest.mark.asyncio
+async def test_collect_runtime_config_with_metrics_reset():
+    from sigenergy2mqtt.common import ProtocolVersion
+    from sigenergy2mqtt.config.service import SettingsService
+    from sigenergy2mqtt.devices.base.registry import DeviceRegistry
+    from sigenergy2mqtt.metrics.service import MetricsService
+
+    DeviceRegistry.clear()
+    try:
+        _ = SettingsService()
+        _ = MetricsService(ProtocolVersion.N_A)
+        payload = await DiagnosticsCollectors._diagnostics_collect_runtime_config()
+        assert "controls" in payload
+        controls = payload["controls"]
+        assert "metrics_reset" in controls
+        reset_ctrl = controls["metrics_reset"]
+        assert reset_ctrl["type"] == "button"
+        assert reset_ctrl["label"] == "Reset Metrics"
+        assert reset_ctrl["endpoint"] == "metrics_reset"
+        assert reset_ctrl["value"] == "Reset"
+    finally:
+        DeviceRegistry.clear()
+

--- a/tests/unit/diagnostics/test_server.py
+++ b/tests/unit/diagnostics/test_server.py
@@ -395,3 +395,84 @@ async def test_handle_config_update_validation_rejected(server: DiagnosticsServe
         assert body["ok"] is False
     finally:
         DeviceRegistry.clear()
+
+
+@pytest.mark.asyncio
+async def test_handle_config_update_metrics_reset_success(server: DiagnosticsServer) -> None:
+    from sigenergy2mqtt.common import ProtocolVersion
+    from sigenergy2mqtt.config.service import SettingsService
+    from sigenergy2mqtt.devices.base.registry import DeviceRegistry
+    from sigenergy2mqtt.metrics.metrics import Metrics
+    from sigenergy2mqtt.metrics.service import MetricsService
+
+    DeviceRegistry.clear()
+    try:
+        _ = SettingsService()
+        _ = MetricsService(ProtocolVersion.N_A)
+
+        # Mutate a metric to verify reset
+        Metrics.sigenergy2mqtt_modbus_reads = 42
+
+        request = make_mocked_request("POST", "/diagnostics/config/metrics_reset", match_info={"endpoint": "metrics_reset"})
+        request.json = AsyncMock(return_value={"value": 1})
+
+        response = await server._handle_config_update(request)
+        assert response.status == 200
+        body = json.loads(response.text)
+        assert body["ok"] is True
+        assert "revision" in body
+        await Metrics.drain()
+        assert Metrics.sigenergy2mqtt_modbus_reads == 0
+    finally:
+        DeviceRegistry.clear()
+
+
+@pytest.mark.asyncio
+async def test_handle_config_update_reset_metrics_alias(server: DiagnosticsServer) -> None:
+    from sigenergy2mqtt.common import ProtocolVersion
+    from sigenergy2mqtt.config.service import SettingsService
+    from sigenergy2mqtt.devices.base.registry import DeviceRegistry
+    from sigenergy2mqtt.metrics.metrics import Metrics
+    from sigenergy2mqtt.metrics.service import MetricsService
+
+    DeviceRegistry.clear()
+    try:
+        _ = SettingsService()
+        _ = MetricsService(ProtocolVersion.N_A)
+
+        Metrics.sigenergy2mqtt_mqtt_publish_attempts = 15
+
+        request = make_mocked_request("POST", "/diagnostics/config/reset_metrics", match_info={"endpoint": "reset_metrics"})
+        request.json = AsyncMock(return_value={"value": "reset"})
+
+        response = await server._handle_config_update(request)
+        assert response.status == 200
+        body = json.loads(response.text)
+        assert body["ok"] is True
+        await Metrics.drain()
+        assert Metrics.sigenergy2mqtt_mqtt_publish_attempts == 0
+    finally:
+        DeviceRegistry.clear()
+
+
+@pytest.mark.asyncio
+async def test_handle_config_update_metrics_reset_fallback(server: DiagnosticsServer) -> None:
+    from sigenergy2mqtt.devices.base.registry import DeviceRegistry
+    from sigenergy2mqtt.metrics.metrics import Metrics
+
+    DeviceRegistry.clear()
+    try:
+        Metrics.sigenergy2mqtt_modbus_reads = 99
+
+        request = make_mocked_request("POST", "/diagnostics/config/metrics_reset", match_info={"endpoint": "metrics_reset"})
+        request.json = AsyncMock(return_value={})
+
+        response = await server._handle_config_update(request)
+        assert response.status == 200
+        body = json.loads(response.text)
+        assert body["ok"] is True
+        await Metrics.drain()
+        assert Metrics.sigenergy2mqtt_modbus_reads == 0
+    finally:
+        DeviceRegistry.clear()
+


### PR DESCRIPTION
# Add Button to Call Metrics.reset() via Diagnostics Web Service

## Summary of Changes
Added support for button controls in the diagnostics module's runtime configuration service and UI, enabling users to invoke `Metrics.reset()` to clear all operational metric counters.

### Diagnostics Backend & Web Service
- [collectors.py](file:///root/repositories/seud0nym/sigenergy2mqtt/sigenergy2mqtt/diagnostics/collectors.py):
  - Updated `_diagnostics_collect_runtime_config` to collect `WriteOnlySensorMixin` sensors from virtual services registered at `plant_index = -1` (such as `ResetMetrics` on `MetricsService`).
  - Derived endpoint name (`metrics_reset`) and created descriptor with `"type": "button"`, `"value": "Reset"`, and `"label": "Reset Metrics"`.
- [server.py](file:///root/repositories/seud0nym/sigenergy2mqtt/sigenergy2mqtt/diagnostics/server.py):
  - Updated `_handle_config_update` to match `WriteOnlySensorMixin` sensors via `metrics_reset` and alias `reset_metrics`.
  - Added direct fallback to `Metrics.reset()` if the endpoint is called when `MetricsService` is not present in the registry.
  - Handled button request payloads (accepting empty body or `"value": 1` / `"value": "reset"`).
  - Exercised `matched_sensor.set_value(...)`, which triggers `ResetMetrics._write_value` and executes `await Metrics.reset()`.

### Diagnostics UI (Frontend)
- [diagnostics.html](file:///root/repositories/seud0nym/sigenergy2mqtt/sigenergy2mqtt/diagnostics/static/diagnostics.html):
  - Added `.ctrl-btn` CSS matching the theme styling of `.ctrl-select` and `.ctrl-number` with hover, active, and disabled states.
  - In `buildControls`, rendered `ctrl.type === 'button'` as a `<button class="ctrl-btn">` that calls `sendConfigUpdate(endpoint, 1, btn)` on click and provides instant visual feedback via `.flash-ok`.
  - In `updateControlsCard`, skipped `ctrl.type === 'button'` so button elements remain stable across periodic WebSocket snapshot updates.

### Unit Tests
- [test_collectors.py](file:///root/repositories/seud0nym/sigenergy2mqtt/tests/unit/diagnostics/test_collectors.py):
  - Added `test_collect_runtime_config_with_metrics_reset` verifying that `metrics_reset` is exposed with `type == "button"`.
- [test_server.py](file:///root/repositories/seud0nym/sigenergy2mqtt/tests/unit/diagnostics/test_server.py):
  - Added `test_handle_config_update_metrics_reset_success` verifying `POST /diagnostics/config/metrics_reset` calls `Metrics.reset()` and returns `200` with `{"ok": True}`.
  - Added `test_handle_config_update_reset_metrics_alias` verifying the `reset_metrics` endpoint alias.
  - Added `test_handle_config_update_metrics_reset_fallback` verifying successful reset when `MetricsService` is not explicitly in `DeviceRegistry`.

## Verification Results
- Executed diagnostics tests:
  ```bash
  .venv/bin/python -m pytest -n auto tests/unit/diagnostics/
  ```
  Result: **164 passed in 8.11s**
- Executed complete unit test suite:
  ```bash
  .venv/bin/python -m pytest -n auto tests/unit/
  ```
  Result: **2119 passed in 82.02s**
